### PR TITLE
fix: handle document overflow in update operations Legacy URLs

### DIFF
--- a/repositories/legacy/emoji_url_repository.py
+++ b/repositories/legacy/emoji_url_repository.py
@@ -69,8 +69,7 @@ class EmojiUrlRepository:
         $inc/$set/$addToSet pattern from the legacy handle_legacy_click().
 
         If the update exceeds MongoDB's 16 MB document limit (due to
-        unbounded $addToSet IP arrays), the update is retried without
-        $addToSet so that counters and metadata are still recorded.
+        unbounded $addToSet IP arrays), only total-clicks is incremented.
         """
         try:
             await self._col.update_one({"_id": alias}, update_ops)
@@ -78,7 +77,19 @@ class EmojiUrlRepository:
             if exc.code != _DOCUMENT_TOO_LARGE_CODE:
                 raise
             # $inc on an existing integer never changes BSON size.
-            await self._col.update_one({"_id": alias}, {"$inc": {"total-clicks": 1}})
+            inc = update_ops.get("$inc", {}).get("total-clicks", 1)
+            try:
+                await self._col.update_one(
+                    {"_id": alias}, {"$inc": {"total-clicks": inc}}
+                )
+            except PyMongoError as retry_exc:
+                log.error(
+                    "emoji_url_repo_overflow_retry_failed",
+                    alias=alias,
+                    error=str(retry_exc),
+                    error_type=type(retry_exc).__name__,
+                )
+                raise
             log.info(
                 "emoji_url_repo_document_overflow",
                 alias=alias,

--- a/repositories/legacy/emoji_url_repository.py
+++ b/repositories/legacy/emoji_url_repository.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 from typing import Any
 
 from pymongo.asynchronous.collection import AsyncCollection
-from pymongo.errors import DuplicateKeyError, PyMongoError
+from pymongo.errors import DuplicateKeyError, PyMongoError, WriteError
 
 from schemas.models.url import EmojiUrlDoc
 from shared.logging import get_logger
 
 log = get_logger(__name__)
+
+_DOCUMENT_TOO_LARGE_CODE = 10334
 
 
 class EmojiUrlRepository:
@@ -65,9 +67,23 @@ class EmojiUrlRepository:
 
         The update document is built by the click service using the exact
         $inc/$set/$addToSet pattern from the legacy handle_legacy_click().
+
+        If the update exceeds MongoDB's 16 MB document limit (due to
+        unbounded $addToSet IP arrays), the update is retried without
+        $addToSet so that counters and metadata are still recorded.
         """
         try:
             await self._col.update_one({"_id": alias}, update_ops)
