### PR TITLE
Update IP handling to ensure 'ips' field is not empty before processing

### DIFF
--- a/blueprints/stats.py
+++ b/blueprints/stats.py
@@ -196,7 +196,7 @@ def analytics(short_code):
     except Exception:
         pass
 
-    if "ips" in url_data:
+    if "ips" in url_data and url_data["ips"]:
         url_data["total_unique_clicks"] = len(url_data["ips"])
 
     (

--- a/blueprints/url_shortener.py
+++ b/blueprints/url_shortener.py
@@ -150,9 +150,9 @@ def shorten_url():
                 400,
             )
 
-        data = {"url": url, "password": password, "counter": {}, "total-clicks": 0}
+        data = {"url": url, "password": password, "counter": {}, "total-clicks": 0, "ips":[]}
     else:
-        data = {"url": url, "counter": {}, "total-clicks": 0}
+        data = {"url": url, "counter": {}, "total-clicks": 0, "ips":[]}
 
     if max_clicks:
         if not is_positive_integer(max_clicks):
@@ -508,7 +508,7 @@ def redirect_url(short_code):
     updates["$inc"][f"counter.{today}"] = 1
 
     if "ips" in url_data:
-        if user_ip not in url_data["ips"]:
+        if url_data["ips"] and user_ip not in url_data["ips"]:
             updates["$inc"][f"unique_counter.{today}"] = 1
     else:
         updates["$inc"][f"unique_counter.{today}"] = 1


### PR DESCRIPTION
This PR addresses Issue #34

## Summary by Sourcery

Bug Fixes:
- Ensure the 'ips' field is initialized as an empty list to prevent processing errors when it is empty.