### PR TITLE
fix(deploy): write IMAGE_TAG to .env, use explicit --env-file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,11 +80,15 @@ jobs:
             set -e
             cd /opt/spoo
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            export IMAGE_TAG="${IMAGE_TAG}"
-            docker compose -f docker-compose.prod.yml pull
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+            # write IMAGE_TAG to .env so compose substitution picks it up
+            grep -v '^IMAGE_TAG=' .env > .env.tmp 2>/dev/null || true
+            echo "IMAGE_TAG=${IMAGE_TAG}" >> .env.tmp
+            mv .env.tmp .env
+            chmod 600 .env
+            docker compose --env-file .env -f docker-compose.prod.yml pull
+            docker compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans
             docker image prune -f
-            docker compose -f docker-compose.prod.yml ps
+            docker compose --env-file .env -f docker-compose.prod.yml ps
 
       - name: Verify health
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
Compose was not auto-loading /opt/spoo/.env reliably under the SSH session, so CF_TUNNEL_TOKEN came up empty and IMAGE_TAG fell back to :latest. Persist IMAGE_TAG into .env on each deploy and reference it explicitly via --env-file.

## Summary by Sourcery

Ensure deployment uses an explicitly managed .env file to propagate IMAGE_TAG and other environment variables to Docker Compose.

Build:
- Persist IMAGE_TAG into the remote .env file during deployment so Docker Compose picks it up reliably.
- Invoke Docker Compose commands with an explicit --env-file to avoid relying on implicit .env loading behavior over SSH.