### PR TITLE
fix: prevent modification and deletion of blocked URLs in UrlService

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -75,6 +75,11 @@ class ConflictError(AppError):
     error_code = "conflict"
 
 
+class BlockedUrlError(AppError):
+    status_code = 451
+    error_code = "blocked"
+
+
 class GoneError(AppError):
     status_code = 410
     error_code = "gone"

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -16,7 +16,13 @@ from fastapi.responses import RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from dependencies import get_click_service, get_url_service
-from errors import ForbiddenError, GoneError, NotFoundError, ValidationError
+from errors import (
+    BlockedUrlError,
+    ForbiddenError,
+    GoneError,
+    NotFoundError,
+    ValidationError,
+)
 from middleware.rate_limiter import Limits, limiter
 from services.click import ClickService
 from services.url_service import UrlService
@@ -76,9 +82,9 @@ async def redirect_url(
     except NotFoundError:
         log.info("url_not_found", short_code=short_code)
         return _error_page(request, "404", "URL NOT FOUND", 404)
-    except ForbiddenError:
+    except BlockedUrlError:
         log.warning("url_blocked", short_code=short_code)
-        return _error_page(request, "403", "ACCESS DENIED", 403)
+        return _error_page(request, "451", "THIS URL HAS BEEN BLOCKED", 451)
     except GoneError:
         log.info("url_gone", short_code=short_code)
         return _error_page(request, "410", "SHORT URL EXPIRED", 410)
@@ -159,7 +165,7 @@ async def check_password(
 
     try:
         url_data, schema = await url_service.resolve(short_code)
-    except (NotFoundError, ForbiddenError, GoneError):
+    except (NotFoundError, BlockedUrlError, ForbiddenError, GoneError):
         return _error_page(
             request, "400", "Invalid short code or URL not password-protected", 400
         )

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -24,6 +24,7 @@ from bson import ObjectId
 
 from errors import (
     AppError,
+    BlockedUrlError,
     ConflictError,
     ForbiddenError,
     GoneError,
@@ -280,7 +281,7 @@ class UrlService:
 
         Raises:
             NotFoundError:  URL doesn't exist.
-            ForbiddenError: Caller doesn't own the URL.
+            ForbiddenError: Caller doesn't own the URL, or URL is blocked.
             ConflictError:  Requested alias is already taken.
             ValidationError: Invalid field values.
         """
@@ -398,7 +399,7 @@ class UrlService:
 
         Raises:
             NotFoundError:  URL doesn't exist.
-            ForbiddenError: Caller doesn't own the URL.
+            ForbiddenError: Caller doesn't own the URL, or URL is blocked.
         """
         existing = await self._url_repo.find_by_id(url_id)
         if existing is None:
@@ -586,7 +587,7 @@ class UrlService:
 
 def _raise_for_status(status: str) -> None:
     if status == "BLOCKED":
-        raise ForbiddenError("URL is blocked")
+        raise BlockedUrlError("URL is blocked")
     raise GoneError("URL has expired or is no longer active")
 
 

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -295,6 +295,10 @@ class UrlService:
         if existing.owner_id != owner_id:
             raise ForbiddenError("Access denied: you do not own this URL")
 
+        # 2b. Admin-blocked URLs cannot be modified by the owner
+        if existing.status == "BLOCKED":
+            raise ForbiddenError("Cannot modify a blocked URL")
+
         # 3. Build update ops — only changed fields
         update_ops: dict = {}
         fields_set = request.model_fields_set
@@ -402,6 +406,9 @@ class UrlService:
 
         if existing.owner_id != owner_id:
             raise ForbiddenError("Access denied: you do not own this URL")
+
+        if existing.status == "BLOCKED":
+            raise ForbiddenError("Cannot delete a blocked URL")
 
         await self._url_repo.delete(url_id)
         await self._url_cache.invalidate(existing.alias)

--- a/static/css/dashboard/links.css
+++ b/static/css/dashboard/links.css
@@ -808,9 +808,23 @@ input[type="datetime-local"]::-webkit-inner-spin-button {
 }
 
 .badge-status.badge-inactive {
-    background: rgba(239, 68, 68, 0.1);
-    color: #ef4444;
-    border: 1px solid rgba(239, 68, 68, 0.2);
+    background: rgba(249, 115, 22, 0.1);
+    color: #f97316;
+    border: 1px solid rgba(249, 115, 22, 0.2);
+}
+
+.badge-status.badge-blocked {
+    background: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.table-row.row-blocked {
+    background: rgba(239, 68, 68, 0.05);
+}
+
+.table-row.row-blocked:hover {
+    background: rgba(239, 68, 68, 0.08);
 }
 
 .badge-password {
@@ -826,9 +840,9 @@ input[type="datetime-local"]::-webkit-inner-spin-button {
 }
 
 .badge-private {
-    background: rgba(239, 68, 68, 0.1);
-    color: #ef4444;
-    border: 1px solid rgba(239, 68, 68, 0.2);
+    background: rgba(100, 116, 139, 0.1);
+    color: #64748b;
+    border: 1px solid rgba(100, 116, 139, 0.2);
 }
 
 .badge-block-bots {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -89,6 +89,7 @@
 		const long = node.querySelector('.link-long');
 		const activeBadge = node.querySelector('.badge-active');
 		const inactiveBadge = node.querySelector('.badge-inactive');
+		const blockedBadge = node.querySelector('.badge-blocked');
 		const pwBadge = node.querySelector('.badge-password');
 		const mcBadge = node.querySelector('.badge-max-clicks');
 		const privBadge = node.querySelector('.badge-private');
@@ -113,13 +114,11 @@
 		// Status badges - show appropriate badge based on status
 		if (it.status === 'ACTIVE') {
 			activeBadge.style.display = 'inline-flex';
-			inactiveBadge.style.display = 'none';
 		} else if (it.status === 'INACTIVE') {
-			activeBadge.style.display = 'none';
 			inactiveBadge.style.display = 'inline-flex';
-		} else {
-			activeBadge.style.display = 'none';
-			inactiveBadge.style.display = 'none';
+		} else if (it.status === 'BLOCKED') {
+			blockedBadge.style.display = 'inline-flex';
+			node.classList.add('row-blocked');
 		}
 
 		// Password badge

--- a/static/js/url-manager.js
+++ b/static/js/url-manager.js
@@ -186,6 +186,19 @@ class UrlManager {
 
         // Update deactivate button based on current status
         this.updateDeactivateButton(urlData.status);
+
+        // Blocked URLs: disable all editing
+        const isBlocked = urlData.status === 'BLOCKED';
+        if (this.deleteBtn) this.deleteBtn.disabled = isBlocked;
+        if (this.saveBtn) this.saveBtn.disabled = isBlocked;
+        if (this.aliasInput) this.aliasInput.disabled = isBlocked;
+        if (this.longUrlInput) this.longUrlInput.disabled = isBlocked;
+        if (this.passwordInput) this.passwordInput.disabled = isBlocked;
+        if (this.maxClicksInput) this.maxClicksInput.disabled = isBlocked;
+        if (this.expireAfterInput) this.expireAfterInput.disabled = isBlocked;
+        if (this.blockBotsCheckbox) this.blockBotsCheckbox.disabled = isBlocked;
+        if (this.privateStatsCheckbox) this.privateStatsCheckbox.disabled = isBlocked;
+        if (this.removePasswordCheckbox) this.removePasswordCheckbox.disabled = isBlocked;
     }
 
     handlePasswordCheckboxChange() {
@@ -210,12 +223,18 @@ class UrlManager {
 
     updateDeactivateButton(status) {
         if (this.deactivateBtn) {
-            if (status === 'ACTIVE') {
+            if (status === 'BLOCKED') {
+                this.deactivateBtn.innerHTML = '<i class="ti ti-ban"></i><span>Blocked</span>';
+                this.deactivateBtn.className = 'btn btn-danger';
+                this.deactivateBtn.disabled = true;
+            } else if (status === 'ACTIVE') {
                 this.deactivateBtn.innerHTML = '<i class="ti ti-player-pause"></i><span>Deactivate</span>';
                 this.deactivateBtn.className = 'btn btn-warning';
+                this.deactivateBtn.disabled = false;
             } else {
                 this.deactivateBtn.innerHTML = '<i class="ti ti-player-play"></i><span>Activate</span>';
                 this.deactivateBtn.className = 'btn btn-success';
+                this.deactivateBtn.disabled = false;
             }
         }
     }
@@ -675,17 +694,19 @@ class UrlManager {
                         // Update status badges
                         const activeBadge = row.querySelector('.badge-active');
                         const inactiveBadge = row.querySelector('.badge-inactive');
-                        if (activeBadge && inactiveBadge) {
-                            if (updatedUrlData.status === 'ACTIVE') {
-                                activeBadge.style.display = 'inline-flex';
-                                inactiveBadge.style.display = 'none';
-                            } else if (updatedUrlData.status === 'INACTIVE') {
-                                activeBadge.style.display = 'none';
-                                inactiveBadge.style.display = 'inline-flex';
-                            } else {
-                                activeBadge.style.display = 'none';
-                                inactiveBadge.style.display = 'none';
-                            }
+                        const blockedBadge = row.querySelector('.badge-blocked');
+                        if (activeBadge) activeBadge.style.display = 'none';
+                        if (inactiveBadge) inactiveBadge.style.display = 'none';
+                        if (blockedBadge) blockedBadge.style.display = 'none';
+                        row.classList.remove('row-blocked');
+
+                        if (updatedUrlData.status === 'ACTIVE' && activeBadge) {
+                            activeBadge.style.display = 'inline-flex';
+                        } else if (updatedUrlData.status === 'INACTIVE' && inactiveBadge) {
+                            inactiveBadge.style.display = 'inline-flex';
+                        } else if (updatedUrlData.status === 'BLOCKED' && blockedBadge) {
+                            blockedBadge.style.display = 'inline-flex';
+                            row.classList.add('row-blocked');
                         }
 
                         const passwordBadge = row.querySelector('.badge-password');

--- a/templates/dashboard/links.html
+++ b/templates/dashboard/links.html
@@ -3,7 +3,7 @@
 {% block title %}Links | Dashboard | spoo.me{% endblock %}
 
 {% block head_css %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/links.css') }}?v=2">
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/links.css') }}?v=3">
 <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/url-modal.css') }}?v=1">
 <script defer src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
@@ -187,6 +187,10 @@
                 <span class="badge badge-status badge-inactive tooltip-trigger" data-tooltip="Inactive"
                     style="display:none">
                     <i class="ti ti-circle-x"></i>
+                </span>
+                <span class="badge badge-status badge-blocked tooltip-trigger" data-tooltip="Blocked by admin"
+                    style="display:none">
+                    <i class="ti ti-ban"></i>
                 </span>
                 <span class="badge badge-password tooltip-trigger" data-tooltip="Password protected"
                     style="display:none">
@@ -606,8 +610,8 @@
 
 {% block scripts %}
 <script src="{{ url_for('static', path='js/dashboard/smart-datetime.js') }}?v=1"></script>
-<script src="{{ url_for('static', path='js/dashboard.js') }}?v=1" defer></script>
-<script src="{{ url_for('static', path='js/url-manager.js') }}?v=1" defer></script>
+<script src="{{ url_for('static', path='js/dashboard.js') }}?v=2" defer></script>
+<script src="{{ url_for('static', path='js/url-manager.js') }}?v=2" defer></script>
 <script>
     // Initialize segmented controls for the options dropdown
     document.addEventListener('DOMContentLoaded', function () {

--- a/tests/integration/test_redirect.py
+++ b/tests/integration/test_redirect.py
@@ -25,7 +25,13 @@ os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 
 from config import AppSettings
 from dependencies import get_click_service, get_url_service
-from errors import ForbiddenError, GoneError, NotFoundError, ValidationError
+from errors import (
+    BlockedUrlError,
+    ForbiddenError,
+    GoneError,
+    NotFoundError,
+    ValidationError,
+)
 from infrastructure.cache.url_cache import UrlCacheData
 from middleware.error_handler import register_error_handlers
 from middleware.rate_limiter import limiter
@@ -237,9 +243,9 @@ def test_redirect_wrong_password():
 
 
 def test_redirect_blocked_url():
-    """resolve raises ForbiddenError -> 403 HTML."""
+    """resolve raises BlockedUrlError -> 451 HTML."""
     mock_url_svc = AsyncMock()
-    mock_url_svc.resolve = AsyncMock(side_effect=ForbiddenError("Blocked"))
+    mock_url_svc.resolve = AsyncMock(side_effect=BlockedUrlError("Blocked"))
     mock_click_svc = AsyncMock()
 
     app = _build_test_app(
@@ -251,7 +257,7 @@ def test_redirect_blocked_url():
     client = TestClient(app, raise_server_exceptions=False)
     resp = client.get("/abc123", follow_redirects=False)
 
-    assert resp.status_code == 403
+    assert resp.status_code == 451
     assert "text/html" in resp.headers.get("content-type", "")
 
 

--- a/tests/integration/test_redirect_routes.py
+++ b/tests/integration/test_redirect_routes.py
@@ -21,6 +21,7 @@ os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 from config import AppSettings
 from dependencies import get_click_service, get_url_service
 from errors import (
+    BlockedUrlError,
     ForbiddenError,
     GoneError,
     NotFoundError,
@@ -132,16 +133,16 @@ def test_redirect_not_found_returns_404_html():
     assert "text/html" in resp.headers["content-type"]
 
 
-def test_redirect_blocked_url_returns_403_html():
+def test_redirect_blocked_url_returns_451_html():
     url_svc = MagicMock()
-    url_svc.resolve = AsyncMock(side_effect=ForbiddenError("blocked"))
+    url_svc.resolve = AsyncMock(side_effect=BlockedUrlError("blocked"))
     click_svc = _mock_click_service()
     app = _build_test_app(
         {get_url_service: lambda: url_svc, get_click_service: lambda: click_svc}
     )
     with TestClient(app) as client:
         resp = client.get("/blocked1")
-    assert resp.status_code == 403
+    assert resp.status_code == 451
     assert "text/html" in resp.headers["content-type"]
 
 

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -647,6 +647,42 @@ class TestUrlServiceUpdate:
         with pytest.raises(ConflictError):
             await svc.update(URL_OID, req, USER_OID)
 
+    @pytest.mark.asyncio
+    async def test_update_blocked_url_raises_forbidden(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        existing = make_url_v2_doc(status="BLOCKED")
+        url_repo.find_by_id.return_value = existing
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        req = UpdateUrlRequest(long_url="https://new-url.com")
+        with pytest.raises(ForbiddenError, match="Cannot modify a blocked URL"):
+            await svc.update(URL_OID, req, USER_OID)
+
+        url_repo.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_blocked_url_status_change_raises_forbidden(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        existing = make_url_v2_doc(status="BLOCKED")
+        url_repo.find_by_id.return_value = existing
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        req = UpdateUrlRequest(status="ACTIVE")
+        with pytest.raises(ForbiddenError, match="Cannot modify a blocked URL"):
+            await svc.update(URL_OID, req, USER_OID)
+
+        url_repo.update.assert_not_called()
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestUrlServiceDelete
@@ -697,6 +733,21 @@ class TestUrlServiceDelete:
 
         with pytest.raises(NotFoundError):
             await svc.delete(URL_OID, USER_OID)
+
+    @pytest.mark.asyncio
+    async def test_delete_blocked_url_raises_forbidden(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        existing = make_url_v2_doc(status="BLOCKED")
+        url_repo.find_by_id.return_value = existing
+
+        with pytest.raises(ForbiddenError, match="Cannot delete a blocked URL"):
+            await svc.delete(URL_OID, USER_OID)
+
+        url_repo.delete.assert_not_called()
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -14,6 +14,7 @@ import pytest
 from bson import ObjectId
 
 from errors import (
+    BlockedUrlError,
     ConflictError,
     ForbiddenError,
     GoneError,
@@ -164,7 +165,7 @@ class TestUrlServiceResolve:
         url_repo.find_by_alias.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cache_hit_blocked_v2_raises_forbidden(self):
+    async def test_cache_hit_blocked_v2_raises_blocked_url_error(self):
         url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
         svc = make_service(
             url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
@@ -184,7 +185,7 @@ class TestUrlServiceResolve:
         )
         url_cache.get.return_value = cached
 
-        with pytest.raises(ForbiddenError):
+        with pytest.raises(BlockedUrlError):
             await svc.resolve(ALIAS)
 
     @pytest.mark.asyncio
@@ -340,7 +341,7 @@ class TestUrlServiceResolve:
         blocked_doc = make_url_v2_doc(alias=ALIAS, status="BLOCKED")
         url_repo.find_by_alias.return_value = blocked_doc
 
-        with pytest.raises(ForbiddenError):
+        with pytest.raises(BlockedUrlError):
             await svc.resolve(ALIAS)
 
         # Cache should have been populated (even for blocked URLs)
@@ -664,6 +665,7 @@ class TestUrlServiceUpdate:
             await svc.update(URL_OID, req, USER_OID)
 
         url_repo.update.assert_not_called()
+        url_cache.invalidate.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_blocked_url_status_change_raises_forbidden(self):
@@ -682,6 +684,7 @@ class TestUrlServiceUpdate:
             await svc.update(URL_OID, req, USER_OID)
 
         url_repo.update.assert_not_called()
+        url_cache.invalidate.assert_not_called()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -748,6 +751,7 @@ class TestUrlServiceDelete:
             await svc.delete(URL_OID, USER_OID)
 
         url_repo.delete.assert_not_called()
+        url_cache.invalidate.assert_not_called()
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary by Sourcery

Prevent blocked URLs from being modified or deleted in the URL service.

Bug Fixes:
- Disallow updates to URLs marked as BLOCKED by raising a forbidden error instead of proceeding with modifications.
- Disallow deletion of URLs marked as BLOCKED by raising a forbidden error instead of proceeding with deletion.

Tests:
- Add unit tests verifying that attempts to update a blocked URL raise a forbidden error and do not call the repository update method.
- Add a unit test verifying that attempts to delete a blocked URL raise a forbidden error and do not call the repository delete method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocked links are now clearly labeled with a "Blocked" badge and a distinct row style.
  * Edit/delete actions and form controls for blocked links are disabled in the UI.

* **Bug Fixes**
  * Attempts to modify or delete a blocked link are rejected with a clear error message.

* **Style**
  * Updated status and privacy badge color schemes and hover/row shading for blocked items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->