### PR TITLE
feat: improve hCaptcha support & site analytics support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ SENTRY_SEND_PII="false"                # Send user emails/IPs (consider GDPR imp
 SENTRY_TRACES_SAMPLE_RATE=0.1       # % of transactions to capture (1.0 in dev, 0.05-0.1 in prod to reduce costs)
 SENTRY_PROFILE_SAMPLE_RATE=0.05     # % of profiling sessions to capture (1.0 in dev, 0.01-0.05 in prod, very expensive)
 
+# Analytics & tracking (leave empty to disable)
+CLARITY_ID=""                          # Microsoft Clarity tracking ID
+HCAPTCHA_SITEKEY=""                    # hCaptcha site key (public, used in templates)
+
 # App configs
 SECRET_KEY="" # To generate: python -c "import os; print(os.urandom(32).hex())"
 HOST_URI="127.0.0.1:8000"

--- a/app.py
+++ b/app.py
@@ -14,7 +14,6 @@ import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
 from pymongo.asynchronous.mongo_client import AsyncMongoClient
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -45,6 +44,7 @@ from routes.oauth_routes import router as oauth_router
 from routes.redirect_routes import router as redirect_router
 from routes.static_routes import router as static_router
 from shared.logging import get_logger
+from shared.templates import configure_template_globals, templates
 
 log = get_logger(__name__)
 
@@ -142,17 +142,21 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
 
     configure_openapi(app, app_url=settings.app_url)
 
+    # ── Template globals (tracking IDs available in every template) ─────
+    configure_template_globals(
+        clarity_id=settings.clarity_id,
+        sentry_client_key=settings.sentry.client_key,
+        hcaptcha_sitekey=settings.hcaptcha_sitekey,
+    )
+
     # ── /docs — Scalar in dev, redirect in prod ──────────────────────────
     _is_prod = settings.is_production
-    _templates = Jinja2Templates(
-        directory=os.path.join(os.path.dirname(__file__), "templates")
-    )
 
     @app.get("/docs", include_in_schema=False)
     async def docs(request: Request):
         if _is_prod:
             return RedirectResponse(_DOCS_URL)
