### PR TITLE
feat: enhance Raycast integration and redirect URI validation

### DIFF
--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -78,10 +78,18 @@ apps:
   spoo-raycast:
     name: Raycast Extension
     icon: raycast.svg
-    description: Shorten links from Raycast
+    description: Shorten and manage your spoo.me links from Raycast
     verified: true
     status: coming_soon
     type: device_auth
+    redirect_uris:
+      - https://raycast.com/redirect*
+    links:
+      raycast: https://www.raycast.com/spoo-me/spoo
+    permissions:
+      - Access your spoo.me account
+      - Create and manage short URLs
+      - View and export your analytics
 
   spoo-vscode:
     name: VS Code Extension

--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -80,7 +80,7 @@ apps:
     icon: raycast.svg
     description: Shorten and manage your spoo.me links from Raycast
     verified: true
-    status: coming_soon
+    status: live
     type: device_auth
     redirect_uris:
       - https://raycast.com/redirect*

--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -83,7 +83,7 @@ apps:
     status: live
     type: device_auth
     redirect_uris:
-      - https://raycast.com/redirect*
+      - https://raycast.com/redirect?*
     links:
       raycast: https://www.raycast.com/spoo-me/spoo
     permissions:

--- a/routes/auth/device.py
+++ b/routes/auth/device.py
@@ -66,12 +66,29 @@ def _device_error(request: Request, error: str, status_code: int = 400) -> Respo
     )
 
 
+def _redirect_uri_allowed(redirect_uri: str, app: AppEntry) -> bool:
+    """Match a redirect_uri against an app's allowlist.
+
+    Mirrors ``DeviceAuthService.validate_redirect_uri``: exact match, or
+    prefix match for an allowlist entry ending with ``*``.
+    """
+    if not redirect_uri:
+        return False
+    for allowed in app.redirect_uris:
+        if allowed.endswith("*"):
+            if redirect_uri.startswith(allowed[:-1]):
+                return True
+        elif redirect_uri == allowed:
+            return True
+    return False
+
+
 def _build_callback_redirect(
     code: str, state: str, redirect_uri: str, app: AppEntry
 ) -> RedirectResponse:
     """Build the redirect to the callback page or a registered redirect_uri."""
     params = urlencode({"code": code, "state": state})
-    if redirect_uri and redirect_uri in app.redirect_uris:
+    if _redirect_uri_allowed(redirect_uri, app):
         separator = "&" if "?" in redirect_uri else "?"
         return RedirectResponse(f"{redirect_uri}{separator}{params}", status_code=302)
     return RedirectResponse(f"/auth/device/callback?{params}", status_code=302)

--- a/routes/auth/device.py
+++ b/routes/auth/device.py
@@ -66,29 +66,16 @@ def _device_error(request: Request, error: str, status_code: int = 400) -> Respo
     )
 
 
-def _redirect_uri_allowed(redirect_uri: str, app: AppEntry) -> bool:
-    """Match a redirect_uri against an app's allowlist.
-
-    Mirrors ``DeviceAuthService.validate_redirect_uri``: exact match, or
-    prefix match for an allowlist entry ending with ``*``.
-    """
-    if not redirect_uri:
-        return False
-    for allowed in app.redirect_uris:
-        if allowed.endswith("*"):
-            if redirect_uri.startswith(allowed[:-1]):
-                return True
-        elif redirect_uri == allowed:
-            return True
-    return False
-
-
 def _build_callback_redirect(
-    code: str, state: str, redirect_uri: str, app: AppEntry
+    code: str,
+    state: str,
+    redirect_uri: str,
+    app: AppEntry,
+    svc: DeviceAuthSvc,
 ) -> RedirectResponse:
     """Build the redirect to the callback page or a registered redirect_uri."""
     params = urlencode({"code": code, "state": state})
-    if _redirect_uri_allowed(redirect_uri, app):
+    if redirect_uri and svc.validate_redirect_uri(redirect_uri, app):
         separator = "&" if "?" in redirect_uri else "?"
         return RedirectResponse(f"{redirect_uri}{separator}{params}", status_code=302)
     return RedirectResponse(f"/auth/device/callback?{params}", status_code=302)
