### PR TITLE
feat: add URL preview feature

### DIFF
--- a/blueprints/url_shortener.py
+++ b/blueprints/url_shortener.py
@@ -397,7 +397,11 @@ def preview_url(short_code):
     # Parse URL to extract domain, path, and protocol
     parsed = urlparse(long_url)
     domain = parsed.netloc or parsed.path.split("/")[0]  # Handle edge cases
-    path = parsed.path + ("?" + parsed.query if parsed.query else "")
+    path = (
+        parsed.path
+        + ("?" + parsed.query if parsed.query else "")
+        + ("#" + parsed.fragment if parsed.fragment else "")
+    )
     # Hide "/" path for homepage
     if path == "/":
         path = ""

--- a/static/css/preview.css
+++ b/static/css/preview.css
@@ -22,8 +22,8 @@
 body {
     font-family: 'Nata Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     background: radial-gradient(1000px 600px at 50% -10%, rgba(124, 58, 237, 0.18), transparent 60%),
-                radial-gradient(900px 600px at 50% 110%, rgba(37, 99, 235, 0.16), transparent 60%),
-                linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+        radial-gradient(900px 600px at 50% 110%, rgba(37, 99, 235, 0.16), transparent 60%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
     background-color: var(--dashboard-bg);
     min-height: 100vh;
     display: flex;
@@ -53,8 +53,15 @@ body {
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-10px); }
-    to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .preview-icon {
@@ -169,9 +176,26 @@ h1 {
 /* Full URL container - keeps everything inline */
 .full-url {
     font-size: 18px;
-    line-height: 1.5;
-    word-break: break-all;
+    line-height: 1.6;
+    white-space: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
     flex: 1;
+    min-width: 0;
+    /* Critical for proper text wrapping in flex containers */
+    display: block;
+    /* Hide scrollbar for cleaner look, but allow scroll */
+    scrollbar-width: none;
+    /* Firefox */
+    -ms-overflow-style: none;
+    /* IE and Edge */
+    -webkit-overflow-scrolling: touch;
+    /* Smooth scrolling on iOS */
+}
+
+.full-url::-webkit-scrollbar {
+    display: none;
+    /* Chrome, Safari and Opera */
 }
 
 /* Domain name - PROMINENT (inline) */
@@ -179,6 +203,7 @@ h1 {
     font-weight: 700;
     color: var(--text-primary);
     letter-spacing: -0.3px;
+    word-break: keep-all;
 }
 
 /* URL path - secondary emphasis (inline, same line) */
@@ -186,6 +211,7 @@ h1 {
     font-weight: 400;
     color: var(--text-secondary);
     font-family: 'Courier New', monospace;
+    word-break: break-word;
 }
 
 /* HTTPS security badge */
@@ -234,7 +260,8 @@ h1 {
     margin-top: 32px;
 }
 
-.btn-primary, .btn-secondary {
+.btn-primary,
+.btn-secondary {
     flex: 1;
     padding: 14px 24px;
     border-radius: var(--radius-sm);
@@ -293,29 +320,29 @@ h1 {
     .preview-card {
         padding: 24px 20px;
     }
-    
+
     .preview-subtitle {
         font-size: 14px;
     }
-    
+
     h1 {
         font-size: 24px;
     }
-    
+
     .button-group {
         flex-direction: column;
     }
-    
+
     .preview-icon {
         width: 56px;
         height: 56px;
         font-size: 28px;
     }
-    
+
     .full-url {
         font-size: 16px;
     }
-    
+
     .url-header {
         flex-wrap: wrap;
     }

--- a/static/css/preview.css
+++ b/static/css/preview.css
@@ -1,0 +1,322 @@
+/* Preview Page Styles - Matches Dashboard Vibe */
+
+:root {
+    --dashboard-bg: #090d1a;
+    --border-color: rgba(255, 255, 255, 0.10);
+    --text-primary: #ffffff;
+    --text-secondary: rgba(255, 255, 255, 0.70);
+    --accent-primary: #7c3aed;
+    --accent-secondary: #2563eb;
+    --hover-bg: rgba(255, 255, 255, 0.08);
+    --radius-lg: 16px;
+    --radius-md: 12px;
+    --radius-sm: 8px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Nata Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(1000px 600px at 50% -10%, rgba(124, 58, 237, 0.18), transparent 60%),
+                radial-gradient(900px 600px at 50% 110%, rgba(37, 99, 235, 0.16), transparent 60%),
+                linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+    background-color: var(--dashboard-bg);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.preview-container {
+    width: 100%;
+    max-width: 600px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.preview-card {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+    backdrop-filter: blur(20px) saturate(1.2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 36px 40px;
+    text-align: center;
+    animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.preview-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-size: 32px;
+}
+
+.preview-icon-normal {
+    background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+    color: white;
+}
+
+.lock-icon {
+    background: rgba(245, 158, 11, 0.15);
+    color: #f59e0b;
+}
+
+.error-icon {
+    background: rgba(239, 68, 68, 0.15);
+    color: #ef4444;
+}
+
+h1 {
+    font-size: 28px;
+    font-weight: 700;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+    letter-spacing: -0.5px;
+}
+
+.preview-subtitle {
+    font-size: 15px;
+    color: var(--text-secondary);
+    margin-bottom: 28px;
+    line-height: 1.5;
+}
+
+.url-display {
+    margin-bottom: 20px;
+    text-align: left;
+}
+
+.url-display.destination {
+    margin-top: 24px;
+}
+
+.url-label {
+    display: block;
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+    font-weight: 500;
+}
+
+.short-url {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 12px 16px;
+    font-size: 14px;
+    color: var(--text-primary);
+    font-family: 'Courier New', monospace;
+    word-break: break-all;
+    opacity: 0.8;
+}
+
+/* Enhanced destination URL box */
+.long-url {
+    background: rgba(124, 58, 237, 0.12);
+    border: 1px solid rgba(124, 58, 237, 0.30);
+    border-radius: var(--radius-md);
+    padding: 20px;
+    transition: all 0.3s ease;
+}
+
+.long-url:hover {
+    background: rgba(124, 58, 237, 0.15);
+    border-color: rgba(124, 58, 237, 0.40);
+    box-shadow: 0 0 20px rgba(124, 58, 237, 0.2);
+}
+
+/* URL content container */
+.url-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+}
+
+/* Header with favicon + URL + HTTPS badge */
+.url-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+/* Favicon */
+.favicon {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+/* Full URL container - keeps everything inline */
+.full-url {
+    font-size: 18px;
+    line-height: 1.5;
+    word-break: break-all;
+    flex: 1;
+}
+
+/* Domain name - PROMINENT (inline) */
+.domain-name {
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: -0.3px;
+}
+
+/* URL path - secondary emphasis (inline, same line) */
+.url-path {
+    font-weight: 400;
+    color: var(--text-secondary);
+    font-family: 'Courier New', monospace;
+}
+
+/* HTTPS security badge */
+.https-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    flex-shrink: 0;
+}
+
+.https-badge i {
+    font-size: 14px;
+}
+
+.info-text {
+    color: var(--text-secondary);
+    font-size: 15px;
+    margin-bottom: 24px;
+    line-height: 1.6;
+}
+
+.error-message {
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+}
+
+.error-message code {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-family: 'Courier New', monospace;
+    color: var(--text-primary);
+}
+
+.button-group {
+    display: flex;
+    gap: 12px;
+    margin-top: 32px;
+}
+
+.btn-primary, .btn-secondary {
+    flex: 1;
+    padding: 14px 24px;
+    border-radius: var(--radius-sm);
+    font-size: 15px;
+    font-weight: 600;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    cursor: pointer;
+    border: none;
+    font-family: 'Nata Sans', sans-serif;
+    transition: all 0.2s;
+}
+
+.btn-primary {
+    background: var(--accent-primary);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: #8b4ff5;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(124, 58, 237, 0.4);
+}
+
+.btn-secondary {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.btn-secondary:hover {
+    background: var(--hover-bg);
+    transform: translateY(-1px);
+}
+
+.preview-footer {
+    text-align: center;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+
+.preview-footer:hover {
+    opacity: 0.8;
+}
+
+.footer-link {
+    display: inline-block;
+}
+
+/* Mobile Responsive */
+@media (max-width: 640px) {
+    .preview-card {
+        padding: 24px 20px;
+    }
+    
+    .preview-subtitle {
+        font-size: 14px;
+    }
+    
+    h1 {
+        font-size: 24px;
+    }
+    
+    .button-group {
+        flex-direction: column;
+    }
+    
+    .preview-icon {
+        width: 56px;
+        height: 56px;
+        font-size: 28px;
+    }
+    
+    .full-url {
+        font-size: 16px;
+    }
+    
+    .url-header {
+        flex-wrap: wrap;
+    }
+}

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Link Preview | spoo.me</title>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nata+Sans:wght@100..900&display=swap" rel="stylesheet">
+
+    <!-- Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons@latest/iconfont/tabler-icons.min.css">
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/preview.css') }}">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
+</head>
+
+<body>
+    <div class="preview-container">
+        {% if error %}
+        <!-- URL Not Found -->
+        <div class="preview-card error">
+            <div class="preview-icon error-icon">
+                <i class="ti ti-alert-circle"></i>
+            </div>
+            <h1>URL Not Found</h1>
+            <p class="error-message">The short URL <code>{{ short_code }}</code> does not exist.</p>
+            <a href="/" class="btn-primary">Go to spoo.me</a>
+        </div>
+
+        {% elif password_protected %}
+        <!-- Password Protected -->
+        <div class="preview-card locked">
+            <div class="preview-icon lock-icon">
+                <i class="ti ti-lock"></i>
+            </div>
+            <h1>Password Protected</h1>
+            <div class="url-display">
+                <span class="url-label">Short URL:</span>
+                <div class="short-url">{{ short_url }}</div>
+            </div>
+            <p class="info-text">This link requires a password. The destination is hidden for security.</p>
+            <div class="button-group">
+                <a href="/{{ alias }}" class="btn-primary">
+                    <i class="ti ti-key"></i>
+                    Enter Password
+                </a>
+                <button onclick="copyUrl('{{ short_url }}', event)" class="btn-secondary">
+                    <i class="ti ti-copy"></i>
+                    Copy Link
+                </button>
+            </div>
+        </div>
+
+        {% else %}
+        <!-- Normal Preview -->
+        <div class="preview-card">
+            <h1>Link Preview</h1>
+            <p class="preview-subtitle">See where this link goes before you click</p>
+            <div class="url-display">
+                <span class="url-label">Short URL:</span>
+                <div class="short-url">{{ short_url }}</div>
+            </div>
+            <div class="url-display destination">
+                <span class="url-label">Redirects to:</span>
+                <div class="long-url">
+                    <div class="url-content">
+                        <div class="url-header">
+                            <img src="https://www.google.com/s2/favicons?domain={{ domain }}&sz=32" class="favicon"
+                                alt="favicon" onerror="this.style.display='none'">
+                            <span class="full-url">
+                                <span class="domain-name">{{ domain }}</span><span class="url-path">{{ path }}</span>
+                            </span>
+                            {% if is_https %}
+                            <span class="https-badge">
+                                <i class="ti ti-lock"></i>
+                                HTTPS
+                            </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="button-group">
+                <a href="/{{ alias }}" class="btn-primary">
+                    <i class="ti ti-external-link"></i>
+                    Continue to Destination
+                </a>
+                <button onclick="copyUrl('{{ short_url }}', event)" class="btn-secondary">
+                    <i class="ti ti-copy"></i>
+                    Copy Link
+                </button>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Footer -->
+        <div class="preview-footer">
+            <a href="/" class="footer-link">
+                <img src="{{ url_for('static', filename='images/logo-text-dark.png') }}" alt="spoo.me" height="20">
+            </a>
+        </div>
+    </div>
+
+    <script>
+        function copyUrl(url, event) {
+            const btn = event.target.closest('button');
+            const originalHTML = btn.innerHTML;
+
+            navigator.clipboard.writeText(url).then(() => {
+                // Add copied class for animation
+                btn.classList.add('copied');
+                btn.innerHTML = '<i class="ti ti-check"></i> Copied!';
+
+                setTimeout(() => {
+                    btn.classList.remove('copied');
+                    btn.innerHTML = originalHTML;
+                }, 2000);
+            }).catch(() => {
+                // Fallback for older browsers
+                btn.innerHTML = '<i class="ti ti-x"></i> Failed';
+                setTimeout(() => {
+                    btn.innerHTML = originalHTML;
+                }, 2000);
+            });
+        }
+    </script>
+</body>
+
+</html>

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/preview.css') }}">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
+    <link rel=" icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
 </head>
 
 <body>
@@ -27,9 +27,6 @@
         {% if error %}
         <!-- URL Not Found -->
         <div class="preview-card error">
-            <div class="preview-icon error-icon">
-                <i class="ti ti-alert-circle"></i>
-            </div>
             <h1>URL Not Found</h1>
             <p class="error-message">The short URL <code>{{ short_code }}</code> does not exist.</p>
             <a href="/" class="btn-primary">Go to spoo.me</a>
@@ -38,15 +35,13 @@
         {% elif password_protected %}
         <!-- Password Protected -->
         <div class="preview-card locked">
-            <div class="preview-icon lock-icon">
-                <i class="ti ti-lock"></i>
-            </div>
             <h1>Password Protected</h1>
+            <p class="preview-subtitle">This link requires a password to access</p>
             <div class="url-display">
                 <span class="url-label">Short URL:</span>
                 <div class="short-url">{{ short_url }}</div>
             </div>
-            <p class="info-text">This link requires a password. The destination is hidden for security.</p>
+            <p class="info-text">The destination is hidden for security.</p>
             <div class="button-group">
                 <a href="/{{ alias }}" class="btn-primary">
                     <i class="ti ti-key"></i>


### PR DESCRIPTION
## Summary by Sourcery

Add a new URL preview feature that lets users see where a short link redirects before clicking, with handling for password-protected links and styled preview pages.

New Features:
- Add a rate-limited preview_url endpoint at "/<short_code>+" to show where a short URL redirects
- Create preview.html template with separate states for not found, password protected, and normal previews
- Add static CSS (preview.css) for the preview page design and ensure mobile responsiveness
- Implement client-side copy-to-clipboard functionality and navigation buttons

Enhancements:
- Parse and display the destination domain, path, favicon, and HTTPS badge in the preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview page for shortened URLs shows destination domain, path, HTTPS badge, and favicon before visiting
  * Password-protected URL detection with appropriate access prompt (hides destination until unlocked)
  * Copy-to-clipboard for shortened links with temporary “Copied” feedback
  * Continue-to-destination action from preview and an error page for invalid/missing short URLs
  * Mobile-responsive preview interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->