-        return _templates.TemplateResponse(
+        return templates.TemplateResponse(
             request,
             "scalar_docs.html",
             {

--- a/config.py
+++ b/config.py
@@ -10,6 +10,8 @@ FLASK_SECRET_KEY is also accepted as an alias for backward compatibility
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -97,6 +99,16 @@ class SentrySettings(BaseSettings):
     sentry_traces_sample_rate: float = 0.1
     sentry_profile_sample_rate: float = 0.05
 
+    @property
+    def client_key(self) -> str:
+        """Extract the public key from the DSN for the frontend loader script."""
+        if not self.sentry_dsn:
+            return ""
+        try:
+            return urlparse(self.sentry_dsn).username or ""
+        except Exception:
+            return ""
+
 
 class AppSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -121,10 +133,14 @@ class AppSettings(BaseSettings):
     # GitHub repository (owner/repo) — used for star count + outbound links
     github_repo: str = "spoo-me/spoo"
 
+    # Analytics & tracking (leave empty to disable)
+    clarity_id: str = ""
+
     # External service URLs
     contact_webhook: str = ""
     url_report_webhook: str = ""
     hcaptcha_secret: str = ""
+    hcaptcha_sitekey: str = ""
 
     # Sub-configs (composed via model_validator below)
     db: DatabaseSettings | None = None

--- a/infrastructure/captcha/hcaptcha.py
+++ b/infrastructure/captcha/hcaptcha.py
@@ -21,8 +21,7 @@ class HCaptchaProvider:
 
     async def verify(self, token: str) -> bool:
         if not self._secret:
-            log.warning("hcaptcha_secret_not_configured")
-            return False
+            return True
         try:
             response = await self._http.post(
                 _HCAPTCHA_VERIFY_URL,

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -7,22 +7,17 @@ Browser/page requests get the error.html template.
 
 from __future__ import annotations
 
-import os
-
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
-from fastapi.templating import Jinja2Templates
 from pydantic import ValidationError as PydanticValidationError
 from slowapi.errors import RateLimitExceeded
 
 from errors import AppError
 from shared.logging import get_logger
+from shared.templates import templates
 
 log = get_logger(__name__)
-
-_TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 
 def _wants_json(request: Request) -> bool:

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -19,11 +19,8 @@ POST /auth/reset-password
 
 from __future__ import annotations
 
-import os
-
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 
 from dependencies import AuthUser, get_auth_service
 from errors import AuthenticationError
@@ -52,13 +49,11 @@ from schemas.dto.responses.common import MessageResponse
 from services.auth_service import OTP_EXPIRY_SECONDS, AuthService
 from shared.ip_utils import get_client_ip
 from shared.logging import get_logger
+from shared.templates import templates
 
 log = get_logger(__name__)
 
 router = APIRouter(tags=["Authentication"])
-
-_TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 
 # ── Redirect shortcuts ────────────────────────────────────────────────────────

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -13,11 +13,8 @@ POST /dashboard/profile-pictures  → set profile picture (JSON)
 
 from __future__ import annotations
 
-import os
-
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
 from dependencies import (
@@ -30,13 +27,11 @@ from errors import NotFoundError
 from middleware.rate_limiter import Limits, limiter
 from services.profile_picture_service import AvailablePicture, ProfilePictureService
 from shared.logging import get_logger
+from shared.templates import templates
 
 log = get_logger(__name__)
 
 router = APIRouter(prefix="/dashboard", include_in_schema=False)
-
-_TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/routes/legacy/stats.py
+++ b/routes/legacy/stats.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import csv
 import io
 import json
-import os
 import zipfile
 from datetime import datetime, timezone
 from urllib.parse import unquote
@@ -26,7 +25,6 @@ from fastapi.responses import (
     RedirectResponse,
     Response,
 )
-from fastapi.templating import Jinja2Templates
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font
 
@@ -44,16 +42,12 @@ from shared.legacy_helpers import (
     top_four,
 )
 from shared.logging import get_logger
+from shared.templates import templates
 from shared.validators import validate_emoji_alias
 
 log = get_logger(__name__)
 
 router = APIRouter(include_in_schema=False)
-
-_TEMPLATE_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "templates"
-)
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 
 # ── Stats entry form ──────────────────────────────────────────────────────────

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -12,14 +12,12 @@ GET  /metric        → global metrics (JSON, DualCache)
 
 from __future__ import annotations
 
-import os
 import time
 from datetime import datetime
 from urllib.parse import unquote, urlparse
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from fastapi.templating import Jinja2Templates
 
 from dependencies import OptionalUser, get_db, get_redis, get_settings, get_url_service
 from errors import ForbiddenError, GoneError, NotFoundError
@@ -33,6 +31,7 @@ from services.url_service import UrlService
 from shared.generators import generate_emoji_alias, generate_short_code
 from shared.legacy_helpers import humanize_number, is_positive_integer
 from shared.logging import get_logger
+from shared.templates import templates
 from shared.validators import (
     validate_alias,
     validate_blocked_url,
@@ -44,11 +43,6 @@ from shared.validators import (
 log = get_logger(__name__)
 
 router = APIRouter(include_in_schema=False)
-
-_TEMPLATE_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "templates"
-)
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 METRIC_PIPELINE_V1 = [
     {

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -7,13 +7,11 @@ POST /<short_code>/password → password form submission
 
 from __future__ import annotations
 
-import os
 import time
 from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse, Response
-from fastapi.templating import Jinja2Templates
 
 from dependencies import get_click_service, get_url_service
 from errors import (
@@ -30,13 +28,11 @@ from services.url_service import UrlService
 from shared.crypto import verify_password
 from shared.ip_utils import get_client_ip
 from shared.logging import get_logger, should_sample
+from shared.templates import templates
 
 log = get_logger(__name__)
 
 router = APIRouter()
-
-_TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 
 def _error_page(request: Request, code: str, message: str, status: int) -> Response:

--- a/routes/static_routes.py
+++ b/routes/static_routes.py
@@ -12,7 +12,6 @@ import os
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import FileResponse, RedirectResponse, Response
-from fastapi.templating import Jinja2Templates
 
 from dependencies import get_contact_service, get_url_service
 from errors import AppError, ForbiddenError, ValidationError
@@ -21,6 +20,7 @@ from services.contact_service import ContactService
 from services.url_service import UrlService
 from shared.ip_utils import get_client_ip
 from shared.logging import get_logger
+from shared.templates import templates
 
 log = get_logger(__name__)
 
@@ -29,8 +29,6 @@ router = APIRouter(include_in_schema=False)
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 _MISC_DIR = os.path.join(_PROJECT_ROOT, "misc")
 _STATIC_DIR = os.path.join(_PROJECT_ROOT, "static")
-_TEMPLATE_DIR = os.path.join(_PROJECT_ROOT, "templates")
-templates = Jinja2Templates(directory=_TEMPLATE_DIR)
 
 
 # ── SEO files ────────────────────────────────────────────────────────────────

--- a/routes/static_routes.py
+++ b/routes/static_routes.py
@@ -13,7 +13,8 @@ import os
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import FileResponse, RedirectResponse, Response
 
-from dependencies import get_contact_service, get_url_service
+from config import AppSettings
+from dependencies import get_contact_service, get_settings, get_url_service
 from errors import AppError, ForbiddenError, ValidationError
 from middleware.rate_limiter import Limits, limiter
 from services.contact_service import ContactService
@@ -140,8 +141,21 @@ async def docs_wildcard(path: str, request: Request) -> Response:
 async def contact(
     request: Request,
     contact_service: ContactService = Depends(get_contact_service),
+    settings: AppSettings = Depends(get_settings),
 ) -> Response:
     host_url = str(request.base_url)
+
+    if not settings.contact_webhook:
+        return templates.TemplateResponse(
+            request,
+            "error.html",
+            {
+                "error_code": "503",
+                "error_message": "CONTACT FORM NOT CONFIGURED",
+                "host_url": host_url,
+            },
+            status_code=503,
+        )
 
     if request.method == "GET":
         return templates.TemplateResponse(
@@ -153,9 +167,9 @@ async def contact(
     form = await request.form()
     email = form.get("email")
     message = form.get("message")
-    captcha_token = form.get("h-captcha-response")
+    captcha_token = form.get("h-captcha-response", "")
 
-    if not captcha_token:
+    if settings.hcaptcha_sitekey and not captcha_token:
         return templates.TemplateResponse(
             request,
             "contact.html",
@@ -207,8 +221,21 @@ async def report(
     request: Request,
     contact_service: ContactService = Depends(get_contact_service),
     url_service: UrlService = Depends(get_url_service),
+    settings: AppSettings = Depends(get_settings),
 ) -> Response:
     host_url = str(request.base_url)
+
+    if not settings.url_report_webhook:
+        return templates.TemplateResponse(
+            request,
+            "error.html",
+            {
+                "error_code": "503",
+                "error_message": "REPORT FORM NOT CONFIGURED",
+                "host_url": host_url,
+            },
+            status_code=503,
+        )
 
     if request.method == "GET":
         return templates.TemplateResponse(
@@ -220,9 +247,9 @@ async def report(
     form = await request.form()
     short_code = form.get("short_code")
     reason = form.get("reason")
-    captcha_token = form.get("h-captcha-response")
+    captcha_token = form.get("h-captcha-response", "")
 
-    if not captcha_token:
+    if settings.hcaptcha_sitekey and not captcha_token:
         return templates.TemplateResponse(
             request,
             "report.html",

--- a/shared/templates.py
+++ b/shared/templates.py
@@ -1,0 +1,29 @@
+"""Shared Jinja2Templates instance for the entire application.
+
+Every module that renders templates should import ``templates`` from here
+instead of creating its own ``Jinja2Templates`` object.  This guarantees
+that Jinja2 environment globals (tracking IDs, feature flags, etc.) are
+available in **all** templates regardless of which route renders them.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi.templating import Jinja2Templates
+
+_TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
+
+templates = Jinja2Templates(directory=_TEMPLATE_DIR)
+
+
+def configure_template_globals(
+    *,
+    clarity_id: str,
+    sentry_client_key: str,
+    hcaptcha_sitekey: str,
+) -> None:
+    """Set Jinja2 globals that are available in every rendered template."""
+    templates.env.globals["clarity_id"] = clarity_id
+    templates.env.globals["sentry_client_key"] = sentry_client_key
+    templates.env.globals["hcaptcha_sitekey"] = hcaptcha_sitekey

--- a/templates/api.html
+++ b/templates/api.html
@@ -44,6 +44,26 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/contacts-modal.css') }}?v=9">
     <link rel="stylesheet" href="{{ url_for('static', path='css/self-promo.css') }}?v=2">
 
+    {% if sentry_client_key or clarity_id %}
+    <script>
+        addEventListener("load", function () {
+            {% if sentry_client_key %}
+            var s = document.createElement("script");
+            s.src = "https://js.sentry-cdn.com/{{ sentry_client_key }}.min.js";
+            s.crossOrigin = "anonymous";
+            document.head.appendChild(s);
+            {% endif %}
+            {% if clarity_id %}
+            (function (c, l, a, r, i, t, y) {
+                c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+                t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+                y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+            })(window, document, "clarity", "script", "{{ clarity_id }}");
+            {% endif %}
+        });
+    </script>
+    {% endif %}
+
 </head>
 
 <body>
@@ -2231,16 +2251,6 @@ print(f"Shortened URL: {short_url}")
     <script src="{{ url_for('static', path='js/contacts-popup.js') }}?v=1" defer=""></script>
     <script src="{{ url_for('static', path='js/header.js') }}?v=6" defer=""></script>
     <script src="{{ url_for('static', path='js/self-promo.js') }}?v=1" defer></script>
-
-    <script>
-        window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/speed-insights/script.js"></script>
-
-    <script>
-        window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/insights/script.js"></script>
 
 </body>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,8 +19,25 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/v2-announcement.css') }}?v=2">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons@latest/iconfont/tabler-icons.min.css">
 
-    <!-- Sentry session replays -->
-    <script src="https://js.sentry-cdn.com/846878c0ca155c98146ef71f12143e3e.min.js" crossorigin="anonymous"></script>
+    {% if sentry_client_key or clarity_id %}
+    <script>
+        addEventListener("load", function () {
+            {% if sentry_client_key %}
+            var s = document.createElement("script");
+            s.src = "https://js.sentry-cdn.com/{{ sentry_client_key }}.min.js";
+            s.crossOrigin = "anonymous";
+            document.head.appendChild(s);
+            {% endif %}
+            {% if clarity_id %}
+            (function (c, l, a, r, i, t, y) {
+                c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+                t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+                y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+            })(window, document, "clarity", "script", "{{ clarity_id }}");
+            {% endif %}
+        });
+    </script>
+    {% endif %}
 
     <!-- Confetti for v2 announcement -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.4/dist/confetti.browser.min.js"></script>
@@ -48,15 +65,6 @@
     <script src="{{ url_for('static', path='js/self-promo.js') }}?v=2" defer></script>
     <script src="{{ url_for('static', path='js/auth.js') }}?v=2" defer></script>
     <script src="{{ url_for('static', path='js/v2-announcement.js') }}?v=3" defer></script>
-
-    <script>
-        window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/speed-insights/script.js"></script>
-    <script>
-        window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/insights/script.js"></script>
 
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -37,7 +37,11 @@
         {% endif %}
         <input type="text" id="email" name="email" placeholder="Email" value="{{ email }}" required>
         <textarea id="message" name="message" placeholder="Message" required>{{ message }}</textarea>
-        <button type="submit" class="h-captcha" data-sitekey="ab2b86e1-0532-4971-87ce-26a0b1ea8712" data-callback="onSubmit"><img alt="hCapcha Logo" src="{{ url_for('static', path='images/hcaptcha.png') }}">Submit</button>
+        {% if hcaptcha_sitekey %}
+        <button type="submit" class="h-captcha" data-sitekey="{{ hcaptcha_sitekey }}" data-callback="onSubmit"><img alt="hCaptcha Logo" src="{{ url_for('static', path='images/hcaptcha.png') }}">Submit</button>
+        {% else %}
+        <button type="submit">Submit</button>
+        {% endif %}
     </form>
     <p id="opts">or connect with us via</p>
     <div class="button-container-upper" style="display: flex; justify-content: center; align-items: center;">
@@ -52,7 +56,9 @@
 {% endblock %}
 
 {% block scripts %}
+    {% if hcaptcha_sitekey %}
     <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+    {% endif %}
     <script>
         function onSubmit(token) {
             if (!validateEmail() || !validateMessage()) { return; }

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -27,8 +27,25 @@
     <link rel="icon" type="image/png" href="{{ url_for('static', path='images/favicon.png') }}">
 
 
-    <!-- Sentry session replays -->
-    <script src="https://js.sentry-cdn.com/846878c0ca155c98146ef71f12143e3e.min.js" crossorigin="anonymous"></script>
+    {% if sentry_client_key or clarity_id %}
+    <script>
+        addEventListener("load", function () {
+            {% if sentry_client_key %}
+            var s = document.createElement("script");
+            s.src = "https://js.sentry-cdn.com/{{ sentry_client_key }}.min.js";
+            s.crossOrigin = "anonymous";
+            document.head.appendChild(s);
+            {% endif %}
+            {% if clarity_id %}
+            (function (c, l, a, r, i, t, y) {
+                c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+                t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+                y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+            })(window, document, "clarity", "script", "{{ clarity_id }}");
+            {% endif %}
+        });
+    </script>
+    {% endif %}
 
     {% block head_css %}{% endblock %}
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,13 +3,6 @@
 {% block title %}spoo.me URL Shortener{% endblock %}
 
 {% block meta %}
-<script type="text/javascript">
-    (function (c, l, a, r, i, t, y) {
-        c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
-        t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
-        y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
-    })(window, document, "clarity", "script", "k9zlm89vrc");
-</script>
 <meta name="description"
     content="spoo.me is a free and easy-to-use URL shortener that lets you create short links for any website. You can even choose your own alias, set a password, and limit the number of clicks.">
 <link rel="canonical" href="https://spoo.me">

--- a/templates/legal/base.html
+++ b/templates/legal/base.html
@@ -18,6 +18,26 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/docs.css') }}?v=3">
     <link rel="stylesheet" href="{{ url_for('static', path='css/header.css') }}?v=6">
     <link rel="stylesheet" href="{{ url_for('static', path='css/mobile-header.css') }}?v=6">
+
+    {% if sentry_client_key or clarity_id %}
+    <script>
+        addEventListener("load", function () {
+            {% if sentry_client_key %}
+            var s = document.createElement("script");
+            s.src = "https://js.sentry-cdn.com/{{ sentry_client_key }}.min.js";
+            s.crossOrigin = "anonymous";
+            document.head.appendChild(s);
+            {% endif %}
+            {% if clarity_id %}
+            (function (c, l, a, r, i, t, y) {
+                c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+                t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+                y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+            })(window, document, "clarity", "script", "{{ clarity_id }}");
+            {% endif %}
+        });
+    </script>
+    {% endif %}
 </head>
 
 <body>
@@ -124,16 +144,6 @@
 
     <script src="{{ url_for('static', path='js/contacts-popup.js') }}?v=1" defer=""></script>
     <script src="{{ url_for('static', path='js/header.js') }}?v=6" defer=""></script>
-
-    <script>
-        window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/speed-insights/script.js"></script>
-
-    <script>
-        window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/insights/script.js"></script>
 
 </body>
 

--- a/templates/legal/privacy-policy.html
+++ b/templates/legal/privacy-policy.html
@@ -145,7 +145,6 @@
     <ul>
         <li><strong>hCaptcha:</strong> Used for spam and abuse prevention. See <a href="https://www.hcaptcha.com/privacy">hCaptcha Privacy Policy</a></li>
         <li><strong>Microsoft Clarity:</strong> Used for analytics and user experience insights. See <a href="https://privacy.microsoft.com/en-us/privacystatement">Microsoft Privacy Policy</a></li>
-        <li><strong>Vercel Analytics:</strong> Used for web analytics. See <a href="https://vercel.com/legal/privacy-policy">Vercel Privacy Policy</a></li>
     </ul>
 
     <p>We do not sell your personal data to third parties.</p>
@@ -303,12 +302,11 @@
         visit, your browser add-ons, and other information that assists us in improving the service. We may collect
         and use this analytics information together with your IP address to infer your approximate location.</p>
 
-    <p>Specifically, we use Microsoft Clarity and Vercel's web analytics feature for insights into our website's
-        usage and user experience. These tools record information about your interaction with our website, such as
+    <p>Specifically, we use Microsoft Clarity for insights into our website's
+        usage and user experience. This tool records information about your interaction with our website, such as
         mouse clicks, mouse movements, scrolling activity, and the text you type into the website, which helps us to
         understand our users' interactions with our website and improve user experience. For more information, you
-        can refer to <a href="https://privacy.microsoft.com/en-us/privacystatement">Microsoft's Privacy Policy</a>
-        and <a href="https://vercel.com/legal/privacy-policy">Vercel's Privacy Policy</a>.</p>
+        can refer to <a href="https://privacy.microsoft.com/en-us/privacystatement">Microsoft's Privacy Policy</a>.</p>
 
     <br>
 

--- a/templates/report.html
+++ b/templates/report.html
@@ -36,12 +36,18 @@
             <input type="text" id="alias" name="short_code" placeholder="short-code" value="{{ short_code }}" required>
         </div>
         <textarea id="message" name="reason" placeholder="Reason for Reporting this Short URL" required>{{ reason }}</textarea>
-        <button type="submit" class="h-captcha" data-sitekey="ab2b86e1-0532-4971-87ce-26a0b1ea8712" data-callback="onSubmit"><img alt="hCaptcha Logo" src="{{ url_for('static', path='images/hcaptcha.png') }}">Report</button>
+        {% if hcaptcha_sitekey %}
+        <button type="submit" class="h-captcha" data-sitekey="{{ hcaptcha_sitekey }}" data-callback="onSubmit"><img alt="hCaptcha Logo" src="{{ url_for('static', path='images/hcaptcha.png') }}">Report</button>
+        {% else %}
+        <button type="submit">Report</button>
+        {% endif %}
     </form>
 {% endblock %}
 
 {% block scripts %}
+    {% if hcaptcha_sitekey %}
     <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+    {% endif %}
     <script>
         function onSubmit(token) {
             if (!validateMessage()) { return; }

--- a/tests/integration/test_contact_report.py
+++ b/tests/integration/test_contact_report.py
@@ -78,7 +78,12 @@ def _build_test_app(
     contact_svc: MagicMock | None = None,
     url_svc: MagicMock | None = None,
 ) -> FastAPI:
-    settings = AppSettings()
+    settings = AppSettings(
+        contact_webhook="https://test.webhook/contact",
+        url_report_webhook="https://test.webhook/report",
+        hcaptcha_sitekey="test-sitekey",
+        hcaptcha_secret="test-secret",
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/tests/integration/test_static_routes.py
+++ b/tests/integration/test_static_routes.py
@@ -51,7 +51,12 @@ def _mock_url_service(alias_available=True):
 
 
 def _build_test_app(contact_svc=None, url_svc=None):
-    settings = AppSettings()
+    settings = AppSettings(
+        contact_webhook="https://test.webhook/contact",
+        url_report_webhook="https://test.webhook/report",
+        hcaptcha_sitekey="test-sitekey",
+        hcaptcha_secret="test-secret",
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/tests/unit/infrastructure/test_captcha.py
+++ b/tests/unit/infrastructure/test_captcha.py
@@ -27,9 +27,9 @@ class TestHCaptchaProvider:
         http.post = AsyncMock(return_value=resp)
         assert await provider.verify("bad-token") is False
 
-    async def test_returns_false_when_secret_empty(self):
+    async def test_skips_verification_when_secret_empty(self):
         provider, _ = self._make(secret="")
-        assert await provider.verify("any-token") is False
+        assert await provider.verify("any-token") is True
 
     async def test_returns_false_on_http_error(self):
         provider, http = self._make()


### PR DESCRIPTION
## Summary by Sourcery

Centralize template configuration and make analytics and hCaptcha integration configurable across the app.

New Features:
- Expose Microsoft Clarity ID, Sentry client key, and hCaptcha site key as configurable settings and Jinja2 template globals.
- Add conditional loading of Sentry and Microsoft Clarity scripts across public, dashboard, API, and legal templates based on configured IDs.
- Make hCaptcha usage on contact and report forms optional with a configurable site key and fallback submit buttons when disabled.

Enhancements:
- Introduce a shared Jinja2Templates instance and helper to configure global template variables, replacing per-route template initializations.
- Refine privacy policy content to reflect the current analytics stack by removing references to Vercel analytics.

Documentation:
- Update privacy policy to describe only Microsoft Clarity as the analytics provider and remove Vercel-related references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analytics and security features now configurable via environment variables: Microsoft Clarity tracking, Sentry error monitoring, and hCaptcha form protection are all optional.

* **Documentation**
  * Updated privacy policy to reflect current analytics service usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->