### PR TITLE
feat: create base email template and refactor existing email template…

### DIFF
--- a/templates/emails/base.html
+++ b/templates/emails/base.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html
+    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+
+<head>
+    <link rel="preload" as="image" href="https://spoo-landing.netlify.app/logo.png" />
+    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-github.png" />
+    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-discord.png" />
+    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-x.png" />
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+</head>
+
+<body
+    style='background-color:rgb(255,255,255);font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";padding-top:40px;padding-bottom:40px'>
+    <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
+        data-skip-in-text="true">
+        {% block preview %}{% endblock %}
+        <div> ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ </div>
+    </div>
+    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+        style="background-color:rgb(26,24,24);border-radius:8px;padding-left:32px;padding-right:32px;padding-top:40px;padding-bottom:40px;margin-left:auto;margin-right:auto;max-width:600px">
+        <tbody>
+            <tr style="width:100%">
+                <td>
+                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                        style="text-align:center;margin-bottom:32px">
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <img alt="spoo.me" src="https://spoo-landing.netlify.app/logo.png"
+                                        style="width:120px;height:auto;margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    {% block content %}{% endblock %}
+                    <hr
+                        style="border-color:rgb(51,51,51);border-style:solid;margin-top:32px;margin-bottom:32px;width:100%;border:none;border-top:1px solid #333333" />
+                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:14px;text-align:center;margin-bottom:0px;margin:0px;line-height:24px;margin-top:0px;margin-left:0px;margin-right:0px">
+                                        Need help? Contact us at <a href="mailto:support@spoo.me"
+                                            style="color:rgb(124,58,237);text-decoration-line:none"
+                                            target="_blank">support@spoo.me</a></p>
+                                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0"
+                                        role="presentation" style="margin-top:16px;margin-bottom:24px">
+                                        <tbody style="width:100%">
+                                            <tr style="width:100%">
+                                                <td align="center">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                        role="presentation" style="display:inline-block">
+                                                        <tbody>
+                                                            <tr>
+                                                                <td style="padding:0 8px">
+                                                                    <a href="https://github.com/spoo-me/spoo"
+                                                                        style="color:#067df7;text-decoration-line:none"
+                                                                        target="_blank"><img alt="GitHub"
+                                                                            src="https://new.email/static/emails/social/social-github.png"
+                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
+                                                                </td>
+                                                                <td style="padding:0 8px">
+                                                                    <a href="https://spoo.me/discord"
+                                                                        style="color:#067df7;text-decoration-line:none"
+                                                                        target="_blank"><img alt="Discord"
+                                                                            src="https://new.email/static/emails/social/social-discord.png"
+                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
+                                                                </td>
+                                                                <td style="padding:0 8px">
+                                                                    <a href="https://x.com/spoo_me"
+                                                                        style="color:#067df7;text-decoration-line:none"
+                                                                        target="_blank"><img alt="X (Twitter)"
+                                                                            src="https://new.email/static/emails/social/social-x.png"
+                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
+                                                                </td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:12px;text-align:center;margin:0px;line-height:24px;margin-top:0px;margin-bottom:0px;margin-left:0px;margin-right:0px">
+                                        © 2025 spoo.me. All rights reserved.</p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -1,43 +1,8 @@
-<!DOCTYPE html
-    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html dir="ltr" lang="en">
+{% extends "base.html" %}
 
-<head>
-    <link rel="preload" as="image" href="https://spoo-landing.netlify.app/logo.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-github.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-discord.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-x.png" />
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-    <meta name="x-apple-disable-message-reformatting" />
-</head>
+{% block preview %}Your spoo.me password reset code: {{ otp_code }}{% endblock %}
 
-<body
-    style='background-color:rgb(255,255,255);font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";padding-top:40px;padding-bottom:40px'>
-    <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
-        data-skip-in-text="true">
-        Your spoo.me password reset code: {{ otp_code }}
-        <div> ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ </div>
-    </div>
-    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
-        style="background-color:rgb(26,24,24);border-radius:8px;padding-left:32px;padding-right:32px;padding-top:40px;padding-bottom:40px;margin-left:auto;margin-right:auto;max-width:600px">
-        <tbody>
-            <tr style="width:100%">
-                <td>
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="text-align:center;margin-bottom:32px">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <img alt="spoo.me" src="https://spoo-landing.netlify.app/logo.png"
-                                        style="width:120px;height:auto;margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none" />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+{% block content %}<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
                         style="margin-bottom:32px">
                         <tbody>
                             <tr>
