### PR TITLE
feat(infra): replace CF Tunnel with direct origin + Caddy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,11 +90,17 @@ jobs:
             # Wait for app healthy before declaring success — Caddy keeps a
             # connection pool to app:8000 with retries, so users see a brief
             # latency bump (not 502) during the swap.
+            status=""
             for i in 1 2 3 4 5 6 7 8; do
               status=$(docker inspect spoo_app --format '{{.State.Health.Status}}')
               [ "$status" = "healthy" ] && break
               echo "app $status, retry $i"; sleep 3
             done
+            if [ "$status" != "healthy" ]; then
+              echo "::error::app failed to reach healthy after 8 retries (last status: $status)"
+              docker compose --env-file .env -f docker-compose.prod.yml logs --tail=100 app
+              exit 1
+            fi
             docker image prune -f
             docker compose --env-file .env -f docker-compose.prod.yml ps
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,9 +87,14 @@ jobs:
             chmod 600 .env
             docker compose --env-file .env -f docker-compose.prod.yml pull app
             docker compose --env-file .env -f docker-compose.prod.yml up -d --no-deps app
-            # Restart cloudflared so it re-resolves app's IP (even though we now
-            # pin static IPs, this guarantees fresh tunnel state after deploy).
-            docker compose --env-file .env -f docker-compose.prod.yml restart cloudflared
+            # Wait for app healthy before declaring success — Caddy keeps a
+            # connection pool to app:8000 with retries, so users see a brief
+            # latency bump (not 502) during the swap.
+            for i in 1 2 3 4 5 6 7 8; do
+              status=$(docker inspect spoo_app --format '{{.State.Health.Status}}')
+              [ "$status" = "healthy" ] && break
+              echo "app $status, retry $i"; sleep 3
+            done
             docker image prune -f
             docker compose --env-file .env -f docker-compose.prod.yml ps
 

--- a/caddy/.gitignore
+++ b/caddy/.gitignore
@@ -1,0 +1,2 @@
+origin.crt
+origin.key

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -4,11 +4,39 @@
 	# 443 for inbound traffic; CF orange-cloud handles edge TLS for clients.
 	auto_https disable_certs
 
-	# Trust X-Forwarded-* headers from Cloudflare. UFW restricts inbound 443 to
-	# CF IP ranges only, so any request reaching us came from CF.
+	# Trust X-Forwarded-* headers ONLY from Cloudflare. UFW already restricts
+	# inbound 443 to these ranges at the host level — this is defense in
+	# depth so a UFW misconfig can't enable CF-Connecting-IP spoofing.
+	#
+	# CIDR list mirrors https://www.cloudflare.com/ips-v4 and /ips-v6.
+	# infrastructure/ufw-cloudflare.sh refreshes UFW from the same source.
+	# When Cloudflare rotates ranges (rare, ~yearly), update both files.
 	servers {
-		trusted_proxies static 0.0.0.0/0 ::/0
-		client_ip_headers CF-Connecting-IP
+		trusted_proxies static \
+			173.245.48.0/20 \
+			103.21.244.0/22 \
+			103.22.200.0/22 \
+			103.31.4.0/22 \
+			141.101.64.0/18 \
+			108.162.192.0/18 \
+			190.93.240.0/20 \
+			188.114.96.0/20 \
+			197.234.240.0/22 \
+			198.41.128.0/17 \
+			162.158.0.0/15 \
+			104.16.0.0/13 \
+			104.24.0.0/14 \
+			172.64.0.0/13 \
+			131.0.72.0/22 \
+			2400:cb00::/32 \
+			2606:4700::/32 \
+			2803:f800::/32 \
+			2405:b500::/32 \
+			2405:8100::/32 \
+			2a06:98c0::/29 \
+			2c0f:f248::/32
+		trusted_proxies_strict
+		client_ip_headers CF-Connecting-IP X-Forwarded-For
 	}
 
 	# Structured logs to stdout for Vector → Axiom pickup.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,45 @@
