### PR TITLE
Feat: Feature rollout system

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,13 @@ class RedisSettings(BaseSettings):
     redis_uri: str | None = None
     redis_ttl_seconds: int = 3600
 
+    # Feature flag cache TTLs. Positive results cached for `feature_flag_ttl_seconds`
+    # so flag flips propagate within that window. Negative results (unregistered
+    # flag names) cached for a shorter window so newly-registered flags become
+    # visible faster than the positive TTL.
+    feature_flag_ttl_seconds: int = 60
+    feature_flag_negative_ttl_seconds: int = 30
+
 
 class JWTSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/dependencies/services.py
+++ b/dependencies/services.py
@@ -25,6 +25,7 @@ from services.auth.verification import EmailVerificationService
 from services.click import ClickService
 from services.contact_service import ContactService
 from services.export.service import ExportService
+from services.feature_flag_service import FeatureFlagService
 from services.oauth_service import OAuthService
 from services.profile_picture_service import ProfilePictureService
 from services.stats_service import StatsService
@@ -99,6 +100,10 @@ def get_app_grant_repo(request: Request) -> AppGrantRepository:
     return request.app.state.app_grant_repo
 
 
+def get_feature_flag_service(request: Request) -> FeatureFlagService:
+    return request.app.state.feature_flag_service
+
+
 # ── Annotated type aliases — Depends shortcuts for route signatures ──────────
 
 UrlSvc = Annotated[UrlService, Depends(get_url_service)]