+        except WriteError as exc:
+            if exc.code != _DOCUMENT_TOO_LARGE_CODE:
+                raise
+            # $inc on an existing integer never changes BSON size.
+            await self._col.update_one({"_id": alias}, {"$inc": {"total-clicks": 1}})
+            log.info(
+                "emoji_url_repo_document_overflow",
+                alias=alias,
+                msg="document exceeded 16 MB limit; click recorded with total-clicks only",
+            )
         except PyMongoError as exc:
             log.error(
                 "emoji_url_repo_update_failed",

--- a/repositories/legacy/legacy_url_repository.py
+++ b/repositories/legacy/legacy_url_repository.py
@@ -81,8 +81,7 @@ class LegacyUrlRepository:
         executes it as-is to preserve the exact embedded analytics format.
 
         If the update exceeds MongoDB's 16 MB document limit (due to
-        unbounded $addToSet IP arrays), the update is retried without
-        $addToSet so that counters and metadata are still recorded.
+        unbounded $addToSet IP arrays), only total-clicks is incremented.
         """
         try:
             await self._col.update_one({"_id": short_code}, update_ops)
@@ -90,9 +89,19 @@ class LegacyUrlRepository:
             if exc.code != _DOCUMENT_TOO_LARGE_CODE:
                 raise
             # $inc on an existing integer never changes BSON size.
-            await self._col.update_one(
-                {"_id": short_code}, {"$inc": {"total-clicks": 1}}
-            )
+            inc = update_ops.get("$inc", {}).get("total-clicks", 1)
+            try:
+                await self._col.update_one(
+                    {"_id": short_code}, {"$inc": {"total-clicks": inc}}
+                )
+            except PyMongoError as retry_exc:
+                log.error(
+                    "legacy_url_repo_overflow_retry_failed",
+                    short_code=short_code,
+                    error=str(retry_exc),
+                    error_type=type(retry_exc).__name__,
+                )
+                raise
             log.info(
                 "legacy_url_repo_document_overflow",
                 short_code=short_code,

--- a/repositories/legacy/legacy_url_repository.py
+++ b/repositories/legacy/legacy_url_repository.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 from typing import Any
 
 from pymongo.asynchronous.collection import AsyncCollection
-from pymongo.errors import DuplicateKeyError, PyMongoError
+from pymongo.errors import DuplicateKeyError, PyMongoError, WriteError
 
 from schemas.models.url import LegacyUrlDoc
 from shared.logging import get_logger
 
 log = get_logger(__name__)
+
+_DOCUMENT_TOO_LARGE_CODE = 10334
 
 
 class LegacyUrlRepository:
@@ -77,9 +79,25 @@ class LegacyUrlRepository:
         $inc/$set/$addToSet pattern from the legacy handle_legacy_click().
         The repository does not interpret or construct the update — it
         executes it as-is to preserve the exact embedded analytics format.
+
+        If the update exceeds MongoDB's 16 MB document limit (due to
+        unbounded $addToSet IP arrays), the update is retried without
+        $addToSet so that counters and metadata are still recorded.
         """
         try:
             await self._col.update_one({"_id": short_code}, update_ops)
+        except WriteError as exc:
+            if exc.code != _DOCUMENT_TOO_LARGE_CODE:
+                raise
+            # $inc on an existing integer never changes BSON size.
+            await self._col.update_one(
+                {"_id": short_code}, {"$inc": {"total-clicks": 1}}
+            )
+            log.info(
+                "legacy_url_repo_document_overflow",
+                short_code=short_code,
+                msg="document exceeded 16 MB limit; click recorded with total-clicks only",
+            )
         except PyMongoError as exc:
             log.error(
                 "legacy_url_repo_update_failed",

--- a/tests/unit/repositories/test_emoji_url_repository.py
+++ b/tests/unit/repositories/test_emoji_url_repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 from pymongo.errors import WriteError
@@ -68,9 +68,12 @@ class TestEmojiUrlRepository:
             side_effect=[WriteError("too large", code=10334), MagicMock()]
         )
         await self._repo(col).update("\U0001f525\U0001f4af", update_ops)