@@ -103,66 +68,4 @@
                                 </td>
                             </tr>
                         </tbody>
-                    </table>
-                    <hr
-                        style="border-color:rgb(51,51,51);border-style:solid;margin-top:32px;margin-bottom:32px;width:100%;border:none;border-top:1px solid #333333" />
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <p
-                                        style="color:rgb(227,235,242);font-size:14px;text-align:center;margin-bottom:0px;margin:0px;line-height:24px;margin-top:0px;margin-left:0px;margin-right:0px">
-                                        Need help? Contact us at <a href="mailto:support@spoo.me"
-                                            style="color:rgb(124,58,237);text-decoration-line:none"
-                                            target="_blank">support@spoo.me</a></p>
-                                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0"
-                                        role="presentation" style="margin-top:16px;margin-bottom:24px">
-                                        <tbody style="width:100%">
-                                            <tr style="width:100%">
-                                                <td align="center">
-                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                        role="presentation" style="display:inline-block">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://github.com/spoo-me/spoo"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="GitHub"
-                                                                            src="https://new.email/static/emails/social/social-github.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://spoo.me/discord"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="Discord"
-                                                                            src="https://new.email/static/emails/social/social-discord.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://x.com/spoo_me"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="X (Twitter)"
-                                                                            src="https://new.email/static/emails/social/social-x.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <p
-                                        style="color:rgb(227,235,242);font-size:12px;text-align:center;margin:0px;line-height:24px;margin-top:0px;margin-bottom:0px;margin-left:0px;margin-right:0px">
-                                        © 2025 spoo.me. All rights reserved.</p>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</body>
-
-</html>
+                    </table>{% endblock %}

--- a/templates/emails/verification.html
+++ b/templates/emails/verification.html
@@ -1,43 +1,8 @@
-<!DOCTYPE html
-    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html dir="ltr" lang="en">
+{% extends "base.html" %}
 
-<head>
-    <link rel="preload" as="image" href="https://spoo-landing.netlify.app/logo.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-github.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-discord.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-x.png" />
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-    <meta name="x-apple-disable-message-reformatting" />
-</head>
+{% block preview %}Your spoo.me verification code: {{ otp_code }}{% endblock %}
 
-<body
-    style='background-color:rgb(255,255,255);font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";padding-top:40px;padding-bottom:40px'>
-    <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
-        data-skip-in-text="true">
-        Your spoo.me verification code: {{ otp_code }}
-        <div> ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ </div>
-    </div>
-    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
-        style="background-color:rgb(26,24,24);border-radius:8px;padding-left:32px;padding-right:32px;padding-top:40px;padding-bottom:40px;margin-left:auto;margin-right:auto;max-width:600px">
-        <tbody>
-            <tr style="width:100%">
-                <td>
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="text-align:center;margin-bottom:32px">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <img alt="spoo.me" src="https://spoo-landing.netlify.app/logo.png"
-                                        style="width:120px;height:auto;margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none" />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+{% block content %}<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
                         style="margin-bottom:32px">
                         <tbody>
                             <tr>
@@ -102,66 +67,4 @@
                                 </td>
                             </tr>
                         </tbody>
-                    </table>
-                    <hr
-                        style="border-color:rgb(51,51,51);border-style:solid;margin-top:32px;margin-bottom:32px;width:100%;border:none;border-top:1px solid #333333" />
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <p
-                                        style="color:rgb(227,235,242);font-size:14px;text-align:center;margin-bottom:0px;margin:0px;line-height:24px;margin-top:0px;margin-left:0px;margin-right:0px">
-                                        Need help? Contact us at <a href="mailto:support@spoo.me"
-                                            style="color:rgb(124,58,237);text-decoration-line:none"
-                                            target="_blank">support@spoo.me</a></p>
-                                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0"
-                                        role="presentation" style="margin-top:16px;margin-bottom:24px">
-                                        <tbody style="width:100%">
-                                            <tr style="width:100%">
-                                                <td align="center">
-                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                        role="presentation" style="display:inline-block">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://github.com/spoo-me/spoo"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="GitHub"
-                                                                            src="https://new.email/static/emails/social/social-github.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://spoo.me/discord"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="Discord"
-                                                                            src="https://new.email/static/emails/social/social-discord.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://x.com/spoo_me"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="X (Twitter)"
-                                                                            src="https://new.email/static/emails/social/social-x.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <p
-                                        style="color:rgb(227,235,242);font-size:12px;text-align:center;margin:0px;line-height:24px;margin-top:0px;margin-bottom:0px;margin-left:0px;margin-right:0px">
-                                        © 2025 spoo.me. All rights reserved.</p>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</body>
-
-</html>
+                    </table>{% endblock %}