@@ -117,3 +122,4 @@ ProfilePictureSvc = Annotated[
 ContactSvc = Annotated[ContactService, Depends(get_contact_service)]
 ClickSvc = Annotated[ClickService, Depends(get_click_service)]
 AppGrantRepo = Annotated[AppGrantRepository, Depends(get_app_grant_repo)]
+FeatureFlagSvc = Annotated[FeatureFlagService, Depends(get_feature_flag_service)]

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from config import AppSettings
+from infrastructure.cache.feature_flag_cache import FeatureFlagCache
 from infrastructure.cache.url_cache import UrlCache
 from infrastructure.captcha.hcaptcha import HCaptchaProvider
 from infrastructure.webhook.discord import DiscordWebhookProvider
@@ -19,6 +20,7 @@ from repositories.api_key_repository import ApiKeyRepository
 from repositories.app_grant_repository import AppGrantRepository
 from repositories.blocked_url_repository import BlockedUrlRepository
 from repositories.click_repository import ClickRepository
+from repositories.feature_flag_repository import FeatureFlagRepository
 from repositories.legacy.emoji_url_repository import EmojiUrlRepository
 from repositories.legacy.legacy_url_repository import LegacyUrlRepository
 from repositories.token_repository import TokenRepository
@@ -34,6 +36,7 @@ from services.click import ClickService, LegacyClickHandler, V2ClickHandler
 from services.contact_service import ContactService
 from services.export.formatters import default_formatters
 from services.export.service import ExportService
+from services.feature_flag_service import FeatureFlagService
 from services.oauth_service import OAuthService
 from services.profile_picture_service import ProfilePictureService
 from services.stats_service import StatsService
@@ -60,9 +63,11 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     api_key_repo = ApiKeyRepository(db["api-keys"])
     blocked_url_repo = BlockedUrlRepository(db["blocked-urls"])
     app_grant_repo = AppGrantRepository(db["app-grants"])
+    feature_flag_repo = FeatureFlagRepository(db["feature_flags"])
 
     # ── Infrastructure ───────────────────────────────────────────────────
     url_cache = UrlCache(redis_client, ttl_seconds=settings.redis.redis_ttl_seconds)
+    feature_flag_cache = FeatureFlagCache(redis_client)
     captcha = HCaptchaProvider(settings.hcaptcha_secret, http_client)
     contact_webhook = DiscordWebhookProvider(settings.contact_webhook, http_client)
     report_webhook = DiscordWebhookProvider(settings.url_report_webhook, http_client)
@@ -143,3 +148,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     app.state.click_service = ClickService({"v2": v2_handler, "v1": v1_handler})
 
     app.state.app_grant_repo = app_grant_repo
+
+    app.state.feature_flag_service = FeatureFlagService(
+        feature_flag_repo, feature_flag_cache
+    )

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -67,7 +67,11 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
 
     # ── Infrastructure ───────────────────────────────────────────────────
     url_cache = UrlCache(redis_client, ttl_seconds=settings.redis.redis_ttl_seconds)
-    feature_flag_cache = FeatureFlagCache(redis_client)
+    feature_flag_cache = FeatureFlagCache(
+        redis_client,
+        ttl_seconds=settings.redis.feature_flag_ttl_seconds,
+        negative_ttl_seconds=settings.redis.feature_flag_negative_ttl_seconds,
+    )
     captcha = HCaptchaProvider(settings.hcaptcha_secret, http_client)
     contact_webhook = DiscordWebhookProvider(settings.contact_webhook, http_client)
     report_webhook = DiscordWebhookProvider(settings.url_report_webhook, http_client)

--- a/infrastructure/cache/feature_flag_cache.py
+++ b/infrastructure/cache/feature_flag_cache.py
@@ -1,0 +1,110 @@
+"""Redis-backed read-through cache for feature flag documents.
+
+Stores ``FeatureFlagDoc`` as JSON. Negative cache (sentinel string ``MISS``)
+prevents repo hammering for unregistered flag names. Cache invalidation is
+purely TTL-based — flags mutate via direct mongosh edits (no app event to
+trigger active invalidation), so flips propagate within ``ttl_seconds``.
+
+Mirrors ``infrastructure/cache/url_cache.UrlCache`` shape: tolerates
+``redis_client is None`` so the app runs without Redis (self-hosters,
+local dev) by always missing through to the repo.
+"""
+
+from __future__ import annotations
+
+import redis.asyncio as aioredis
+
+from infrastructure.logging import get_logger
+from schemas.models.feature_flag import FeatureFlagDoc
+
+log = get_logger(__name__)
+
+_NEGATIVE_SENTINEL = "MISS"
+
+
+class FeatureFlagCache:
+    def __init__(
+        self,
+        redis_client: aioredis.Redis | None,
+        ttl_seconds: int = 60,
+        negative_ttl_seconds: int = 30,
+    ) -> None:
+        self._redis = redis_client
+        self.ttl_seconds = ttl_seconds
+        self.negative_ttl_seconds = negative_ttl_seconds
+
+    def _key(self, name: str) -> str:
+        return f"flag:{name}"
+
+    async def get(self, name: str) -> FeatureFlagDoc | NegativeMiss | None:
+        """Return cached doc, ``NEGATIVE_MISS`` if cached negative, or ``None`` on real miss.
+
+        Distinguishing "cached miss" from "uncached" lets the service skip
+        the repo round-trip for known-absent flags.
+        """
+        if self._redis is None:
+            return None
+        try:
+            raw = await self._redis.get(self._key(name))
+        except Exception as e:
+            log.warning("feature_flag_cache_get_error", name=name, error=str(e))
+            return None
+        if raw is None:
+            return None
+        if raw == _NEGATIVE_SENTINEL or raw == _NEGATIVE_SENTINEL.encode():
+            return NEGATIVE_MISS
+        # Pydantic model_validate_json parses bytes/str transparently.
+        try:
+            return FeatureFlagDoc.model_validate_json(raw)
+        except Exception as e:
+            log.warning("feature_flag_cache_decode_error", name=name, error=str(e))
+            return None
+
+    async def set(self, name: str, doc: FeatureFlagDoc) -> None:
+        if self._redis is None:
+            return
+        try:
+            await self._redis.setex(
+                self._key(name),
+                self.ttl_seconds,
+                doc.model_dump_json(by_alias=True),
+            )
+        except Exception as e:
+            log.error("feature_flag_cache_set_error", name=name, error=str(e))
+
+    async def set_negative(self, name: str) -> None:
+        """Cache a negative result (no doc found) with a shorter TTL."""
+        if self._redis is None:
+            return
+        try:
+            await self._redis.setex(
+                self._key(name),
+                self.negative_ttl_seconds,
+                _NEGATIVE_SENTINEL,
+            )
+        except Exception as e:
+            log.error("feature_flag_cache_set_negative_error", name=name, error=str(e))
+
+    async def invalidate(self, name: str) -> None:
+        """Drop a flag from cache. Used by admin scripts after manual edits.
+
+        Not called from the request path — flips rely on TTL expiry.
+        """
+        if self._redis is None:
+            return
+        try:
+            await self._redis.delete(self._key(name))
+        except Exception as e:
+            log.error("feature_flag_cache_invalidate_error", name=name, error=str(e))
+
+
+class NegativeMiss:
+    """Sentinel type for "cache says this flag does not exist".
+
+    Distinct from ``None`` (real cache miss / no Redis). Service compares
+    via ``is NEGATIVE_MISS`` to decide whether to skip the repo lookup.
+    """
+
+
+# Module-level singleton — `is` comparison decides "cached miss".
+NEGATIVE_MISS = NegativeMiss()

--- a/repositories/feature_flag_repository.py
+++ b/repositories/feature_flag_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository for the `feature_flags` MongoDB collection.
+
+Read-mostly. Mutations are rare and happen via direct mongosh edits during
+rollouts (PR0 ships without an admin API). The ``upsert`` and ``list_all``
+methods exist to support tests, internal scripts, and the lifespan-time
+``ensure_feature_flag`` helper that registers known flags on boot.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from repositories.base import BaseRepository
+from schemas.models.feature_flag import FeatureFlagDoc
+
+
+class FeatureFlagRepository(BaseRepository[FeatureFlagDoc]):
+    async def find_by_name(self, name: str) -> FeatureFlagDoc | None:
+        """Return the flag doc by name, or None if not registered."""
+        return await self._find_one({"name": name})
+
+    async def upsert(self, name: str, fields: dict) -> ObjectId:
+        """Insert or update a flag doc by name. Returns the doc's _id.
+
+        Uses ``$setOnInsert`` for ``created_at`` so re-running the upsert
+        does not overwrite the original creation timestamp. ``updated_at``
+        is always refreshed.
+        """
+        now = datetime.now(timezone.utc)
+        set_fields = {**fields, "updated_at": now}
+        result = await self._col.update_one(
+            {"name": name},
+            {
+                "$set": set_fields,
+                "$setOnInsert": {"created_at": now, "name": name},
+            },
+            upsert=True,
+        )
+        if result.upserted_id is not None:
+            return result.upserted_id
+        # Existing doc — fetch its _id for the return contract.
+        doc = await self._find_one_raw({"name": name}, {"_id": 1})
+        if doc is None:  # pragma: no cover — race only possible if doc deleted mid-call
+            raise RuntimeError(
+                f"feature flag {name!r} vanished between upsert and read"
+            )
+        return doc["_id"]
+
+    async def list_all(self) -> list[FeatureFlagDoc]:
+        """Return all registered flags. Used by admin scripts + tests."""
+        cursor = self._col.find({})
+        docs = await cursor.to_list(length=None)
+        return [
+            FeatureFlagDoc.from_mongo(d)  # type: ignore[misc]
+            for d in docs
+        ]

--- a/repositories/feature_flag_repository.py
+++ b/repositories/feature_flag_repository.py
@@ -2,9 +2,9 @@
 Repository for the `feature_flags` MongoDB collection.
 
 Read-mostly. Mutations are rare and happen via direct mongosh edits during
-rollouts (PR0 ships without an admin API). The ``upsert`` and ``list_all``
-methods exist to support tests, internal scripts, and the lifespan-time
-``ensure_feature_flag`` helper that registers known flags on boot.
+rollouts (PR0 ships without an admin API). ``upsert`` and ``list_all``
+exist for tests and any future bootstrap script that wants to register
+known flags programmatically.
 """
 
 from __future__ import annotations
@@ -23,14 +23,14 @@ class FeatureFlagRepository(BaseRepository[FeatureFlagDoc]):
         return await self._find_one({"name": name})
 
     async def upsert(self, name: str, fields: dict) -> ObjectId:
-        """Insert or update a flag doc by name. Returns the doc's _id.
-
-        Uses ``$setOnInsert`` for ``created_at`` so re-running the upsert
-        does not overwrite the original creation timestamp. ``updated_at``
-        is always refreshed.
-        """
+        """Insert or update a flag doc by name. Returns the doc's _id."""
         now = datetime.now(timezone.utc)
-        set_fields = {**fields, "updated_at": now}
+        # Strip keys that live in $setOnInsert — same key in both $set and
+        # $setOnInsert raises a path-conflict error on MongoDB >= 4.4.
+        set_fields = {
+            k: v for k, v in fields.items() if k not in ("name", "created_at")
+        }
+        set_fields["updated_at"] = now
         result = await self._col.update_one(
             {"name": name},
             {

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -93,4 +93,8 @@ async def ensure_indexes(db: AsyncDatabase) -> None:
     await app_grants_col.create_index([("user_id", 1), ("revoked_at", 1)])
     await app_grants_col.create_index([("app_id", 1), ("revoked_at", 1)])
 
+    # ── feature-flags ──────────────────────────────────────────────────
+    feature_flags_col = db["feature_flags"]
+    await feature_flags_col.create_index([("name", 1)], unique=True)
+
     log.info("mongodb_indexes_ensured")

--- a/schemas/enums/rollout_type.py
+++ b/schemas/enums/rollout_type.py
@@ -1,0 +1,27 @@
+"""
+Feature flag rollout strategies.
+
+Each rollout type defines how `FeatureFlagService.is_enabled` decides whether
+a given user sees a flag. Strategies are mutually exclusive; a flag picks
+exactly one ``RolloutType`` and configures the corresponding fields on
+``FeatureFlagDoc``.
+
+OFF acts as a kill switch independent of the doc-level ``enabled`` boolean —
+useful when you want to keep the flag registered but force a False result
+without rewriting the rest of the doc.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RolloutType(str, Enum):
+    """How a feature flag decides which users are inside the rollout."""
+
+    OFF = "off"
+    EVERYONE = "everyone"
+    ALLOWLIST = "allowlist"
+    PERCENTAGE = "percentage"
+    HEX_DIGIT = "hex_digit"
+    TIER = "tier"

--- a/schemas/models/feature_flag.py
+++ b/schemas/models/feature_flag.py
@@ -1,0 +1,100 @@
+"""
+Feature flag document model.
+
+Maps to the `feature_flags` MongoDB collection. One document per registered
+flag. The document IS the rollout state — there is no admin API; engineers
+edit Mongo directly via mongosh and the running app picks up changes within
+the cache TTL window (~60s).
+
+The `enabled` boolean is a coarse on/off; `rollout_type` decides the audience
+when enabled. ``RolloutType.OFF`` is a separate kill-switch independent of
+``enabled`` so a flag can be paused without rewriting its other fields.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from bson import ObjectId
+from pydantic import Field, field_validator
+
+from schemas.enums.rollout_type import RolloutType
+from schemas.models.base import MongoBaseModel, PyObjectId
+
+
+class FeatureFlagDoc(MongoBaseModel):
+    """Document model for the `feature_flags` collection."""
+
+    name: str
+    enabled: bool = False
+    rollout_type: RolloutType = RolloutType.OFF
+
+    # ALLOWLIST fields — match either user_id or lowercased email.
+    allowlist_user_ids: list[PyObjectId] = Field(default_factory=list)
+    allowlist_emails: list[str] = Field(default_factory=list)
+
+    # PERCENTAGE field — 0-100 inclusive. Stable hash determines bucket.
+    percentage: int = 0
+
+    # HEX_DIGIT field — list of single hex chars (0-f). Each digit ≈ 6.25% of
+    # users. Stable hash places each user in exactly one bucket per flag.
+    enabled_digits: list[str] = Field(default_factory=list)
+
+    # TIER field — defensive lookup via ``getattr(user, "tier", None)``.
+    # Null when not in TIER mode.
+    tier: str | None = None
+
+    # Free-form note for the engineer editing Mongo. Not surfaced to users.
+    description: str = ""
+
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _name_non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("flag name must not be empty")
+        return v
+
+    @field_validator("percentage")
+    @classmethod
+    def _percentage_in_range(cls, v: int) -> int:
+        if not 0 <= v <= 100:
+            raise ValueError(f"percentage must be 0-100, got {v}")
+        return v
+
+    @field_validator("enabled_digits")
+    @classmethod
+    def _digits_are_single_hex(cls, v: list[str]) -> list[str]:
+        if len(v) > 16:
+            raise ValueError(f"enabled_digits has at most 16 entries, got {len(v)}")
+        normalised: list[str] = []
+        for d in v:
+            if not isinstance(d, str) or len(d) != 1 or d not in "0123456789abcdef":
+                raise ValueError(
+                    f"enabled_digits must be single lowercase hex chars 0-f, got {d!r}"
+                )
+            normalised.append(d)
+        # De-duplicate while preserving order — the digits list is the rollout
+        # state; duplicates would mislead the human reading Mongo.
+        seen: set[str] = set()
+        deduped = [d for d in normalised if not (d in seen or seen.add(d))]
+        return deduped
+
+    @field_validator("allowlist_emails")
+    @classmethod
+    def _normalise_emails(cls, v: list[str]) -> list[str]:
+        # Lowercase for case-insensitive comparison in is_enabled.
+        return [e.strip().lower() for e in v if e.strip()]
+
+    def is_user_in_allowlist(self, user_id: ObjectId, email: str | None) -> bool:
+        """Return True when the user matches by id or normalised email.
+
+        Kept on the model so the service layer doesn't reach into the doc's
+        internal field shape.
+        """
+        if user_id in self.allowlist_user_ids:
+            return True
+        return bool(email and email.lower() in self.allowlist_emails)

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -1,0 +1,154 @@
+"""
+Feature flag service.
+
+Public API is one method: ``is_enabled(name, user) -> bool``. Default-deny
+on every error path:
+
+  - Doc missing                     → False (forces explicit registration)
+  - Doc.enabled = False             → False
+  - rollout_type = OFF              → False (kill switch)
+  - user is None on a non-EVERYONE  → False
+  - Cache + repo failure            → False (with logged error)
+
+The service consults a read-through Redis cache (60s positive TTL, 30s
+negative TTL). Flag mutations happen via direct mongosh edits with no app
+event, so changes propagate within the cache TTL window. This is acceptable
+for non-emergency rollouts; admin scripts can call ``cache.invalidate(name)``
+for an immediate flush after a hot edit.
+
+Stable hashing uses ``blake2b(salt=name + user_id)`` so the same user gets
+different positions in different flags' rollouts, enabling independent
+percentage and hex-digit gates per feature.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from bson import ObjectId
+
+from infrastructure.cache.feature_flag_cache import (
+    NEGATIVE_MISS,
+    FeatureFlagCache,
+)
+from infrastructure.logging import get_logger
+from repositories.feature_flag_repository import FeatureFlagRepository
+from schemas.enums.rollout_type import RolloutType
+from schemas.models.feature_flag import FeatureFlagDoc
+
+if TYPE_CHECKING:
+    # CurrentUser lives in dependencies.auth which imports back through
+    # dependencies/__init__.py — avoid the circular import by importing the
+    # type only for type-checking. ``__future__ annotations`` makes the
+    # runtime annotation a string so the import is never resolved at runtime.
+    from dependencies.auth import CurrentUser
+
+log = get_logger(__name__)
+
+
+def _stable_hash(user_id: ObjectId, salt: str) -> int:
+    """Return 0-99 deterministically per ``(user_id, salt)``.
+
+    Used by ``RolloutType.PERCENTAGE``. The salt is the flag name so the same
+    user has independent positions across different flags' rollouts.
+    """
+    h = hashlib.blake2b(f"{salt}:{user_id}".encode(), digest_size=4).digest()
+    return int.from_bytes(h, "big") % 100
+
+
+def _digit_bucket(user_id: ObjectId, salt: str) -> str:
+    """Return a single hex digit (0-f) deterministically per ``(user_id, salt)``.
+
+    Used by ``RolloutType.HEX_DIGIT``. 16 buckets, each ≈6.25% of users.
+    """
+    h = hashlib.blake2b(f"{salt}:{user_id}".encode(), digest_size=1).hexdigest()
+    return h[0]
+
+
+class FeatureFlagService:
+    def __init__(
+        self,
+        repo: FeatureFlagRepository,
+        cache: FeatureFlagCache,
+    ) -> None:
+        self._repo = repo
+        self._cache = cache
+
+    async def is_enabled(self, name: str, user: CurrentUser | None) -> bool:
+        """Return whether ``name`` is enabled for ``user``.
+
+        Default-deny on any error or unregistered flag.
+        """
+        flag = await self._lookup(name)
+        if flag is None or not flag.enabled:
+            return False
+
+        rollout = flag.rollout_type
+
+        if rollout == RolloutType.OFF:
+            return False
+        if rollout == RolloutType.EVERYONE:
+            return True
+
+        # All non-EVERYONE rollouts require an authenticated user — anonymous
+        # callers get default-deny.
+        if user is None:
+            return False
+
+        if rollout == RolloutType.ALLOWLIST:
+            return flag.is_user_in_allowlist(user.user_id, _email_of(user))
+
+        if rollout == RolloutType.PERCENTAGE:
+            return _stable_hash(user.user_id, salt=flag.name) < flag.percentage
+
+        if rollout == RolloutType.HEX_DIGIT:
+            return _digit_bucket(user.user_id, salt=flag.name) in flag.enabled_digits
+
+        if rollout == RolloutType.TIER:
+            # Defensive — ``CurrentUser`` doesn't carry ``tier`` today. When a
+            # tier system ships and adds the field this branch starts working
+            # without code changes here.
+            return getattr(user, "tier", None) == flag.tier
+
+        # Unknown rollout type from a future client writing to Mongo before
+        # this service is upgraded. Default-deny is the safe answer.
+        log.warning("feature_flag_unknown_rollout", name=name, rollout=str(rollout))
+        return False
+
+    async def _lookup(self, name: str) -> FeatureFlagDoc | None:
+        """Fetch a flag through cache → repo, returning None for unregistered."""
+        try:
+            cached = await self._cache.get(name)
+        except Exception as e:
+            log.warning("feature_flag_cache_lookup_error", name=name, error=str(e))
+            cached = None
+
+        if cached is NEGATIVE_MISS:
+            return None
+        if isinstance(cached, FeatureFlagDoc):
+            return cached
+
+        try:
+            doc = await self._repo.find_by_name(name)
+        except Exception as e:
+            log.error("feature_flag_repo_lookup_error", name=name, error=str(e))
+            return None
+
+        if doc is None:
+            await self._cache.set_negative(name)
+            return None
+        await self._cache.set(name, doc)
+        return doc
+
+
+def _email_of(user: CurrentUser) -> str | None:
+    """Best-effort email extraction.
+
+    ``CurrentUser`` has ``user_id`` always but email is not on the dataclass
+    today. When auth resolves a JWT or API key the user's email lives on the
+    underlying ``UserDoc`` and isn't propagated here. For now allowlist by
+    email is best-effort: if the email field is added later, this picks it
+    up via ``getattr`` without code changes.
+    """
+    return getattr(user, "email", None)

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -106,13 +106,14 @@ class FeatureFlagService:
             return _digit_bucket(user.user_id, salt=flag.name) in flag.enabled_digits
 
         if rollout == RolloutType.TIER:
-            # Defensive — ``CurrentUser`` doesn't carry ``tier`` today. When a
-            # tier system ships and adds the field this branch starts working
-            # without code changes here.
+            # Default-deny when flag.tier is unset — None == None would
+            # otherwise enable for every user with no tier attribute.
+            if flag.tier is None:
+                return False
             return getattr(user, "tier", None) == flag.tier
 
-        # Unknown rollout type from a future client writing to Mongo before
-        # this service is upgraded. Default-deny is the safe answer.
+        # Unreachable today — Pydantic validates rollout_type against the
+        # RolloutType enum. Kept as default-deny if the field is ever widened.
         log.warning("feature_flag_unknown_rollout", name=name, rollout=str(rollout))
         return False
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -61,6 +61,7 @@ def _build_smoke_app() -> FastAPI:
         app.state.profile_picture_service = AsyncMock()
         app.state.contact_service = AsyncMock()
         app.state.click_service = AsyncMock()
+        app.state.feature_flag_service = AsyncMock()
         yield
 
     app = FastAPI(

--- a/tests/unit/infrastructure/test_feature_flag_cache.py
+++ b/tests/unit/infrastructure/test_feature_flag_cache.py
@@ -1,0 +1,168 @@
+"""Unit tests for FeatureFlagCache.
+
+Mirrors the shape of ``test_cache.py::TestUrlCache``: hit/miss/no-redis
+tolerance, plus the negative-sentinel and JSON-decode-error paths that are
+specific to this cache.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+from infrastructure.cache.feature_flag_cache import (
+    NEGATIVE_MISS,
+    FeatureFlagCache,
+    NegativeMiss,
+)
+from schemas.enums.rollout_type import RolloutType
+from schemas.models.feature_flag import FeatureFlagDoc
+
+from .conftest import _fake_redis
+
+
+def _flag(**overrides) -> FeatureFlagDoc:
+    base = {
+        "name": "test_flag",
+        "enabled": True,
+        "rollout_type": RolloutType.EVERYONE,
+        "allowlist_user_ids": [],
+        "allowlist_emails": [],
+        "percentage": 0,
+        "enabled_digits": [],
+        "tier": None,
+        "description": "",
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return FeatureFlagDoc.model_validate(base)
+
+
+class TestFeatureFlagCacheGet:
+    async def test_get_returns_none_when_redis_none(self):
+        cache = FeatureFlagCache(redis_client=None)
+        assert await cache.get("any") is None
+
+    async def test_get_returns_doc_on_hit(self):
+        flag = _flag()
+        r = _fake_redis(get_returns=flag.model_dump_json(by_alias=True))
+        cache = FeatureFlagCache(r)
+        result = await cache.get("test_flag")
+        assert isinstance(result, FeatureFlagDoc)
+        assert result.name == "test_flag"
+        assert result.enabled is True
+
+    async def test_get_returns_none_on_miss(self):
+        r = _fake_redis(get_returns=None)
+        cache = FeatureFlagCache(r)
+        assert await cache.get("missing") is None
+
+    async def test_get_returns_negative_miss_on_str_sentinel(self):
+        # Service set_negative writes the sentinel as a string. Confirm the
+        # cache decodes it back into the singleton ``NEGATIVE_MISS``.
+        r = _fake_redis(get_returns="MISS")
+        cache = FeatureFlagCache(r)
+        result = await cache.get("missing")
+        assert result is NEGATIVE_MISS
+        assert isinstance(result, NegativeMiss)
+
+    async def test_get_returns_negative_miss_on_bytes_sentinel(self):
+        # Redis client may return bytes when decode_responses=False.
+        r = _fake_redis(get_returns=b"MISS")
+        cache = FeatureFlagCache(r)
+        result = await cache.get("missing")
+        assert result is NEGATIVE_MISS
+
+    async def test_get_returns_none_on_decode_error(self):
+        # Corrupted cache entry — must not raise; service falls through to repo.
+        r = _fake_redis(get_returns='{"this is": not_valid_json"')
+        cache = FeatureFlagCache(r)
+        assert await cache.get("test_flag") is None
+
+    async def test_get_swallows_redis_error(self):
+        r = AsyncMock()
+        r.get.side_effect = ConnectionError("redis down")
+        cache = FeatureFlagCache(r)
+        # Swallows the exception — service falls through to repo.
+        assert await cache.get("test_flag") is None
+
+
+class TestFeatureFlagCacheSet:
+    async def test_set_calls_setex_with_ttl(self):
+        r = _fake_redis()
+        cache = FeatureFlagCache(r, ttl_seconds=42)
+        await cache.set("test_flag", _flag())
+        r.setex.assert_called_once()
+        call_args = r.setex.call_args[0]
+        assert call_args[0] == "flag:test_flag"
+        assert call_args[1] == 42
+
+    async def test_set_stores_json_serialisable_doc(self):
+        import json
+
+        r = _fake_redis()
+        cache = FeatureFlagCache(r)
+        await cache.set("test_flag", _flag(percentage=42))
+        _, _, payload = r.setex.call_args[0]
+        parsed = json.loads(payload)
+        assert parsed["name"] == "test_flag"
+        assert parsed["percentage"] == 42
+
+    async def test_set_noop_when_redis_none(self):
+        cache = FeatureFlagCache(redis_client=None)
+        await cache.set("test_flag", _flag())  # must not raise
+
+    async def test_set_swallows_redis_error(self):
+        r = AsyncMock()
+        r.setex.side_effect = ConnectionError("redis down")
+        cache = FeatureFlagCache(r)
+        # Swallows — caller doesn't need to retry.
+        await cache.set("test_flag", _flag())
+
+
+class TestFeatureFlagCacheSetNegative:
+    async def test_set_negative_calls_setex_with_negative_ttl(self):
+        r = _fake_redis()
+        cache = FeatureFlagCache(r, negative_ttl_seconds=15)
+        await cache.set_negative("missing")
+        r.setex.assert_called_once()
+        call_args = r.setex.call_args[0]
+        assert call_args[0] == "flag:missing"
+        assert call_args[1] == 15
+        assert call_args[2] == "MISS"
+
+    async def test_set_negative_noop_when_redis_none(self):
+        cache = FeatureFlagCache(redis_client=None)
+        await cache.set_negative("missing")  # must not raise
+
+    async def test_set_negative_swallows_redis_error(self):
+        r = AsyncMock()
+        r.setex.side_effect = ConnectionError("redis down")
+        cache = FeatureFlagCache(r)
+        await cache.set_negative("missing")
+
+
+class TestFeatureFlagCacheInvalidate:
+    async def test_invalidate_deletes_key(self):
+        r = _fake_redis()
+        cache = FeatureFlagCache(r)
+        await cache.invalidate("test_flag")
+        r.delete.assert_called_once_with("flag:test_flag")
+
+    async def test_invalidate_noop_when_redis_none(self):
+        cache = FeatureFlagCache(redis_client=None)
+        await cache.invalidate("test_flag")  # must not raise
+
+    async def test_invalidate_swallows_redis_error(self):
+        r = AsyncMock()
+        r.delete.side_effect = ConnectionError("redis down")
+        cache = FeatureFlagCache(r)
+        await cache.invalidate("test_flag")
+
+
+class TestFeatureFlagCacheKeyPrefix:
+    """Keys must use the ``flag:`` prefix so they don't collide with
+    ``url_cache:`` or any other Redis namespace in the same instance."""
+
+    def test_key_prefix(self):
+        cache = FeatureFlagCache(redis_client=None)
+        assert cache._key("custom_domains") == "flag:custom_domains"

--- a/tests/unit/repositories/test_feature_flag_repository.py
+++ b/tests/unit/repositories/test_feature_flag_repository.py
@@ -1,0 +1,89 @@
+"""Unit tests for FeatureFlagRepository."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+
+from .conftest import make_collection
+
+FLAG_OID = ObjectId("eeeeeeeeeeeeeeeeeeeeeeee")
+
+
+def _flag_doc(name: str = "custom_domains") -> dict:
+    return {
+        "_id": FLAG_OID,
+        "name": name,
+        "enabled": True,
+        "rollout_type": "allowlist",
+        "allowlist_user_ids": [],
+        "allowlist_emails": ["zingzy@spoo.me"],
+        "percentage": 0,
+        "enabled_digits": [],
+        "tier": None,
+        "description": "test",
+        "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+    }
+
+
+class TestFeatureFlagRepository:
+    def _repo(self, col=None):
+        from repositories.feature_flag_repository import FeatureFlagRepository
+
+        return FeatureFlagRepository(col or make_collection())
+
+    @pytest.mark.asyncio
+    async def test_find_by_name_returns_model(self):
+        col = make_collection()
+        col.find_one = AsyncMock(return_value=_flag_doc())
+        result = await self._repo(col).find_by_name("custom_domains")
+        col.find_one.assert_awaited_once_with({"name": "custom_domains"})
+        assert result is not None
+        assert result.name == "custom_domains"
+        assert result.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_find_by_name_returns_none_on_miss(self):
+        col = make_collection()
+        col.find_one = AsyncMock(return_value=None)
+        result = await self._repo(col).find_by_name("missing")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_inserts_when_missing(self):
+        col = make_collection()
+        result_mock = MagicMock(upserted_id=FLAG_OID)
+        col.update_one = AsyncMock(return_value=result_mock)
+        oid = await self._repo(col).upsert("new_flag", {"enabled": True})
+        col.update_one.assert_awaited_once()
+        assert oid == FLAG_OID
+
+    @pytest.mark.asyncio
+    async def test_upsert_returns_existing_id_when_no_insert(self):
+        col = make_collection()
+        # update_one matched but did not insert
+        col.update_one = AsyncMock(return_value=MagicMock(upserted_id=None))
+        col.find_one = AsyncMock(return_value={"_id": FLAG_OID})
+        oid = await self._repo(col).upsert("existing", {"enabled": True})
+        assert oid == FLAG_OID
+
+    @pytest.mark.asyncio
+    async def test_list_all_returns_models(self):
+        col = make_collection()
+        col.find.return_value.to_list = AsyncMock(
+            return_value=[_flag_doc("a"), _flag_doc("b")]
+        )
+        result = await self._repo(col).list_all()
+        assert len(result) == 2
+        assert {r.name for r in result} == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_list_all_empty(self):
+        col = make_collection()
+        col.find.return_value.to_list = AsyncMock(return_value=[])
+        result = await self._repo(col).list_all()
+        assert result == []

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -22,6 +22,7 @@ class TestEnsureIndexes:
         tokens_col = AsyncMock()
 
         app_grants_col = AsyncMock()
+        feature_flags_col = AsyncMock()
 
         db.__getitem__ = lambda self, name: {
             "users": users_col,
@@ -30,6 +31,7 @@ class TestEnsureIndexes:
             "api-keys": api_keys_col,
             "verification-tokens": tokens_col,
             "app-grants": app_grants_col,
+            "feature_flags": feature_flags_col,
         }[name]
 
         # create_collection raises CollectionInvalid when collection already exists
@@ -58,6 +60,7 @@ class TestEnsureIndexes:
             [("user_id", 1), ("revoked_at", 1)]
         )
         app_grants_col.create_index.assert_any_await([("app_id", 1), ("revoked_at", 1)])
+        feature_flags_col.create_index.assert_any_await([("name", 1)], unique=True)
 
     @pytest.mark.asyncio
     async def test_ensure_indexes_creates_timeseries_collection(self):

--- a/tests/unit/services/test_feature_flag_service.py
+++ b/tests/unit/services/test_feature_flag_service.py
@@ -259,6 +259,16 @@ class TestRolloutTier:
         service, _, _ = make_service(flag=flag)
         assert await service.is_enabled("test_flag", _user(tier="free")) is False
 
+    @pytest.mark.asyncio
+    async def test_unset_flag_tier_blocks_all(self):
+        # If the flag has rollout_type=TIER but tier=None, the gate must
+        # default-deny rather than match ``user.tier is None == flag.tier is None``.
+        flag = _flag(rollout_type=RolloutType.TIER, tier=None)
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user()) is False
+        assert await service.is_enabled("test_flag", _user(tier="pro")) is False
+        assert await service.is_enabled("test_flag", _user(tier="free")) is False
+
 
 # ── Caching behaviour ────────────────────────────────────────────────────────
 

--- a/tests/unit/services/test_feature_flag_service.py
+++ b/tests/unit/services/test_feature_flag_service.py
@@ -1,0 +1,331 @@
+"""Unit tests for FeatureFlagService — rollout strategies + caching + default-deny."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from bson import ObjectId
+
+from infrastructure.cache.feature_flag_cache import NEGATIVE_MISS
+from schemas.enums.rollout_type import RolloutType
+from schemas.models.feature_flag import FeatureFlagDoc
+from services.feature_flag_service import (
+    FeatureFlagService,
+    _digit_bucket,
+    _stable_hash,
+)
+
+USER_A = ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")
+USER_B = ObjectId("bbbbbbbbbbbbbbbbbbbbbbbb")
+USER_C = ObjectId("cccccccccccccccccccccccc")
+
+
+def _flag(**overrides) -> FeatureFlagDoc:
+    base = {
+        "name": "test_flag",
+        "enabled": True,
+        "rollout_type": RolloutType.OFF,
+        "allowlist_user_ids": [],
+        "allowlist_emails": [],
+        "percentage": 0,
+        "enabled_digits": [],
+        "tier": None,
+        "description": "",
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return FeatureFlagDoc.model_validate(base)
+
+
+def _user(
+    user_id: ObjectId = USER_A, email: str | None = None, tier: str | None = None
+):
+    """Build a stub CurrentUser-shaped object via SimpleNamespace.
+
+    The real ``CurrentUser`` carries ``user_id`` always; ``email`` and ``tier``
+    are accessed defensively via ``getattr``.
+    """
+    from types import SimpleNamespace
+
+    attrs = {
+        "user_id": user_id,
+        "email_verified": True,
+        "amr": "pwd",
+        "api_key_doc": None,
+    }
+    if email is not None:
+        attrs["email"] = email
+    if tier is not None:
+        attrs["tier"] = tier
+    return SimpleNamespace(**attrs)
+
+
+def make_service(flag: FeatureFlagDoc | None = None, cache_returns=None):
+    """Build a FeatureFlagService with mocked repo + cache.
+
+    By default the cache misses (returns ``None``) and the repo returns
+    ``flag``. Override with ``cache_returns`` to test cache hits.
+    """
+    repo = AsyncMock()
+    repo.find_by_name = AsyncMock(return_value=flag)
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=cache_returns)
+    cache.set = AsyncMock()
+    cache.set_negative = AsyncMock()
+    return FeatureFlagService(repo, cache), repo, cache
+
+
+# ── Default-deny paths ───────────────────────────────────────────────────────
+
+
+class TestDefaultDeny:
+    @pytest.mark.asyncio
+    async def test_unregistered_flag_returns_false(self):
+        service, _repo, cache = make_service(flag=None)
+        assert await service.is_enabled("missing", _user()) is False
+        cache.set_negative.assert_awaited_once_with("missing")
+
+    @pytest.mark.asyncio
+    async def test_disabled_flag_returns_false(self):
+        flag = _flag(enabled=False, rollout_type=RolloutType.EVERYONE)
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user()) is False
+
+    @pytest.mark.asyncio
+    async def test_off_rollout_returns_false_even_if_enabled(self):
+        flag = _flag(enabled=True, rollout_type=RolloutType.OFF)
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user()) is False
+
+    @pytest.mark.asyncio
+    async def test_anonymous_user_blocked_for_non_everyone(self):
+        flag = _flag(rollout_type=RolloutType.PERCENTAGE, percentage=100)
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", None) is False
+
+    @pytest.mark.asyncio
+    async def test_repo_error_returns_false(self):
+        repo = AsyncMock()
+        repo.find_by_name = AsyncMock(side_effect=RuntimeError("db down"))
+        cache = AsyncMock()
+        cache.get = AsyncMock(return_value=None)
+        service = FeatureFlagService(repo, cache)
+        assert await service.is_enabled("test_flag", _user()) is False
+
+
+# ── EVERYONE ─────────────────────────────────────────────────────────────────
+
+
+class TestRolloutEveryone:
+    @pytest.mark.asyncio
+    async def test_authenticated_user_allowed(self):
+        flag = _flag(rollout_type=RolloutType.EVERYONE)
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user()) is True
+
+    @pytest.mark.asyncio
+    async def test_anonymous_user_allowed(self):
+        flag = _flag(rollout_type=RolloutType.EVERYONE)
+        service, _, _ = make_service(flag=flag)
+        # EVERYONE bypasses the anonymous-user gate.
+        assert await service.is_enabled("test_flag", None) is True
+
+
+# ── ALLOWLIST ────────────────────────────────────────────────────────────────
+
+
+class TestRolloutAllowlist:
+    @pytest.mark.asyncio
+    async def test_user_id_match(self):
+        flag = _flag(rollout_type=RolloutType.ALLOWLIST, allowlist_user_ids=[USER_A])
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user(USER_A)) is True
+        assert await service.is_enabled("test_flag", _user(USER_B)) is False
+
+    @pytest.mark.asyncio
+    async def test_email_match_case_insensitive(self):
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_emails=["alice@example.com"],
+        )
+        service, _, _ = make_service(flag=flag)
+        assert (
+            await service.is_enabled("test_flag", _user(email="ALICE@example.com"))
+            is True
+        )
+        assert (
+            await service.is_enabled("test_flag", _user(email="bob@example.com"))
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_email_attribute_falls_back_to_user_id(self):
+        # CurrentUser today doesn't carry email — service must not crash.
+        flag = _flag(rollout_type=RolloutType.ALLOWLIST, allowlist_user_ids=[USER_A])
+        service, _, _ = make_service(flag=flag)
+        # _user() with no email omits the attribute; getattr returns None.
+        assert await service.is_enabled("test_flag", _user(USER_A)) is True
+
+
+# ── PERCENTAGE ───────────────────────────────────────────────────────────────
+
+
+class TestRolloutPercentage:
+    @pytest.mark.asyncio
+    async def test_zero_percent_blocks_all(self):
+        flag = _flag(rollout_type=RolloutType.PERCENTAGE, percentage=0)
+        service, _, _ = make_service(flag=flag)
+        for u in (USER_A, USER_B, USER_C):
+            assert await service.is_enabled("test_flag", _user(u)) is False
+
+    @pytest.mark.asyncio
+    async def test_hundred_percent_allows_all(self):
+        flag = _flag(rollout_type=RolloutType.PERCENTAGE, percentage=100)
+        service, _, _ = make_service(flag=flag)
+        for u in (USER_A, USER_B, USER_C):
+            assert await service.is_enabled("test_flag", _user(u)) is True
+
+    @pytest.mark.asyncio
+    async def test_stable_for_same_user(self):
+        # Same user + same flag name = same answer across calls.
+        flag = _flag(rollout_type=RolloutType.PERCENTAGE, percentage=50)
+        service, _, _ = make_service(flag=flag)
+        first = await service.is_enabled("test_flag", _user(USER_A))
+        second = await service.is_enabled("test_flag", _user(USER_A))
+        assert first == second
+
+
+# ── HEX_DIGIT ────────────────────────────────────────────────────────────────
+
+
+class TestRolloutHexDigit:
+    @pytest.mark.asyncio
+    async def test_empty_digits_blocks_all(self):
+        flag = _flag(rollout_type=RolloutType.HEX_DIGIT, enabled_digits=[])
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user(USER_A)) is False
+
+    @pytest.mark.asyncio
+    async def test_full_set_allows_all(self):
+        flag = _flag(
+            rollout_type=RolloutType.HEX_DIGIT,
+            enabled_digits=list("0123456789abcdef"),
+        )
+        service, _, _ = make_service(flag=flag)
+        for u in (USER_A, USER_B, USER_C):
+            assert await service.is_enabled("test_flag", _user(u)) is True
+
+    @pytest.mark.asyncio
+    async def test_user_in_their_bucket_allowed(self):
+        # Compute the actual bucket and confirm the gate respects it.
+        bucket = _digit_bucket(USER_A, salt="test_flag")
+        flag = _flag(rollout_type=RolloutType.HEX_DIGIT, enabled_digits=[bucket])
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user(USER_A)) is True
+
+    @pytest.mark.asyncio
+    async def test_user_outside_their_bucket_blocked(self):
+        bucket = _digit_bucket(USER_A, salt="test_flag")
+        # Pick a digit guaranteed not to match.
+        other = "f" if bucket != "f" else "0"
+        flag = _flag(rollout_type=RolloutType.HEX_DIGIT, enabled_digits=[other])
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user(USER_A)) is False
+
+
+# ── TIER ─────────────────────────────────────────────────────────────────────
+
+
+class TestRolloutTier:
+    @pytest.mark.asyncio
+    async def test_user_without_tier_attr_blocked(self):
+        flag = _flag(rollout_type=RolloutType.TIER, tier="pro")
+        service, _, _ = make_service(flag=flag)
+        # _user() without tier kwarg omits the attribute.
+        assert await service.is_enabled("test_flag", _user()) is False
+
+    @pytest.mark.asyncio
+    async def test_user_with_matching_tier_allowed(self):
+        flag = _flag(rollout_type=RolloutType.TIER, tier="pro")
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user(tier="pro")) is True
+
+    @pytest.mark.asyncio
+    async def test_user_with_wrong_tier_blocked(self):
+        flag = _flag(rollout_type=RolloutType.TIER, tier="pro")
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled("test_flag", _user(tier="free")) is False
+
+
+# ── Caching behaviour ────────────────────────────────────────────────────────
+
+
+class TestCaching:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_repo(self):
+        flag = _flag(rollout_type=RolloutType.EVERYONE)
+        service, repo, _ = make_service(flag=None, cache_returns=flag)
+        result = await service.is_enabled("test_flag", _user())
+        assert result is True
+        repo.find_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_hit_skips_repo(self):
+        service, repo, _ = make_service(flag=None, cache_returns=NEGATIVE_MISS)
+        result = await service.is_enabled("missing", _user())
+        assert result is False
+        repo.find_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_repo_hit_populates_cache(self):
+        flag = _flag(rollout_type=RolloutType.EVERYONE)
+        service, _, cache = make_service(flag=flag)
+        await service.is_enabled("test_flag", _user())
+        cache.set.assert_awaited_once()
+        # First positional arg is the flag name.
+        assert cache.set.call_args.args[0] == "test_flag"
+
+    @pytest.mark.asyncio
+    async def test_repo_miss_populates_negative_cache(self):
+        service, _, cache = make_service(flag=None)
+        await service.is_enabled("missing", _user())
+        cache.set_negative.assert_awaited_once_with("missing")
+
+
+# ── Stable hashing ───────────────────────────────────────────────────────────
+
+
+class TestStableHash:
+    def test_stable_hash_deterministic(self):
+        # Same input must yield same output 1000x.
+        baseline = _stable_hash(USER_A, "custom_domains")
+        for _ in range(1000):
+            assert _stable_hash(USER_A, "custom_domains") == baseline
+
+    def test_stable_hash_different_per_salt(self):
+        # Same user, different flag names = different positions.
+        # Statistical: at least one of these must differ.
+        salts = [f"flag_{i}" for i in range(20)]
+        positions = {_stable_hash(USER_A, s) for s in salts}
+        assert len(positions) > 1, "salt is not influencing the hash"
+
+    def test_stable_hash_in_range(self):
+        for u in (USER_A, USER_B, USER_C):
+            for salt in ("a", "b", "c"):
+                v = _stable_hash(u, salt)
+                assert 0 <= v < 100
+
+    def test_digit_bucket_is_single_hex_char(self):
+        for u in (USER_A, USER_B, USER_C):
+            for salt in ("a", "b", "c"):
+                d = _digit_bucket(u, salt)
+                assert len(d) == 1
+                assert d in "0123456789abcdef"
+
+    def test_digit_bucket_deterministic(self):
+        baseline = _digit_bucket(USER_A, "custom_domains")
+        for _ in range(1000):
+            assert _digit_bucket(USER_A, "custom_domains") == baseline