-        assert col.update_one.await_count == 2
-        col.update_one.assert_awaited_with(
-            {"_id": "\U0001f525\U0001f4af"}, {"$inc": {"total-clicks": 1}}
+        col.update_one.assert_has_awaits(
+            [
+                call({"_id": "\U0001f525\U0001f4af"}, update_ops),
+                call({"_id": "\U0001f525\U0001f4af"}, {"$inc": {"total-clicks": 1}}),
+            ],
+            any_order=False,
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/repositories/test_emoji_url_repository.py
+++ b/tests/unit/repositories/test_emoji_url_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pymongo.errors import WriteError
 
 from .conftest import _legacy_url_doc, make_collection
 
@@ -47,6 +48,30 @@ class TestEmojiUrlRepository:
         ops = {"$inc": {"total-clicks": 1}, "$set": {"last-click": "2024-01-01"}}
         await self._repo(col).update("\U0001f525\U0001f4af", ops)
         col.update_one.assert_awaited_once_with({"_id": "\U0001f525\U0001f4af"}, ops)
+
+    @pytest.mark.asyncio
+    async def test_update_retries_with_inc_only_on_document_overflow(self):
+        col = make_collection()
+        update_ops = {
+            "$inc": {
+                "total-clicks": 1,
+                "counter.2024-01-15": 1,
+                "country.US.counts": 1,
+            },
+            "$set": {
+                "last-click": "2024-01-15 12:00:00",
+                "last-click-browser": "Chrome",
+            },
+            "$addToSet": {"ips": "1.2.3.4", "country.US.ips": "1.2.3.4"},
+        }
+        col.update_one = AsyncMock(
+            side_effect=[WriteError("too large", code=10334), MagicMock()]
+        )
+        await self._repo(col).update("\U0001f525\U0001f4af", update_ops)
+        assert col.update_one.await_count == 2
+        col.update_one.assert_awaited_with(
+            {"_id": "\U0001f525\U0001f4af"}, {"$inc": {"total-clicks": 1}}
+        )
 
     @pytest.mark.asyncio
     async def test_check_exists_true(self):

--- a/tests/unit/repositories/test_legacy_url_repository.py
+++ b/tests/unit/repositories/test_legacy_url_repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 from pymongo.errors import WriteError
@@ -91,9 +91,12 @@ class TestLegacyUrlRepository:
             side_effect=[WriteError("too large", code=10334), MagicMock()]
         )
         await self._repo(col).update("abc123", update_ops)
-        assert col.update_one.await_count == 2
-        col.update_one.assert_awaited_with(
-            {"_id": "abc123"}, {"$inc": {"total-clicks": 1}}
+        col.update_one.assert_has_awaits(
+            [
+                call({"_id": "abc123"}, update_ops),
+                call({"_id": "abc123"}, {"$inc": {"total-clicks": 1}}),
+            ],
+            any_order=False,
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/repositories/test_legacy_url_repository.py
+++ b/tests/unit/repositories/test_legacy_url_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pymongo.errors import WriteError
 
 from .conftest import _legacy_url_doc, make_collection
 
@@ -69,6 +70,31 @@ class TestLegacyUrlRepository:
         }
         await self._repo(col).update("abc123", update_ops)
         col.update_one.assert_awaited_once_with({"_id": "abc123"}, update_ops)
+
+    @pytest.mark.asyncio
+    async def test_update_retries_with_inc_only_on_document_overflow(self):
+        col = make_collection()
+        update_ops = {
+            "$inc": {
+                "total-clicks": 1,
+                "counter.2024-01-15": 1,
+                "country.US.counts": 1,
+            },
+            "$set": {
+                "last-click": "2024-01-15 12:00:00",
+                "last-click-browser": "Chrome",
+            },
+            "$addToSet": {"ips": "1.2.3.4", "country.US.ips": "1.2.3.4"},
+        }
+        # First call raises WriteError with code 10334 (document too large), retry succeeds
+        col.update_one = AsyncMock(
+            side_effect=[WriteError("too large", code=10334), MagicMock()]
+        )
+        await self._repo(col).update("abc123", update_ops)
+        assert col.update_one.await_count == 2
+        col.update_one.assert_awaited_with(
+            {"_id": "abc123"}, {"$inc": {"total-clicks": 1}}
+        )
 
     @pytest.mark.asyncio
     async def test_check_exists_true(self):


### PR DESCRIPTION
## Summary by Sourcery

Handle MongoDB document-overflow errors in legacy URL update operations by retrying with a reduced update payload and ensure behavior is covered by tests.

Bug Fixes:
- Ensure legacy URL updates still record click counters when MongoDB rejects the full update due to document size limits.
- Ensure emoji URL updates still record click counters when MongoDB rejects the full update due to document size limits.

Enhancements:
- Log document-overflow events in legacy and emoji URL repositories when updates exceed MongoDB's 16 MB limit.

Tests:
- Add unit tests verifying that legacy URL updates retry with an $inc-only operation when a document-too-large WriteError occurs.
- Add unit tests verifying that emoji URL updates retry with an $inc-only operation when a document-too-large WriteError occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for document size limit failures during updates: when an update would exceed storage limits, the system now retries with a streamlined operation that safely increments click counts to preserve metrics and avoid data loss; successful and failed overflow fallbacks are logged.

* **Tests**
  * Added unit tests covering the overflow-retry behavior to ensure reliable retry and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->