+{
+	# Disable Caddy's automatic HTTPS / Let's Encrypt — we use Cloudflare Origin CA
+	# certificate (15-year validity, free from CF dashboard). Caddy only listens on
+	# 443 for inbound traffic; CF orange-cloud handles edge TLS for clients.
+	auto_https disable_certs
+
+	# Trust X-Forwarded-* headers from Cloudflare. UFW restricts inbound 443 to
+	# CF IP ranges only, so any request reaching us came from CF.
+	servers {
+		trusted_proxies static 0.0.0.0/0 ::/0
+		client_ip_headers CF-Connecting-IP
+	}
+
+	# Structured logs to stdout for Vector → Axiom pickup.
+	log default {
+		output stdout
+		format json
+	}
+}
+
+# Shared TLS + headers block reused across all hostnames.
+(common_tls) {
+	tls /etc/caddy/origin.crt /etc/caddy/origin.key {
+		protocols tls1.2 tls1.3
+	}
+	header {
+		-Server
+	}
+}
+
+spoo.me, www.spoo.me {
+	import common_tls
+	reverse_proxy app:8000 {
+		header_up X-Real-IP {client_ip}
+		header_up X-Forwarded-For {client_ip}
+	}
+}
+
+qr.spoo.me {
+	import common_tls
+	reverse_proxy qr:8080 {
+		header_up X-Real-IP {client_ip}
+		header_up X-Forwarded-For {client_ip}
+	}
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,8 +127,13 @@ services:
         condition: service_healthy
       qr:
         condition: service_healthy
+    # Caddy admin API check is the cheapest reliable liveness signal.
+    # An https://localhost/health probe fails on SNI (localhost matches no
+    # host block); an external probe through Cloudflare loops back through
+    # the host network. Admin API on 127.0.0.1:2019 proves the daemon is
+    # accepting config — that's the failure mode we actually want to catch.
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "--no-check-certificate", "https://localhost/health", "--header", "Host: spoo.me"]
+      test: ["CMD", "wget", "-qO-", "--tries=1", "--timeout=3", "http://127.0.0.1:2019/config/"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -100,27 +100,49 @@ services:
         max-size: "5m"
         max-file: "2"
 
-  cloudflared:
-    image: cloudflare/cloudflared:latest
-    container_name: spoo_tunnel
+  caddy:
+    image: caddy:2-alpine
+    container_name: spoo_caddy
     restart: always
-    # http2 is more stable than QUIC across CF backbone for cross-region traffic.
-    # SIN/BOM POPs sometimes fail to route to IAD origin via QUIC.
-    command: tunnel --no-autoupdate --protocol http2 run
-    environment:
-      - TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
+    # Caddy terminates TLS for CF orange-cloud requests using a Cloudflare
+    # Origin CA certificate (mounted from ./caddy/origin.{crt,key}). UFW on
+    # the host (see infrastructure/ufw-cloudflare.sh) restricts inbound 443
+    # to CF IP ranges only — so any request reaching Caddy came from CF.
+    #
+    # Architecturally this replaces cloudflared. CF Tunnel routed all traffic
+    # through IAD POPs which has flaky cross-region backbone for some user
+    # paths (Jio IPv6 → MRS, Berlin POP for Asia traffic). Direct origin uses
+    # CF's standard anycast — no tunnel detour.
+    ports:
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy/origin.crt:/etc/caddy/origin.crt:ro
+      - ./caddy/origin.key:/etc/caddy/origin.key:ro
+      - caddy-data:/data
+      - caddy-config:/config
     depends_on:
       app:
         condition: service_healthy
-    mem_limit: 128m
+      qr:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "--no-check-certificate", "https://localhost/health", "--header", "Host: spoo.me"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    mem_limit: 256m
+    mem_reservation: 64m
     networks:
       spoonet:
         ipv4_address: 172.30.0.20
     logging:
       driver: json-file
       options:
-        max-size: "5m"
-        max-file: "2"
+        max-size: "10m"
+        max-file: "3"
         tag: "{{.Name}}"
 
   redis-exporter:
@@ -170,6 +192,8 @@ services:
 
 volumes:
   redis-data:
+  caddy-data:
+  caddy-config:
 
 networks:
   spoonet:

--- a/infrastructure/ufw-cloudflare.sh
+++ b/infrastructure/ufw-cloudflare.sh
@@ -8,6 +8,10 @@
 #
 # Without this allowlist, any attacker who discovers our origin IP could
 # bypass CF (and bypass orange-cloud DDoS / WAF / rate limit).
+#
+# Order matters: fetch CF ranges and validate BEFORE mutating UFW. A failed
+# fetch mid-run could otherwise leave the host with default-deny and no
+# allow rules — locking 443 entirely.
 
 set -euo pipefail
 
@@ -16,47 +20,61 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
-echo "[ufw-cloudflare] resetting CF allow rules…"
+# ── Step 1: fetch CF IP ranges (read-only, safe to fail) ───────────────
+echo "[ufw-cloudflare] fetching CF IP ranges…"
+v4=$(curl -fsS --connect-timeout 5 --max-time 20 https://www.cloudflare.com/ips-v4)
+v6=$(curl -fsS --connect-timeout 5 --max-time 20 https://www.cloudflare.com/ips-v6)
 
-# Drop existing CF rules (matches comment 'Cloudflare-vN'). UFW lists rules
-# numbered, so we collect their indices and delete from highest to lowest to
-# keep remaining indices stable as we go.
-mapfile -t cf_rule_nums < <(ufw status numbered | awk -F'[][]' '/Cloudflare-v[46]/ { print $2 }' | sort -rn)
-if (( ${#cf_rule_nums[@]} > 0 )); then
-	for n in "${cf_rule_nums[@]}"; do
+if [[ -z "$v4" || -z "$v6" ]]; then
+	echo "[ufw-cloudflare] empty CF IP list — refusing to proceed (UFW unchanged)" >&2
+	exit 2
+fi
+
+# ── Step 2: drop ALL prior 443 allow rules ─────────────────────────────
+# Catches both our own Cloudflare-v[46] tagged rules AND any pre-existing
+# broad rules like `ufw allow 443/tcp` that would let traffic bypass CF.
+# Anything other than CF allow on 443 is a regression we re-establish below.
+echo "[ufw-cloudflare] dropping existing 443 allow rules…"
+mapfile -t rule_nums < <(
+	ufw status numbered \
+		| awk -F'[][]' '/^\[/ {
+			# print rule number for any ALLOW IN line that mentions 443
+			if ($0 ~ /443.*ALLOW IN/) print $2
+		}' \
+		| sort -rn
+)
+if (( ${#rule_nums[@]} > 0 )); then
+	for n in "${rule_nums[@]}"; do
 		[[ -z "$n" ]] && continue
 		ufw --force delete "$n" >/dev/null
 	done
 fi
 
+# ── Step 3: baseline policy ────────────────────────────────────────────
 echo "[ufw-cloudflare] applying baseline rules…"
 ufw default deny incoming >/dev/null
 ufw default allow outgoing >/dev/null
 ufw allow 22/tcp comment 'SSH' >/dev/null
 
-echo "[ufw-cloudflare] fetching CF IP ranges…"
-v4=$(curl -fsS https://www.cloudflare.com/ips-v4)
-v6=$(curl -fsS https://www.cloudflare.com/ips-v6)
-
-if [[ -z "$v4" || -z "$v6" ]]; then
-	echo "[ufw-cloudflare] empty CF IP list — refusing to proceed" >&2
-	exit 2
-fi
-
-echo "[ufw-cloudflare] adding 443 allow rules for CF…"
+# ── Step 4: add CF allow rules ─────────────────────────────────────────
+# TCP for HTTP/2 + HTTP/1.1, UDP for HTTP/3 (QUIC). Compose maps both.
+echo "[ufw-cloudflare] adding 443 allow rules for CF (TCP + UDP)…"
 while IFS= read -r ip; do
 	[[ -z "$ip" ]] && continue
 	ufw allow proto tcp from "$ip" to any port 443 comment 'Cloudflare-v4' >/dev/null
+	ufw allow proto udp from "$ip" to any port 443 comment 'Cloudflare-v4' >/dev/null
 done <<< "$v4"
 
 while IFS= read -r ip; do
 	[[ -z "$ip" ]] && continue
 	ufw allow proto tcp from "$ip" to any port 443 comment 'Cloudflare-v6' >/dev/null
+	ufw allow proto udp from "$ip" to any port 443 comment 'Cloudflare-v6' >/dev/null
 done <<< "$v6"
 
+# ── Step 5: enable + reload ────────────────────────────────────────────
 echo "[ufw-cloudflare] enabling UFW…"
-yes | ufw enable >/dev/null
+ufw --force enable >/dev/null
 ufw reload >/dev/null
 
 echo "[ufw-cloudflare] done. Rules:"
-ufw status | head -50
+ufw status | head -60

--- a/infrastructure/ufw-cloudflare.sh
+++ b/infrastructure/ufw-cloudflare.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Restrict inbound 443 to Cloudflare IP ranges only.
+# Run on VPS as root. Idempotent — safe to re-run from cron.
+#
+# CF publishes its IP ranges at:
+#   https://www.cloudflare.com/ips-v4
+#   https://www.cloudflare.com/ips-v6
+#
+# Without this allowlist, any attacker who discovers our origin IP could
+# bypass CF (and bypass orange-cloud DDoS / WAF / rate limit).
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+	echo "must run as root" >&2
+	exit 1
+fi
+
+echo "[ufw-cloudflare] resetting CF allow rules…"
+
+# Drop existing CF rules (matches comment 'Cloudflare-vN'). UFW lists rules
+# numbered, so we collect their indices and delete from highest to lowest to
+# keep remaining indices stable as we go.
+mapfile -t cf_rule_nums < <(ufw status numbered | awk -F'[][]' '/Cloudflare-v[46]/ { print $2 }' | sort -rn)
+if (( ${#cf_rule_nums[@]} > 0 )); then
+	for n in "${cf_rule_nums[@]}"; do
+		[[ -z "$n" ]] && continue
+		ufw --force delete "$n" >/dev/null
+	done
+fi
+
+echo "[ufw-cloudflare] applying baseline rules…"
+ufw default deny incoming >/dev/null
+ufw default allow outgoing >/dev/null
+ufw allow 22/tcp comment 'SSH' >/dev/null
+
+echo "[ufw-cloudflare] fetching CF IP ranges…"
+v4=$(curl -fsS https://www.cloudflare.com/ips-v4)
+v6=$(curl -fsS https://www.cloudflare.com/ips-v6)
+
+if [[ -z "$v4" || -z "$v6" ]]; then
+	echo "[ufw-cloudflare] empty CF IP list — refusing to proceed" >&2
+	exit 2
+fi
+
+echo "[ufw-cloudflare] adding 443 allow rules for CF…"
+while IFS= read -r ip; do
+	[[ -z "$ip" ]] && continue
+	ufw allow proto tcp from "$ip" to any port 443 comment 'Cloudflare-v4' >/dev/null
+done <<< "$v4"
+
+while IFS= read -r ip; do
+	[[ -z "$ip" ]] && continue
+	ufw allow proto tcp from "$ip" to any port 443 comment 'Cloudflare-v6' >/dev/null
+done <<< "$v6"
+
+echo "[ufw-cloudflare] enabling UFW…"
+yes | ufw enable >/dev/null
+ufw reload >/dev/null
+
+echo "[ufw-cloudflare] done. Rules:"
+ufw status | head -50

--- a/vector.toml
+++ b/vector.toml
@@ -7,7 +7,7 @@
 
 [sources.docker]
 type = "docker_logs"
-include_containers = ["spoo_app", "spoo_tunnel", "spoo_qr"]
+include_containers = ["spoo_app", "spoo_qr", "spoo_caddy"]
 exclude_containers = ["spoo_vector", "spoo_redis_exporter"]
 
 [transforms.parse_and_clean]

--- a/vector.toml
+++ b/vector.toml
@@ -18,7 +18,7 @@ inputs = ["docker"]
 source = '''
 .service = .container_name
 
-if .container_name == "spoo_app" || .container_name == "spoo_qr" {
+if .container_name == "spoo_app" || .container_name == "spoo_qr" || .container_name == "spoo_caddy" {
     parsed = parse_json(.message) ?? null
     if parsed != null && is_object(parsed) {
         . = merge(., object!(parsed))


### PR DESCRIPTION
## Summary by Sourcery

Replace Cloudflare Tunnel with a direct Cloudflare-origin TLS setup using Caddy and tighten origin exposure controls.

New Features:
- Introduce a Caddy-based HTTPS reverse proxy to terminate Cloudflare-origin TLS and front the app service.
- Add a UFW helper script to restrict inbound port 443 access to Cloudflare IP ranges only.

Enhancements:
- Update production docker-compose to run Caddy with health checks, dedicated volumes, and tuned logging limits.
- Adjust deployment workflow to wait for the app container to become healthy after redeploy instead of restarting a tunnel service.
- Include the Caddy container in Vector log collection and define dedicated Docker volumes for Caddy data and config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Move TLS termination to a local reverse-proxy service.
  * Replace tunnel service in compose and update logging to include the proxy.
  * Enforce automated firewall rules allowing only Cloudflare IPs to port 443.
  * Deploy workflow now waits for the app container to report healthy before finishing.
  * Update log collection to include the new proxy service and exclude the removed tunnel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->