### PR DESCRIPTION
## Summary by Sourcery

Introduce a feature flag system with configurable rollout strategies and caching, wired into the application as a first-class service.

New Features:
- Add FeatureFlagService to evaluate feature flags for users using strategies including OFF, EVERYONE, ALLOWLIST, PERCENTAGE, HEX_DIGIT, and TIER.
- Add a Redis-backed FeatureFlagCache to store feature flag documents with positive and negative caching and TTL-based invalidation.
- Define FeatureFlagDoc schema and RolloutType enum to model feature flag configuration and rollout behavior in MongoDB.
- Add FeatureFlagRepository for querying and upserting feature flag documents and listing all registered flags.

Enhancements:
- Wire the feature flag service and cache into the FastAPI application state and dependency injection layer for use in routes and services.
- Create a unique MongoDB index on feature flag name to enforce one document per flag.

Tests:
- Add unit tests for the feature flag service covering rollout logic, caching behavior, and hashing determinism.
- Add unit tests for the feature flag repository behavior, including find, upsert, and list operations.
- Extend existing index and smoke tests to cover the new feature_flags collection and feature flag service wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a feature-flag system with multiple rollout strategies (off, everyone, allowlist, percentage, hex-digit, tier), robust input validation, and a Redis-backed read-through cache for faster evaluations.
* **Chores**
  * Added unique index on feature-flag names and new caching TTL configuration options.
* **Tests**
  * Added comprehensive unit and smoke tests covering repository, caching, service logic, and rollout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->