### PR TITLE
Fix incorrect github star count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,5 @@ ZEPTO_API_TOKEN=""
 ZEPTO_FROM_EMAIL="noreply@your-domain.com"
 ZEPTO_FROM_NAME="Your App Name"
 APP_URL="http://127.0.0.1:8000"
+
+GITHUB_REPO="" # org/repo format

--- a/config.py
+++ b/config.py
@@ -120,6 +120,9 @@ class AppSettings(BaseSettings):
     geoip_country_db: str = "misc/GeoLite2-Country.mmdb"
     geoip_city_db: str = "misc/GeoLite2-City.mmdb"
 
+    # GitHub repository (owner/repo) — used for star count + outbound links
+    github_repo: str = "spoo-me/spoo"
+
     # External service URLs
     contact_webhook: str = ""
     url_report_webhook: str = ""

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -565,7 +565,7 @@ async def metric(
         github_stars = 0
         try:
             resp = await http_client.get(
-                "https://api.github.com/repos/spoo-me/url-shortener", timeout=5
+                "https://api.github.com/repos/spoo-me/spoo", timeout=5
             )
             if resp.status_code == 200:
                 github_stars = resp.json().get("stargazers_count", 0)

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -542,10 +542,12 @@ async def metric(
     request: Request,
     db=Depends(get_db),
     redis=Depends(get_redis),
+    settings=Depends(get_settings),
 ) -> Response:
     """Return global platform metrics, cached for 24 hours via DualCache."""
     dual_cache = DualCache(redis)
     http_client = request.app.state.http_client
+    github_repo = settings.github_repo
 
     async def query() -> dict:
         start = time.time()
@@ -565,7 +567,7 @@ async def metric(
         github_stars = 0
         try:
             resp = await http_client.get(
-                "https://api.github.com/repos/spoo-me/spoo", timeout=5
+                f"https://api.github.com/repos/{github_repo}", timeout=5
             )
             if resp.status_code == 200:
                 github_stars = resp.json().get("stargazers_count", 0)

--- a/static/js/header.js
+++ b/static/js/header.js
@@ -17,10 +17,12 @@ async function fetchGitHubStars() {
         if (response.ok) {
             const data = await response.json();
             const stars = data['github-stars'];
-            const formatted = stars >= 1000 ? (stars / 1000).toFixed(1) + 'k' : stars;
-            const starEl = document.getElementById('github-star-count');
-            if (starEl) {
-                starEl.textContent = formatted;
+            if (stars > 0) {
+                const formatted = stars >= 1000 ? (stars / 1000).toFixed(1) + 'k' : stars;
+                const starEl = document.getElementById('github-star-count');
+                if (starEl) {
+                    starEl.textContent = formatted;
+                }
             }
         }
     } catch (error) {

--- a/static/js/index-script.js
+++ b/static/js/index-script.js
@@ -21,7 +21,9 @@ function get_metrics() {
         .then(data => {
             document.querySelector('#total-urls').textContent = data["total-shortlinks"];
             document.querySelector('#total-clicks').textContent = data["total-clicks"];
-            document.querySelector('#github-stars').textContent = data["github-stars"];
+            if (data["github-stars"] > 0) {
+                document.querySelector('#github-stars').textContent = data["github-stars"];
+            }
         })
         .catch(err => {
             console.warn('Failed to load metrics:', err);

--- a/templates/api.html
+++ b/templates/api.html
@@ -65,7 +65,7 @@
                 <li><a href="#" class="active">API</a></li>
                 <li><a href="/stats">Stats</a></li>
                 <li><a href="/report">Report URL</a></li>
-                <li><a href="https://github.com/spoo-me/url-shortener" rel="noopener" target="_blank">Open-Source ↗</a>
+                <li><a href="https://github.com/spoo-me/spoo" rel="noopener" target="_blank">Open-Source ↗</a>
                 </li>
                 <li onclick="showContactModal();"><a href="#">Contact</a></li>
             </ul>
@@ -87,7 +87,7 @@
             <li><a href="/api">API</a></li>
             <li><a href="/stats">Stats</a></li>
             <li><a href="/report">Report URL</a></li>
-            <li><a href="https://github.com/spoo-me/url-shortener" rel="noopener" target="_blank">Open-Source ↗</a>
+            <li><a href="https://github.com/spoo-me/spoo" rel="noopener" target="_blank">Open-Source ↗</a>
             </li>
             <li onclick="showContactModal();"><a href="#">Contact</a></li>
         </ul>

--- a/templates/api.html
+++ b/templates/api.html
@@ -2229,7 +2229,7 @@ print(f"Shortened URL: {short_url}")
     </script>
 
     <script src="{{ url_for('static', path='js/contacts-popup.js') }}?v=1" defer=""></script>
-    <script src="{{ url_for('static', path='js/header.js') }}?v=4" defer=""></script>
+    <script src="{{ url_for('static', path='js/header.js') }}?v=6" defer=""></script>
     <script src="{{ url_for('static', path='js/self-promo.js') }}?v=1" defer></script>
 
     <script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,7 +44,7 @@
     </main>
 
     <script src="{{ url_for('static', path='js/contacts-popup.js') }}?v=1" defer></script>
-    <script src="{{ url_for('static', path='js/header.js') }}?v=5" defer></script>
+    <script src="{{ url_for('static', path='js/header.js') }}?v=6" defer></script>
     <script src="{{ url_for('static', path='js/self-promo.js') }}?v=2" defer></script>
     <script src="{{ url_for('static', path='js/auth.js') }}?v=2" defer></script>
     <script src="{{ url_for('static', path='js/v2-announcement.js') }}?v=3" defer></script>

--- a/templates/dashboard/statistics.html
+++ b/templates/dashboard/statistics.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/statistics.css') }}?v=1">
 <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/dateRangePicker.css') }}">
 <!-- <link rel="stylesheet" type="text/css" -->
-    <!-- href="https://cdn.jsdelivr.net/gh/spoo-me/url-shortener/static/css/anychart-ui.min.css" /> -->
+    <!-- href="https://cdn.jsdelivr.net/gh/spoo-me/spoo/static/css/anychart-ui.min.css" /> -->
 <link rel="stylesheet" type="text/css"
     href="{{ url_for('static', path='css/anychart-ui.min.css') }}" />
 <link rel="stylesheet" type="text/css"

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -125,7 +125,7 @@
                                                         <tbody>
                                                             <tr>
                                                                 <td style="padding:0 8px">
-                                                                    <a href="https://github.com/spoo-me/url-shortener"
+                                                                    <a href="https://github.com/spoo-me/spoo"
                                                                         style="color:#067df7;text-decoration-line:none"
                                                                         target="_blank"><img alt="GitHub"
                                                                             src="https://new.email/static/emails/social/social-github.png"

--- a/templates/emails/verification.html
+++ b/templates/emails/verification.html
@@ -124,7 +124,7 @@
                                                         <tbody>
                                                             <tr>
                                                                 <td style="padding:0 8px">
-                                                                    <a href="https://github.com/spoo-me/url-shortener"
+                                                                    <a href="https://github.com/spoo-me/spoo"
                                                                         style="color:#067df7;text-decoration-line:none"
                                                                         target="_blank"><img alt="GitHub"
                                                                             src="https://new.email/static/emails/social/social-github.png"

--- a/templates/emails/welcome.html
+++ b/templates/emails/welcome.html
@@ -229,7 +229,7 @@
                                                         <tbody>
                                                             <tr>
                                                                 <td style="padding:0 8px">
-                                                                    <a href="https://github.com/spoo-me/url-shortener"
+                                                                    <a href="https://github.com/spoo-me/spoo"
                                                                         style="color:#067df7;text-decoration-line:none"
                                                                         target="_blank"><img alt="GitHub"
                                                                             src="https://new.email/static/emails/social/social-github.png"

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,5 +125,5 @@
 <script src="{{ url_for('static', path='js/landing-edit-modal.js') }}"></script>
 <script src="{{ url_for('static', path='js/index-recent-links.js') }}?v=1"></script>
 <script src="{{ url_for('static', path='js/index-validate.js') }}?v=1"></script>
-<script src="{{ url_for('static', path='js/index-script.js') }}?v=6" defer></script>
+<script src="{{ url_for('static', path='js/index-script.js') }}?v=7" defer></script>
 {% endblock %}

--- a/templates/legal/base.html
+++ b/templates/legal/base.html
@@ -123,7 +123,7 @@
     {% block custom_js_scripts %}{% endblock %}
 
     <script src="{{ url_for('static', path='js/contacts-popup.js') }}?v=1" defer=""></script>
-    <script src="{{ url_for('static', path='js/header.js') }}?v=5" defer=""></script>
+    <script src="{{ url_for('static', path='js/header.js') }}?v=6" defer=""></script>
 
     <script>
         window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };

--- a/templates/legal/base.html
+++ b/templates/legal/base.html
@@ -30,7 +30,7 @@
                 <li><a href="/api">API</a></li>
                 <li><a href="/stats">Stats</a></li>
                 <li><a href="/report">Report URL</a></li>
-                <li><a href="https://github.com/spoo-me/url-shortener" rel="noopener" target="_blank">Open-Source ↗</a>
+                <li><a href="https://github.com/spoo-me/spoo" rel="noopener" target="_blank">Open-Source ↗</a>
                 </li>
                 <li onclick="showContactModal();"><a href="#">Contact</a></li>
             </ul>
@@ -52,7 +52,7 @@
             <li><a href="/api">API</a></li>
             <li><a href="/stats">Stats</a></li>
             <li><a href="/report">Report URL</a></li>
-            <li><a href="https://github.com/spoo-me/url-shortener" rel="noopener" target="_blank">Open-Source ↗</a>
+            <li><a href="https://github.com/spoo-me/spoo" rel="noopener" target="_blank">Open-Source ↗</a>
             </li>
             <li onclick="showContactModal();"><a href="#">Contact</a></li>
         </ul>

--- a/templates/partials/mobile_navbar.html
+++ b/templates/partials/mobile_navbar.html
@@ -41,7 +41,7 @@
         <li onclick="showContactModal();"><a href="#">Contact</a></li>
         {% endif %}
         <li>
-            <a href="https://github.com/spoo-me/url-shortener" rel="noopener" target="_blank" class="external-link">
+            <a href="https://github.com/spoo-me/spoo" rel="noopener" target="_blank" class="external-link">
                 <span>GitHub</span>
                 <svg width="14" height="14" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M10.5 1.5L1.5 10.5M10.5 1.5H3M10.5 1.5V9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -24,7 +24,7 @@
             <li class="nav-group-secondary" onclick="showContactModal();"><a href="#">Contact</a></li>
             {% endif %}
             <li class="nav-group-secondary">
-                <a href="https://github.com/spoo-me/url-shortener" rel="noopener" target="_blank" class="github-badge">
+                <a href="https://github.com/spoo-me/spoo" rel="noopener" target="_blank" class="github-badge">
                     <span class="github-icon">
                         <svg fill="currentColor" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                             <title>GitHub</title>

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -39,7 +39,7 @@
                             <path
                                 d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
                         </svg>
-                        <span id="github-star-count">170</span>
+                        <span id="github-star-count">200</span>
                     </span>
                 </a>
             </li>

--- a/templates/stats_view.html
+++ b/templates/stats_view.html
@@ -24,7 +24,7 @@
 {% block head_css %}
     <link rel="stylesheet" href="{{ url_for('static', path='css/stats-view.css') }}?v=13">
     <link rel="stylesheet" href="{{ url_for('static', path='css/prism-duotone-dark.css') }}">
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spoo-me/url-shortener/static/css/anychart-ui.min.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spoo-me/spoo/static/css/anychart-ui.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/8.12.1/fonts/css/anychart-font.min.css" />
 {% endblock %}
 


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub star metrics to use the correct repository and avoid displaying unset values.

Bug Fixes:
- Fetch GitHub star count from the correct GitHub repository API endpoint.
- Prevent rendering of GitHub star counts when the API returns zero or missing data to avoid showing incorrect values.

Enhancements:
- Update default navbar GitHub star count display text to a more current value.
- Bump static asset version query params for updated JavaScript bundles that handle GitHub star metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub repository target is now configurable (via environment/config), affecting star count and outbound links.

* **Updates**
  * GitHub star count now displays only when greater than zero.
  * Updated visible GitHub badge count to 200.
  * Updated public GitHub links to point to the new repository.

* **Chores**
  * Bumped cache-busting versions for header and index scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->