### PR TITLE
feat: optimize stats aggregation by implementing $facet for single DB stats aggeragations

### DIFF
--- a/blueprints/url_shortener.py
+++ b/blueprints/url_shortener.py
@@ -446,10 +446,10 @@ def metric():
         v1_clicks = v1_result.get("total-clicks", 0)
 
         # Get document count from v2 urls collection
-        v2_shortlinks = urls_v2_collection.count_documents({})
+        v2_shortlinks = urls_v2_collection.estimated_document_count()
 
         # Get document count from clicks time-series collection
-        total_clicks_from_ts = clicks_collection.count_documents({})
+        total_clicks_from_ts = clicks_collection.estimated_document_count()
 
         # Combine results
         total_shortlinks = v1_shortlinks + v2_shortlinks

--- a/builders/stats.py
+++ b/builders/stats.py
@@ -466,6 +466,7 @@ class StatsQueryBuilder:
                 error=str(e),
                 error_type=type(e).__name__,
                 dimensions=self.group_by,
+                query=query,
             )
             # Fallback to empty results
             for dimension in self.group_by:

--- a/utils/aggregation_strategies.py
+++ b/utils/aggregation_strategies.py
@@ -245,6 +245,7 @@ class BrowserAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 20},
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -277,6 +278,7 @@ class OSAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 20},
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -309,6 +311,7 @@ class DeviceAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 20},
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -341,6 +344,7 @@ class CountryAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 50},  # Top 50 countries
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -375,6 +379,7 @@ class CityAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 50},  # Top 50 cities
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -407,6 +412,7 @@ class ReferrerAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 30},  # Top 30 referrers
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -439,6 +445,7 @@ class ShortCodeAggregationStrategy(AggregationStrategy):
             },
             {"$addFields": {"unique_clicks": {"$size": "$unique_clicks"}}},
             {"$sort": {"total_clicks": -1}},
+            {"$limit": 100},  # Top 100 short codes
         ]
 
     def format_results(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -187,6 +187,13 @@ def configure_stdlib_logging() -> None:
     logging.getLogger("botocore").setLevel(logging.WARNING)
     logging.getLogger("boto3").setLevel(logging.WARNING)
 
+    # Silence pymongo debug logs (connection pool, server monitoring, etc.)
+    logging.getLogger("pymongo").setLevel(logging.WARNING)
+    logging.getLogger("pymongo.connection").setLevel(logging.WARNING)
+    logging.getLogger("pymongo.serverSelection").setLevel(logging.WARNING)
+    logging.getLogger("pymongo.command").setLevel(logging.WARNING)
+    logging.getLogger("pymongo.topology").setLevel(logging.WARNING)
+
 
 def configure_sentry_logging() -> None:
     """


### PR DESCRIPTION
## Summary by Sourcery

Optimize click statistics aggregation by computing summary and grouped metrics in a single MongoDB aggregation call and tuning related analytics performance.

New Features:
- Execute summary and per-dimension click statistics using a single MongoDB aggregation pipeline leveraging $facet.
- Introduce a sentinel anonymous owner ObjectId to normalize owner_id values in the time-series clicks schema.

Enhancements:
- Add result limits to aggregation strategies to cap top-N results for dimensions like URLs, locations, referrers, and short codes.
- Add targeted indexes on clicks time-series collection for owner-level and anonymous short_code queries to improve dashboard and stats performance.
- Silence verbose pymongo logging in standard library logging configuration.
- Use estimated_document_count for fast collection size estimates in stats endpoints.
- Ensure owner_id is always an ObjectId for time-series click records to avoid bucket churn in MongoDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Streamlined statistics generation to reduce database round-trips and speed up dashboard reports.
  * Added indexes to improve analytics and click-tracking performance.

* **Improvements**
  * Added anonymous-owner fallback for click records to stabilize analytics buckets.
  * Aggregation results now include explicit top-N limits per strategy to constrain result sizes.
  * Metrics counts returned as estimates for faster retrieval.

* **Chores**
  * Reduced noisy database driver logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->