@@ -139,7 +126,9 @@ async def device_login(
         code = await device_auth_service.create_device_auth_code(
             profile.id, profile.email, app_id=app_id
         )
-        return _build_callback_redirect(code, state, redirect_uri, app)
+        return _build_callback_redirect(
+            code, state, redirect_uri, app, device_auth_service
+        )
 
     # No grant: show consent screen
     csrf_token = generate_secure_token(_CSRF_TOKEN_BYTES)
@@ -210,7 +199,9 @@ async def device_consent_approve(
     )
 
     # Clear CSRF cookie and redirect
-    response = _build_callback_redirect(code, state, redirect_uri, app)
+    response = _build_callback_redirect(
+        code, state, redirect_uri, app, device_auth_service
+    )
     response.delete_cookie(_CSRF_COOKIE_NAME)
     return response
 

--- a/services/auth/device.py
+++ b/services/auth/device.py
@@ -67,8 +67,22 @@ class DeviceAuthService:
         return entry if entry and entry.is_live_device_app() else None
 
     def validate_redirect_uri(self, redirect_uri: str, app: AppEntry) -> bool:
-        """Return True if redirect_uri is empty or in the app's allowlist."""
-        return not redirect_uri or redirect_uri in app.redirect_uris
+        """Return True if redirect_uri is empty, exact-matches an allowlist
+        entry, or prefix-matches an entry ending with ``*``.
+
+        The ``*`` suffix is used for OAuth clients (e.g. Raycast) that append
+        a varying query string to a fixed redirect URL. Only exact or
+        explicit-wildcard entries are accepted; implicit wildcards are not.
+        """
+        if not redirect_uri:
+            return True
+        for allowed in app.redirect_uris:
+            if allowed.endswith("*"):
+                if redirect_uri.startswith(allowed[:-1]):
+                    return True
+            elif redirect_uri == allowed:
+                return True
+        return False
 
     async def create_device_auth_code(
         self, user_id: ObjectId, email: str, app_id: str | None = None

--- a/tests/integration/test_device_auth.py
+++ b/tests/integration/test_device_auth.py
@@ -107,7 +107,13 @@ def device_auth_svc():
     # resolve_app and validate_redirect_uri are sync — must not be coroutines
     svc.resolve_app = MagicMock(side_effect=_resolve_app)
     svc.validate_redirect_uri = MagicMock(
-        side_effect=lambda uri, app: not uri or uri in app.redirect_uris
+        side_effect=lambda uri, app: (
+            not uri
+            or any(
+                uri.startswith(a[:-1]) if a.endswith("*") else uri == a
+                for a in app.redirect_uris
+            )
+        )
     )
     return svc
 

--- a/tests/unit/services/test_redirect_uri.py
+++ b/tests/unit/services/test_redirect_uri.py
@@ -1,0 +1,77 @@
+"""Unit tests for wildcard redirect URI matching."""
+
+from __future__ import annotations
+
+from schemas.models.app import AppEntry
+from services.auth.device import DeviceAuthService
+
+
+def _app(redirect_uris: list[str]) -> AppEntry:
+    return AppEntry(name="test", description="test app", redirect_uris=redirect_uris)
+
+
+class TestValidateRedirectUri:
+    """Tests for DeviceAuthService.validate_redirect_uri."""
+
+    def setup_method(self):
+        self.svc = DeviceAuthService.__new__(DeviceAuthService)
+
+    def test_empty_uri_allowed(self):
+        app = _app(["https://example.com/callback"])
+        assert self.svc.validate_redirect_uri("", app) is True
+
+    def test_exact_match(self):
+        app = _app(["https://example.com/callback"])
+        assert (
+            self.svc.validate_redirect_uri("https://example.com/callback", app) is True
+        )
+
+    def test_exact_no_match(self):
+        app = _app(["https://example.com/callback"])
+        assert self.svc.validate_redirect_uri("https://evil.com/callback", app) is False
+
+    def test_wildcard_query_match(self):
+        app = _app(["https://raycast.com/redirect?*"])
+        assert (
+            self.svc.validate_redirect_uri(
+                "https://raycast.com/redirect?packageName=spoo&state=abc", app
+            )
+            is True
+        )
+
+    def test_wildcard_prefix_only(self):
+        app = _app(["https://raycast.com/redirect?*"])
+        assert (
+            self.svc.validate_redirect_uri("https://raycast.com/redirect?", app) is True
+        )
+
+    def test_wildcard_rejects_different_path(self):
+        app = _app(["https://raycast.com/redirect?*"])
+        assert (
+            self.svc.validate_redirect_uri("https://raycast.com/redirected", app)
+            is False
+        )
+
+    def test_wildcard_rejects_different_host(self):
+        app = _app(["https://raycast.com/redirect?*"])
+        assert (
+            self.svc.validate_redirect_uri("https://evil.com/redirect?foo=bar", app)
+            is False
+        )
+
+    def test_no_uris_rejects(self):
+        app = _app([])
+        assert self.svc.validate_redirect_uri("https://example.com", app) is False
+
+    def test_multiple_uris_mixed(self):
+        app = _app(["https://a.com/cb", "https://b.com/redirect?*"])
+        assert self.svc.validate_redirect_uri("https://a.com/cb", app) is True
+        assert self.svc.validate_redirect_uri("https://b.com/redirect?x=1", app) is True
+        assert self.svc.validate_redirect_uri("https://c.com/cb", app) is False
+
+    def test_bare_star_matches_everything(self):
+        """A bare '*' entry matches any URI — intentional if configured."""
+        app = _app(["*"])
+        assert (
+            self.svc.validate_redirect_uri("https://anything.com/whatever", app) is True
+        )


### PR DESCRIPTION
- Updated Raycast extension description to clarify link management functionality.
- Added redirect URI allowlist validation to ensure secure handling of redirect URIs in device authentication.
- Improved the `validate_redirect_uri` method to support exact and prefix matching for redirect URIs, enhancing security for OAuth clients.

## Summary by Sourcery

Add wildcard-aware redirect URI validation for device auth and update Raycast app configuration.

New Features:
- Support wildcard-style redirect URIs for device-auth apps, allowing exact and prefix matches in the allowlist.
- Configure the Raycast extension app with redirect URIs, Raycast-specific link, and explicit permissions.

Enhancements:
- Align device auth callback redirect handling with the shared redirect URI validation logic.
- Clarify the Raycast extension description to reflect broader link management capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for wildcard-suffix redirect URIs for OAuth, allowing flexible redirect patterns.
  * Raycast app entry updated: improved description, explicit permissions, redirect URIs, and live status.

* **Tests**
  * Added unit and integration tests validating wildcard and exact redirect URI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->