### PR TITLE
fix: add field validator to handle null owner_id in UrlV2Doc

### DIFF
--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 
-from schemas.models.base import MongoBaseModel, PyObjectId
+from schemas.models.base import ANONYMOUS_OWNER_ID, MongoBaseModel, PyObjectId
 
 
 class UrlV2Doc(MongoBaseModel):
@@ -29,7 +29,14 @@ class UrlV2Doc(MongoBaseModel):
     """
 
     alias: str
-    owner_id: PyObjectId
+    owner_id: PyObjectId = Field(default=ANONYMOUS_OWNER_ID)
+
+    @field_validator("owner_id", mode="before")
+    @classmethod
+    def _coerce_null_owner(cls, v: Any) -> Any:
+        """Legacy v2 URLs may have null owner_id — treat as anonymous."""
+        return v if v is not None else ANONYMOUS_OWNER_ID
+
     created_at: datetime
     creation_ip: Optional[str] = None
     long_url: str

--- a/tests/unit/schemas/models/test_url.py
+++ b/tests/unit/schemas/models/test_url.py
@@ -1,5 +1,8 @@
 """Unit tests for UrlV2Doc, LegacyUrlDoc, and EmojiUrlDoc."""
 
+from bson import ObjectId
+
+from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.url import EmojiUrlDoc, LegacyUrlDoc, UrlV2Doc
 
 from .conftest import now, oid
@@ -41,6 +44,22 @@ class TestUrlV2Doc:
         assert restored.alias == doc.alias
         assert restored.max_clicks == 10
         assert str(restored.id) == str(o)
+
+    def test_null_owner_id_coerced_to_anonymous(self):
+        doc = self._make(owner_id=None)
+        assert doc.owner_id == ANONYMOUS_OWNER_ID
+        assert isinstance(doc.owner_id, ObjectId)
+
+    def test_missing_owner_id_defaults_to_anonymous(self):
+        base = {
+            "_id": oid(),
+            "alias": "abc1234",
+            "created_at": now(),
+            "long_url": "https://example.com",
+        }
+        doc = UrlV2Doc.from_mongo(base)
+        assert doc.owner_id == ANONYMOUS_OWNER_ID
+        assert isinstance(doc.owner_id, ObjectId)
 
     def test_from_mongo_none_returns_none(self):
         assert UrlV2Doc.from_mongo(None) is None


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Default owner_id to an anonymous owner for UrlV2Doc records and coerce null owner_id values to the anonymous owner identifier during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy URL records with missing or null owner information now default to an anonymous owner ID, preventing null-owner inconsistencies and ensuring consistent representation.

* **Tests**
  * Added unit tests to verify missing or null owner values are normalized to the anonymous owner ID and represented correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->