### PR TITLE
fix: stop exporting passwords in legacy stats

### DIFF
--- a/routes/legacy/stats.py
+++ b/routes/legacy/stats.py
@@ -352,6 +352,8 @@ async def export(
     if url_data.get("unique_counter"):
         url_data = add_missing_dates("unique_counter", url_data)
 
+    url_data.pop("password", None)
+
     if fmt == ExportFormat.JSON:
         return _export_json(url_data)
     elif fmt == ExportFormat.CSV:
@@ -397,7 +399,6 @@ def _export_csv(data: dict) -> Response:
             "SHORT CODE": data.get("_id", "N/A"),
             "MAX CLICKS": data.get("max-clicks", "N/A"),
             "EXPIRATION TIME": data.get("expiration-time", "N/A"),
-            "PASSWORD": data.get("password", "N/A"),
             "CREATION DATE": data.get("creation-date", "N/A"),
             "CREATION TIME": data.get("creation-time", "N/A"),
             "EXPIRED": data.get("expired", "N/A"),
@@ -461,7 +462,6 @@ def _export_xlsx(data: dict) -> Response:
         ["SHORT CODE", data.get("_id")],
         ["MAX CLICKS", data.get("max-clicks")],
         ["EXPIRATION TIME", data.get("expiration-time")],
-        ["PASSWORD", data.get("password")],
         ["CREATION DATE", data.get("creation-date")],
         ["CREATION TIME", data.get("creation-time")],
         ["EXPIRED", data.get("expired")],


### PR DESCRIPTION
Stripped the password from the data dictionary before it hits the export formatters.

Change-Id: I81c68eafdaaa4136607b5037e67bf146b6670e29

## Summary by Sourcery

Bug Fixes:
- Stop including the password field in legacy stats export payloads across all supported formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Password data is no longer included in exported files (CSV and XLSX formats).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->