--- a/templates/emails/welcome.html
+++ b/templates/emails/welcome.html
@@ -1,43 +1,8 @@
-<!DOCTYPE html
-    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html dir="ltr" lang="en">
+{% extends "base.html" %}
 
-<head>
-    <link rel="preload" as="image" href="https://spoo-landing.netlify.app/logo.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-github.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-discord.png" />
-    <link rel="preload" as="image" href="https://new.email/static/emails/social/social-x.png" />
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-    <meta name="x-apple-disable-message-reformatting" />
-</head>
+{% block preview %}Welcome to spoo.me - Your URL shortening journey starts here!{% endblock %}
 
-<body
-    style='background-color:rgb(255,255,255);font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";padding-top:40px;padding-bottom:40px'>
-    <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
-        data-skip-in-text="true">
-        Welcome to spoo.me - Your URL shortening journey starts here!
-        <div> ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
-            ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ </div>
-    </div>
-    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
-        style="background-color:rgb(26,24,24);border-radius:8px;padding-left:32px;padding-right:32px;padding-top:40px;padding-bottom:40px;margin-left:auto;margin-right:auto;max-width:600px">
-        <tbody>
-            <tr style="width:100%">
-                <td>
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="text-align:center;margin-bottom:32px">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <img alt="spoo.me" src="https://spoo-landing.netlify.app/logo.png"
-                                        style="width:120px;height:auto;margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none" />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+{% block content %}<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
                         style="margin-bottom:40px">
                         <tbody>
                             <tr>
@@ -207,66 +172,4 @@
                                 </td>
                             </tr>
                         </tbody>
-                    </table>
-                    <hr
-                        style="border-color:rgb(51,51,51);border-style:solid;margin-top:32px;margin-bottom:32px;width:100%;border:none;border-top:1px solid #333333" />
-                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <p
-                                        style="color:rgb(227,235,242);font-size:14px;text-align:center;margin-bottom:0px;margin:0px;line-height:24px;margin-top:0px;margin-left:0px;margin-right:0px">
-                                        Need help? Contact us at <a href="mailto:support@spoo.me"
-                                            style="color:rgb(124,58,237);text-decoration-line:none"
-                                            target="_blank">support@spoo.me</a></p>
-                                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0"
-                                        role="presentation" style="margin-top:16px;margin-bottom:24px">
-                                        <tbody style="width:100%">
-                                            <tr style="width:100%">
-                                                <td align="center">
-                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                        role="presentation" style="display:inline-block">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://github.com/spoo-me/spoo"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="GitHub"
-                                                                            src="https://new.email/static/emails/social/social-github.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://spoo.me/discord"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="Discord"
-                                                                            src="https://new.email/static/emails/social/social-discord.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                                <td style="padding:0 8px">
-                                                                    <a href="https://x.com/spoo_me"
-                                                                        style="color:#067df7;text-decoration-line:none"
-                                                                        target="_blank"><img alt="X (Twitter)"
-                                                                            src="https://new.email/static/emails/social/social-x.png"
-                                                                            style="width:24px;height:24px;display:block;outline:none;border:none;text-decoration:none" /></a>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <p
-                                        style="color:rgb(227,235,242);font-size:12px;text-align:center;margin:0px;line-height:24px;margin-top:0px;margin-bottom:0px;margin-left:0px;margin-right:0px">
-                                        © 2025 spoo.me. All rights reserved.</p>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</body>
-
-</html>
+                    </table>{% endblock %}


### PR DESCRIPTION
…s to extend it

- Added a new `base.html` template for emails, providing a consistent structure and styling.
- Refactored `password_reset.html`, `verification.html`, and `welcome.html` to extend the new base template, simplifying their structure and enhancing maintainability.
- Updated preview blocks in the refactored templates to provide relevant content for each email type.

## Summary by Sourcery

Introduce a shared base email layout and update existing email templates to use it for consistent styling and easier maintenance.

New Features:
- Add a reusable base email HTML template with shared layout, branding, and footer content.

Enhancements:
- Refactor password reset, verification, and welcome email templates to extend the new base template and define only their specific content and preview text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All system-generated emails now feature a unified, standardized template with consistent visual styling, header branding, centralized footer information containing support contact email, and social media links (GitHub, Discord, X), ensuring improved visual consistency and easier access to support resources across all email communications including account verification, password reset, and welcome messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->