### PR TITLE
feat: production deploy via Hetzner + Cloudflare Tunnel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Extract metadata
         id: meta
@@ -71,7 +71,7 @@ jobs:
           script: |
             set -e
             cd /opt/spoo
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d --remove-orphans
             docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+      - 'docs/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-tag: ${{ steps.meta.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          script: |
+            set -e
+            cd /opt/spoo
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker compose -f docker-compose.prod.yml pull
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+            docker image prune -f
+            docker compose -f docker-compose.prod.yml ps
+
+      - name: Verify health
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          script: |
+            sleep 10
+            for i in 1 2 3 4 5; do
+              if docker exec spoo_app curl -fsS http://localhost:8000/health > /dev/null; then
+                echo "✓ Healthy after $i attempts"
+                exit 0
+              fi
+              echo "Attempt $i failed, retrying..."
+              sleep 5
+            done
+            echo "✗ Health check failed after 5 attempts"
+            docker compose -f /opt/spoo/docker-compose.prod.yml logs --tail=100 app
+            exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -60,6 +63,10 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
@@ -68,10 +75,12 @@ jobs:
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
+          envs: IMAGE_TAG
           script: |
             set -e
             cd /opt/spoo
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            export IMAGE_TAG="${IMAGE_TAG}"
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d --remove-orphans
             docker image prune -f
@@ -88,12 +97,12 @@ jobs:
             sleep 10
             for i in 1 2 3 4 5; do
               if docker exec spoo_app curl -fsS http://localhost:8000/health > /dev/null; then
-                echo "✓ Healthy after $i attempts"
+                echo "Healthy after $i attempts"
                 exit 0
               fi
               echo "Attempt $i failed, retrying..."
               sleep 5
             done
-            echo "✗ Health check failed after 5 attempts"
+            echo "Health check failed after 5 attempts"
             docker compose -f /opt/spoo/docker-compose.prod.yml logs --tail=100 app
             exit 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,18 +1,16 @@
 services:
   app:
-    image: ghcr.io/spoo-me/spoo:latest
+    image: ghcr.io/spoo-me/spoo:${IMAGE_TAG:-latest}
     container_name: spoo_app
     restart: always
     command: >
-      uv run gunicorn main:app
+      uv run uvicorn main:app
+      --host 0.0.0.0
+      --port 8000
       --workers 2
-      --worker-class uvicorn.workers.UvicornWorker
-      --bind 0.0.0.0:8000
-      --access-logfile -
-      --error-logfile -
-      --graceful-timeout 30
-      --timeout 60
-      --keep-alive 5
+      --no-access-log
+      --timeout-keep-alive 5
+      --timeout-graceful-shutdown 30
     env_file:
       - .env.production
     healthcheck:
@@ -21,12 +19,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
-    deploy:
-      resources:
-        limits:
-          memory: 3G
-        reservations:
-          memory: 512M
+    mem_limit: 3g
+    mem_reservation: 512m
     logging:
       driver: json-file
       options:
@@ -37,17 +31,13 @@ services:
     image: cloudflare/cloudflared:latest
     container_name: spoo_tunnel
     restart: always
-    command: tunnel --no-autoupdate --metrics 0.0.0.0:2000 run
+    command: tunnel --no-autoupdate run
     environment:
       - TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
     depends_on:
       app:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q -O- http://localhost:2000/ready | grep -q '\"status\":200' || exit 1"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+    mem_limit: 128m
     logging:
       driver: json-file
       options:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,55 @@
+services:
+  app:
+    image: ghcr.io/spoo-me/spoo:latest
+    container_name: spoo_app
+    restart: always
+    command: >
+      uv run gunicorn main:app
+      --workers 2
+      --worker-class uvicorn.workers.UvicornWorker
+      --bind 0.0.0.0:8000
+      --access-logfile -
+      --error-logfile -
+      --graceful-timeout 30
+      --timeout 60
+      --keep-alive 5
+    env_file:
+      - .env.production
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 3G
+        reservations:
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: spoo_tunnel
+    restart: always
+    command: tunnel --no-autoupdate --metrics 0.0.0.0:2000 run
+    environment:
+      - TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:2000/ready | grep -q '\"status\":200' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.12-slim
 
+# Install curl for healthchecks (10MB) and clean up apt cache
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 


### PR DESCRIPTION
- docker-compose.prod.yml: app + cloudflared (managed Redis external)
- .github/workflows/deploy.yml: build to GHCR, SSH deploy on push to main

## Summary by Sourcery

Set up automated production deployment using Docker images on a remote VPS and a dedicated production Docker Compose stack.

Deployment:
- Introduce a GitHub Actions workflow that builds and pushes Docker images to GHCR and deploys them via SSH to the production VPS on pushes to main or manual trigger.
- Add a production Docker Compose configuration defining the app service and a Cloudflare Tunnel sidecar for external access, including health checks and resource limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated CI/CD pipeline for production deployment triggered on main branch updates.
  * Configured production Docker environment with health monitoring and automatic service restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->