### PR TITLE
Fix password protected URLs 500 error

### DIFF
--- a/templates/password.html
+++ b/templates/password.html
@@ -18,7 +18,7 @@
         <div id="glass">
             <h1>{{ host_url }}{{ short_code }}</h1>
         </div>
-            <form class="buttonIn" id="inputForm" method="post" action="{{ url_for('url_shortener.check_password', short_code=short_code) }}">
+            <form class="buttonIn" id="inputForm" method="post" action="{{ url_for('url_redirector.check_password', short_code=short_code) }}">
                 {% if error %}
                     <script>
                         customTopNotification("PasswordError", "<b>Incorrect Password!</b> Please Enter the correct Password to continue", 10, "error");


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the form action to use the 'url_redirector.check_password' endpoint instead of 'url_shortener.check_password' to prevent server errors on protected URLs.