### PR TITLE
feat: Implement Cloudflare Worker for custom domain traffic routing

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -37,10 +37,8 @@
  2c0f:f248::/32
 		trusted_proxies_strict
 		client_ip_headers CF-Connecting-IP X-Forwarded-For
-		# CF SaaS sends SNI=proxy-fallback.spoo.me but Host=customer-hostname.
-		# Caddy auto-enables strict SNI/Host matching when client_auth is set,
-		# which would reject every CF SaaS request. mTLS (AOP) already proves
-		# the request is from CF, so SNI/Host mismatch is safe to allow.
+		# Disable Caddy's auto strict SNI/Host match (triggered by
+		# client_auth) — mTLS is the real auth, SNI/Host mismatch is fine.
 		strict_sni_host insecure_off
 	}
 
@@ -81,11 +79,9 @@ qr.spoo.me {
 	}
 }
 
-# CF for SaaS catch-all. Site address is `:443` (not a hostname) because
-# CF preserves the customer's Host header — a hostname-addressed block
-# would 404. mTLS is mandatory: without it any client reaching our IP
-# could spoof "I'm Cloudflare".
-:443 {
+# CF SaaS fallback origin. CF polls this to keep the origin Active
+# (prereq for Custom Hostname registrations). mTLS via AOP required.
+proxy-fallback.spoo.me {
 	tls /etc/caddy/origin.crt /etc/caddy/origin.key {
 		protocols tls1.2 tls1.3
 		client_auth {
@@ -101,4 +97,24 @@ qr.spoo.me {
 		header_up X-Real-IP {client_ip}
 		header_up X-Forwarded-For {client_ip}
 	}
+}
+
+# CF Worker → origin hop for custom domains (see cloudflare-worker/).
+# Plain HTTP because Workers can't attach AOP. Shared secret gates auth;
+# Host gets rewritten from X-Forwarded-Host so the app builds absolute
+# URLs against the customer hostname.
+:80 {
+	log
+	header {
+		-Server
+	}
+	@authed header X-Worker-Auth {env.WORKER_AUTH_SECRET}
+	handle @authed {
+		reverse_proxy app:8000 {
+			header_up X-Real-IP {client_ip}
+			header_up X-Forwarded-For {client_ip}
+			header_up Host {http.request.header.X-Forwarded-Host}
+		}
+	}
+	respond 403
 }

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -37,6 +37,11 @@
  2c0f:f248::/32
 		trusted_proxies_strict
 		client_ip_headers CF-Connecting-IP X-Forwarded-For
+		# CF SaaS sends SNI=proxy-fallback.spoo.me but Host=customer-hostname.
+		# Caddy auto-enables strict SNI/Host matching when client_auth is set,
+		# which would reject every CF SaaS request. mTLS (AOP) already proves
+		# the request is from CF, so SNI/Host mismatch is safe to allow.
+		strict_sni_host insecure_off
 	}
 
 	# Structured logs to stdout for Vector → Axiom pickup.

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -1,0 +1,98 @@
+# spoo.me Custom Domain Dispatcher Worker
+
+CF Worker that fronts CF SaaS Custom Hostname traffic and proxies it to
+our fallback origin. Required because CF SaaS + fallback origin alone
+doesn't dispatch arbitrary customer-hostname traffic on the Free plan —
+a Worker route bound to the dispatch endpoint is what actually engages
+SaaS routing.
+
+## Why
+
+Without this Worker, CF SaaS registrations succeed (cert issued, hostname
+status active) but real traffic returns 520 with `sliver=none` because
+CF has no Worker route catching the dispatched request.
+
+With this Worker bound to `customers.spoo.me/*`:
+
+```
+customer browser
+    ↓ DNS resolves customer hostname via CF SaaS
+CF edge (TLS terminated with SaaS cert)
+    ↓ dispatched per Custom Hostname's custom_origin_server = customers.spoo.me
+Worker route catches customers.spoo.me/*
+    ↓ this Worker fetches proxy-fallback.spoo.me with X-Forwarded-Host preserved
+CF anycast → Caddy on Hetzner (zone-level Authenticated Origin Pulls)
+    ↓ Caddy validates AOP client cert → reverse_proxy app:8000
+spoo app
+```
+
+## One-time deploy
+
+### 1. Install wrangler
+
+```bash
+npm i -g wrangler
+```
+
+### 2. Authenticate
+
+Either interactively:
+
+```bash
+wrangler login
+```
+
+Or export an API token with `Account → Workers Scripts → Edit` and
+`Zone → Workers Routes → Edit` for the spoo.me zone:
+
+```bash
+export CLOUDFLARE_API_TOKEN=<token>
+export CLOUDFLARE_ACCOUNT_ID=<account-id>   # from CF dashboard
+```
+
+### 3. Deploy
+
+```bash
+./deploy.sh
+```
+
+This uploads `worker.js` and binds it to `customers.spoo.me/*` on the
+spoo.me zone (per `wrangler.toml`).
+
+### 4. Confirm route in CF dashboard
+
+`spoo.me zone → Workers Routes` — verify:
+- Pattern: `customers.spoo.me/*`
+- Worker: `spoo-custom-domains-dispatcher`
+
+## Verification
+
+Once a customer Custom Hostname is registered (via the spoo app's API)
+and DNS propagates:
+
+```bash
+curl -sI https://<customer-hostname>/
+```
+
+Expect a non-520 response (whatever the spoo.me app returns for the
+hostname's request). Trace:
+
+```bash
+curl -s https://<customer-hostname>/cdn-cgi/trace | grep sliver
+```
+
+`sliver=` should now show a value other than `none` (typically `010-tier1`
+or similar) — confirms the Worker engaged.
+
+## Updating
+
+Edit `worker.js`, re-run `./deploy.sh`. CF rolls the new code to the
+edge in seconds.
+
+## Removal
+
+```bash
+wrangler delete
+```
+
+Then remove the route from the CF dashboard.

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -1,93 +1,145 @@
 # spoo.me Custom Domain Dispatcher Worker
 
-CF Worker that fronts CF SaaS Custom Hostname traffic and proxies it to
-our fallback origin. Required because CF SaaS + fallback origin alone
-doesn't dispatch arbitrary customer-hostname traffic on the Free plan —
-a Worker route bound to the dispatch endpoint is what actually engages
-SaaS routing.
+CF Worker that catches CF SaaS Custom Hostname traffic and proxies it
+to our Caddy origin. Required because CF SaaS + fallback origin alone
+doesn't dispatch arbitrary customer-hostname traffic on the Free plan.
 
-## Why
-
-Without this Worker, CF SaaS registrations succeed (cert issued, hostname
-status active) but real traffic returns 520 with `sliver=none` because
-CF has no Worker route catching the dispatched request.
-
-With this Worker bound to `customers.spoo.me/*`:
+## Flow
 
 ```
-customer browser
-    ↓ DNS resolves customer hostname via CF SaaS
-CF edge (TLS terminated with SaaS cert)
-    ↓ dispatched per Custom Hostname's custom_origin_server = customers.spoo.me
-Worker route catches customers.spoo.me/*
-    ↓ this Worker fetches proxy-fallback.spoo.me with X-Forwarded-Host preserved
-CF anycast → Caddy on Hetzner (zone-level Authenticated Origin Pulls)
-    ↓ Caddy validates AOP client cert → reverse_proxy app:8000
+customer browser → <customer-hostname>
+  ↓ CF SaaS terminates TLS (per-hostname cert, auto-renewed)
+  ↓ dispatches per Custom Hostname's custom_origin_server = customers.spoo.me
+
+[at spoo.me zone]
+  ↓ Worker route customers.spoo.me/* catches
+  ↓ this Worker runs
+  ↓ fetch(http://<hetzner-rDNS>/) + X-Forwarded-Host = customer hostname
+
+[off CF — Hetzner rDNS sidesteps CF Worker loop detection]
+  ↓ UFW lets CF IPs hit port 80
+  ↓ Caddy :80 rewrites Host = X-Forwarded-Host
+  ↓ reverse_proxy app:8000 with Host: customer hostname
+
 spoo app
 ```
 
+## Why HTTP, not HTTPS, for the Worker → origin hop
+
+Two CF constraints stack:
+
+1. **CF Workers can't attach Authenticated Origin Pulls (AOP) client
+   cert** on outbound fetch. Caddy's `:443` mTLS check would fail with
+   `tls: certificate required`. (CF SaaS edge auto-attaches AOP when
+   dispatching directly to a fallback origin; Workers don't.)
+2. **CF Worker loop detection** triggers on any fetch to a hostname on
+   the same CF zone, even DNS-only records. Fetching `customers.spoo.me`
+   or any `*.spoo.me` proxied hostname returns 520 with `sliver=none`.
+
+Workaround: fetch a non-CF-managed hostname (Hetzner reverse DNS
+`static.<rev-ip>.clients.your-server.de`) over plain HTTP. UFW restricts
+port 80 to CF IP ranges, so the plaintext hop only exists between CF
+datacenter and our origin. Caddy `header_up Host` rewrites the upstream
+Host header to the customer's hostname (CF Workers can't override Host
+themselves) so the app builds asset URLs against the right hostname.
+
 ## One-time deploy
 
-### 1. Install wrangler
+### Install wrangler
 
 ```bash
 npm i -g wrangler
 ```
 
-### 2. Authenticate
+### Authenticate
 
-Either interactively:
+Interactive:
 
 ```bash
 wrangler login
 ```
 
-Or export an API token with `Account → Workers Scripts → Edit` and
-`Zone → Workers Routes → Edit` for the spoo.me zone:
+Or API token with `Account → Workers Scripts → Edit` and
+`Zone → Workers Routes → Edit` (spoo.me zone):
 
 ```bash
 export CLOUDFLARE_API_TOKEN=<token>
-export CLOUDFLARE_ACCOUNT_ID=<account-id>   # from CF dashboard
+export CLOUDFLARE_ACCOUNT_ID=<account-id>
 ```
 
-### 3. Deploy
+### Deploy
 
 ```bash
 ./deploy.sh
 ```
 
-This uploads `worker.js` and binds it to `customers.spoo.me/*` on the
-spoo.me zone (per `wrangler.toml`).
+Uploads `worker.js`, binds it to `customers.spoo.me/*` on spoo.me zone
+(per `wrangler.toml`).
 
-### 4. Confirm route in CF dashboard
+### Confirm
 
-`spoo.me zone → Workers Routes` — verify:
-- Pattern: `customers.spoo.me/*`
-- Worker: `spoo-custom-domains-dispatcher`
+`spoo.me zone → Workers Routes` — verify pattern + worker name.
+
+### Shared secret for Worker → origin auth
+
+Port 80 is reachable from any CF IP. The shared secret ensures only
+*our* Worker can use the dispatcher path: Worker sends
+`X-Worker-Auth: <secret>`, Caddy 403s without it.
+
+Generate once:
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Put the same value in two places:
+
+- **Hetzner box** `/opt/spoo/.env.production`:
+  `WORKER_AUTH_SECRET=<the-value>` (Caddy reads via `{env.WORKER_AUTH_SECRET}`)
+- **CF Worker secret** (encrypted, scoped to this Worker):
+  ```bash
+  cd cloudflare-worker
+  wrangler secret put WORKER_AUTH_SECRET
+  # paste the value at the prompt
+  ```
+
+Rotate by repeating with a new value, deploying Caddy + Worker
+together. Brief mismatch window during rotation → 403 responses.
+
+### Other prerequisites on origin (one-time, separate from this dir)
+
+- UFW: port 80 allowed from CF IPs (`infrastructure/ufw-cloudflare.sh`
+  handles both 443 + 80).
+- Caddyfile: `:80` listener with shared-secret matcher +
+  `header_up Host {http.request.header.X-Forwarded-Host}`.
+- DNS in spoo.me zone: `customers A 192.0.2.0 Proxied` (sentinel — the
+  Worker route binds to the hostname; the A record is required by CF
+  for the route to engage but is never actually contacted).
 
 ## Verification
 
-Once a customer Custom Hostname is registered (via the spoo app's API)
-and DNS propagates:
+After a Custom Hostname is registered + DNS propagates:
 
 ```bash
 curl -sI https://<customer-hostname>/
 ```
 
-Expect a non-520 response (whatever the spoo.me app returns for the
-hostname's request). Trace:
+Expect a 2xx/3xx response. Trace:
 
 ```bash
 curl -s https://<customer-hostname>/cdn-cgi/trace | grep sliver
 ```
 
-`sliver=` should now show a value other than `none` (typically `010-tier1`
-or similar) — confirms the Worker engaged.
+`sliver` should be `010-tier1` or similar — confirms Worker engaged.
+Stream live Worker logs:
+
+```bash
+wrangler tail spoo-custom-domains-dispatcher --format pretty
+```
 
 ## Updating
 
-Edit `worker.js`, re-run `./deploy.sh`. CF rolls the new code to the
-edge in seconds.
+Edit `worker.js`, rerun `./deploy.sh`. Live in seconds.
 
 ## Removal
 
@@ -95,4 +147,4 @@ edge in seconds.
 wrangler delete
 ```
 
-Then remove the route from the CF dashboard.
+Then remove the route from CF dashboard.

--- a/cloudflare-worker/deploy.sh
+++ b/cloudflare-worker/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# One-shot deploy for the spoo.me custom-domains dispatcher Worker.
+# Requires: wrangler CLI, CLOUDFLARE_API_TOKEN env var (or `wrangler login`).
+#
+# The deploy is idempotent — re-running upgrades the existing Worker in place.
+
+set -euo pipefail
+
+if ! command -v wrangler >/dev/null 2>&1; then
+  echo "wrangler not found. install: npm i -g wrangler" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+echo "deploying spoo-custom-domains-dispatcher..."
+wrangler deploy
+
+echo
+echo "verify route bound:"
+echo "  CF dashboard → spoo.me zone → Workers Routes → confirm customers.spoo.me/* → spoo-custom-domains-dispatcher"
+echo
+echo "smoke test once a Custom Hostname is registered:"
+echo "  curl -sI https://<customer-hostname>/"
+echo "  expect HTTP/2 200 (or whatever the spoo.me app returns)"

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -1,29 +1,9 @@
-// spoo.me Custom Domain dispatcher (Cloudflare Worker).
-//
-// Why this exists: CF SaaS Custom Hostnames + fallback origin alone don't
-// dispatch arbitrary customer-hostname traffic to a single backend on the
-// Free plan. A Worker route bound to the dispatch endpoint is the actual
-// routing mechanism — it catches Custom Hostname traffic and proxies it to
-// our origin while preserving the customer's original Host header.
-//
-// Flow:
-//   1. Customer browser → CF anycast (resolves customer hostname)
-//   2. CF SaaS terminates TLS with the per-hostname SaaS cert
-//   3. CF SaaS dispatches per the hostname's custom_origin_server setting
-//      (set to ORIGIN_HOST below — usually customers.spoo.me)
-//   4. Worker route customers.spoo.me/* catches the dispatched request
-//   5. This Worker fetches FALLBACK_ORIGIN with X-Forwarded-Host preserving
-//      the customer hostname so the app can scope alias lookups
-//   6. CF→origin TLS uses zone-level Authenticated Origin Pulls so Caddy
-//      validates the request actually came from CF
-//
-// Single-backend setup: no per-tenant routing, no metadata lookup. If we
-// ever need per-tenant dispatch later, read request.cf.hostMetadata.appName
-// and route accordingly — CF SaaS exposes custom_metadata via the binding.
+// spoo.me Custom Domain dispatcher. See README.md for the routing
+// chain + why the fetch target is the Hetzner rDNS over plain HTTP.
 
-const FALLBACK_ORIGIN = "proxy-fallback.spoo.me";
+const FALLBACK_ORIGIN = "http://static.168.161.156.178.clients.your-server.de";
 
-// Hop-by-hop headers per RFC 7230 §6.1 — must not be forwarded as-is.
+// RFC 7230 §6.1 — never forward as-is.
 const HOP_BY_HOP = new Set([
   "connection",
   "keep-alive",
@@ -35,30 +15,33 @@ const HOP_BY_HOP = new Set([
   "upgrade",
 ]);
 
-function buildOutboundHeaders(request, customerHost) {
+function buildOutboundHeaders(request, customerHost, authSecret) {
   const out = new Headers();
   for (const [name, value] of request.headers.entries()) {
     if (HOP_BY_HOP.has(name.toLowerCase())) continue;
-    if (name.toLowerCase() === "host") continue; // set by fetch from URL
+    if (name.toLowerCase() === "host") continue;
     out.set(name, value);
   }
-  // Customer hostname → app's tenant resolver middleware (PR4) reads this
-  // to scope alias lookups by tenant.
+  // Caddy rewrites Host from this header (Workers can't override Host).
   out.set("X-Forwarded-Host", customerHost);
+  if (authSecret) {
+    out.set("X-Worker-Auth", authSecret);
+  }
   return out;
 }
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     const originalUrl = new URL(request.url);
     const customerHost = request.headers.get("host") || originalUrl.hostname;
 
-    const upstream = new URL(originalUrl);
-    upstream.hostname = FALLBACK_ORIGIN;
+    const upstream = new URL(FALLBACK_ORIGIN);
+    upstream.pathname = originalUrl.pathname;
+    upstream.search = originalUrl.search;
 
     const init = {
       method: request.method,
-      headers: buildOutboundHeaders(request, customerHost),
+      headers: buildOutboundHeaders(request, customerHost, env.WORKER_AUTH_SECRET),
       redirect: "manual",
     };
     if (request.method !== "GET" && request.method !== "HEAD") {
@@ -67,8 +50,12 @@ export default {
 
     try {
       const response = await fetch(upstream.toString(), init);
+      console.log(
+        `customer=${customerHost} status=${response.status} cf-ray=${response.headers.get("cf-ray") || "n/a"}`,
+      );
       return response;
     } catch (err) {
+      console.log(`upstream-fetch-err customer=${customerHost} err=${err.message}`);
       return new Response(`upstream fetch failed: ${err.message}`, {
         status: 502,
         headers: { "content-type": "text/plain; charset=utf-8" },

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -1,0 +1,78 @@
+// spoo.me Custom Domain dispatcher (Cloudflare Worker).
+//
+// Why this exists: CF SaaS Custom Hostnames + fallback origin alone don't
+// dispatch arbitrary customer-hostname traffic to a single backend on the
+// Free plan. A Worker route bound to the dispatch endpoint is the actual
+// routing mechanism — it catches Custom Hostname traffic and proxies it to
+// our origin while preserving the customer's original Host header.
+//
+// Flow:
+//   1. Customer browser → CF anycast (resolves customer hostname)
+//   2. CF SaaS terminates TLS with the per-hostname SaaS cert
+//   3. CF SaaS dispatches per the hostname's custom_origin_server setting
+//      (set to ORIGIN_HOST below — usually customers.spoo.me)
+//   4. Worker route customers.spoo.me/* catches the dispatched request
+//   5. This Worker fetches FALLBACK_ORIGIN with X-Forwarded-Host preserving
+//      the customer hostname so the app can scope alias lookups
+//   6. CF→origin TLS uses zone-level Authenticated Origin Pulls so Caddy
+//      validates the request actually came from CF
+//
+// Single-backend setup: no per-tenant routing, no metadata lookup. If we
+// ever need per-tenant dispatch later, read request.cf.hostMetadata.appName
+// and route accordingly — CF SaaS exposes custom_metadata via the binding.
+
+const FALLBACK_ORIGIN = "proxy-fallback.spoo.me";
+
+// Hop-by-hop headers per RFC 7230 §6.1 — must not be forwarded as-is.
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function buildOutboundHeaders(request, customerHost) {
+  const out = new Headers();
+  for (const [name, value] of request.headers.entries()) {
+    if (HOP_BY_HOP.has(name.toLowerCase())) continue;
+    if (name.toLowerCase() === "host") continue; // set by fetch from URL
+    out.set(name, value);
+  }
+  // Customer hostname → app's tenant resolver middleware (PR4) reads this
+  // to scope alias lookups by tenant.
+  out.set("X-Forwarded-Host", customerHost);
+  return out;
+}
+
+export default {
+  async fetch(request) {
+    const originalUrl = new URL(request.url);
+    const customerHost = request.headers.get("host") || originalUrl.hostname;
+
+    const upstream = new URL(originalUrl);
+    upstream.hostname = FALLBACK_ORIGIN;
+
+    const init = {
+      method: request.method,
+      headers: buildOutboundHeaders(request, customerHost),
+      redirect: "manual",
+    };
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      init.body = request.body;
+    }
+
+    try {
+      const response = await fetch(upstream.toString(), init);
+      return response;
+    } catch (err) {
+      return new Response(`upstream fetch failed: ${err.message}`, {
+        status: 502,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+  },
+};

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -17,9 +17,18 @@ const HOP_BY_HOP = new Set([
 
 function buildOutboundHeaders(request, customerHost, authSecret) {
   const out = new Headers();
+  // RFC 7230 §6.1: headers named in Connection are also hop-by-hop.
+  const dynamicHops = new Set(
+    (request.headers.get("connection") || "")
+      .split(",")
+      .map((v) => v.trim().toLowerCase())
+      .filter(Boolean),
+  );
   for (const [name, value] of request.headers.entries()) {
-    if (HOP_BY_HOP.has(name.toLowerCase())) continue;
-    if (name.toLowerCase() === "host") continue;
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP.has(lower)) continue;
+    if (dynamicHops.has(lower)) continue;
+    if (lower === "host") continue;
     out.set(name, value);
   }
   // Caddy rewrites Host from this header (Workers can't override Host).
@@ -55,8 +64,9 @@ export default {
       );
       return response;
     } catch (err) {
-      console.log(`upstream-fetch-err customer=${customerHost} err=${err.message}`);
-      return new Response(`upstream fetch failed: ${err.message}`, {
+      // Full error stays in Worker logs; client sees a generic message.
+      console.error("upstream fetch failed", customerHost, err);
+      return new Response("upstream fetch failed", {
         status: 502,
         headers: { "content-type": "text/plain; charset=utf-8" },
       });

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "spoo-custom-domains-dispatcher"
+main = "worker.js"
+compatibility_date = "2026-05-01"
+
+[observability.logs]
+enabled = true
+
+# Worker route catches every request CF SaaS dispatches via the configured
+# custom_origin_server (set to customers.spoo.me on each Custom Hostname).
+# Pattern matches the dispatch hostname's path, not the customer hostname —
+# the customer's hostname arrives in the Host header, preserved by CF SaaS.
+[[routes]]
+pattern = "customers.spoo.me/*"
+zone_name = "spoo.me"

--- a/config.py
+++ b/config.py
@@ -179,8 +179,9 @@ class CustomDomainSettings(BaseSettings):
     # customer create.
     cf_zone_id: str | None = None
     cf_api_token: str | None = None
-    # Friendly CNAME target users see in their DNS dashboard. Created once
-    # in the CF zone as a proxied CNAME to the fallback origin.
+    # Friendly CNAME target users see in their DNS dashboard. Backed in
+    # the SaaS zone by a sentinel proxied A record (192.0.2.0) so the
+    # bound Worker route engages; never actually contacted.
     cf_cname_target: str = "customers.spoo.me"
     # Per-zone delegation hostname returned by CF when Delegated DCV is
     # enabled (e.g. <random>.dcv.cloudflare.com). Customer adds

--- a/config.py
+++ b/config.py
@@ -199,12 +199,16 @@ class CustomDomainSettings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_cf_saas_config(self) -> CustomDomainSettings:
+        # Normalise at config boundary so backend code can trust the value.
+        self.cf_worker_origin = self.cf_worker_origin.strip().strip(".")
         if self.cf_zone_id:
             missing = []
             if not self.cf_api_token:
                 missing.append("cf_api_token")
             if not self.cf_dcv_delegation_target:
                 missing.append("cf_dcv_delegation_target")
+            if not self.cf_worker_origin:
+                missing.append("cf_worker_origin")
             if missing:
                 raise ValueError(
                     f"CF SaaS path requires {missing} when cf_zone_id is set."

--- a/config.py
+++ b/config.py
@@ -186,6 +186,12 @@ class CustomDomainSettings(BaseSettings):
     # enabled (e.g. <random>.dcv.cloudflare.com). Customer adds
     # _acme-challenge.<fqdn> CNAME to <fqdn>.<this value> so CF can renew.
     cf_dcv_delegation_target: str = ""
+    # Hostname CF SaaS dispatches per-Custom-Hostname traffic to. Must match
+    # the Worker route pattern on the SaaS zone — Worker catches dispatched
+    # traffic and proxies to the actual origin. Usually same as
+    # cf_cname_target, kept separate so the user-facing CNAME and the
+    # internal dispatch hostname can diverge if needed.
+    cf_worker_origin: str = "customers.spoo.me"
     # Retry policy for CF API calls. Three attempts with exponential backoff.
     cf_api_max_retries: int = Field(default=3, ge=1)
     cf_api_initial_backoff_seconds: float = Field(default=1.0, gt=0)

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -196,6 +196,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
             custom_domain_repo=custom_domain_repo,
             cname_target=cd_settings.cf_cname_target,
             dcv_delegation_target=cd_settings.cf_dcv_delegation_target,
+            worker_origin=cd_settings.cf_worker_origin,
         )
         # Same instance fills three protocol slots — wiring contract.
         verifiers = {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -116,6 +116,10 @@ services:
     ports:
       - "443:443"
       - "443:443/udp"
+      - "80:80"
+    environment:
+      # Shared with the CF custom-domain Worker; see cloudflare-worker/README.md.
+      - WORKER_AUTH_SECRET=${WORKER_AUTH_SECRET}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./caddy/origin.crt:/etc/caddy/origin.crt:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -119,7 +119,10 @@ services:
       - "80:80"
     environment:
       # Shared with the CF custom-domain Worker; see cloudflare-worker/README.md.
-      - WORKER_AUTH_SECRET=${WORKER_AUTH_SECRET}
+      # `:?` fails compose up if the var is unset/empty — without it, Caddy's
+      # auth matcher would expand to an empty string and let any request
+      # through with no X-Worker-Auth header.
+      - WORKER_AUTH_SECRET=${WORKER_AUTH_SECRET:?WORKER_AUTH_SECRET must be set in .env}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./caddy/origin.crt:/etc/caddy/origin.crt:ro

--- a/infrastructure/cloudflare_client.py
+++ b/infrastructure/cloudflare_client.py
@@ -71,14 +71,16 @@ class CloudflareClient:
         fqdn: str,
         *,
         dcv_method: str,
+        custom_origin_server: str | None = None,
     ) -> CFHostnameResult:
         """Register *fqdn* with CF SaaS.
 
         ``dcv_method`` is one of ``"txt"`` (delegated), ``"http"``, ``"email"``.
-        Spoo uses ``"txt"`` for delegated DCV (CF auto-renews via the
-        permanent ``_acme-challenge`` CNAME) and ``"http"`` as fallback.
+        ``custom_origin_server`` overrides the zone fallback origin per
+        hostname — CF dispatches request to this hostname. Required when a
+        Worker route on the SaaS zone needs to catch dispatched traffic.
         """
-        body = {
+        body: dict = {
             "hostname": fqdn,
             "ssl": {
                 "method": dcv_method,
@@ -86,6 +88,8 @@ class CloudflareClient:
                 "settings": {"min_tls_version": "1.2"},
             },
         }
+        if custom_origin_server:
+            body["custom_origin_server"] = custom_origin_server
         payload = await self._request(
             "POST",
             f"/zones/{self._zone_id}/custom_hostnames",

--- a/infrastructure/ufw-cloudflare.sh
+++ b/infrastructure/ufw-cloudflare.sh
@@ -31,8 +31,9 @@ echo "[ufw-cloudflare] dropping existing 443 + 80 allow rules…"
 mapfile -t rule_nums < <(
 	ufw status numbered \
 		| awk -F'[][]' '/^\[/ {
-			# print rule number for any ALLOW IN line on 443 or 80
-			if ($0 ~ /(443|80).*ALLOW IN/) print $2
+			# Match exact 443/tcp, 443/udp, 80/tcp tokens — naive 443|80
+			# would also match 4430, 8080, etc.
+			if ($0 ~ /(^|[^0-9])(443\/(tcp|udp)|80\/tcp)([^0-9]|$).*ALLOW IN/) print $2
 		}' \
 		| sort -rn
 )

--- a/infrastructure/ufw-cloudflare.sh
+++ b/infrastructure/ufw-cloudflare.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
-# Restrict inbound 443 to Cloudflare IP ranges only.
-# Run on VPS as root. Idempotent — safe to re-run from cron.
+# Allowlist inbound 443 + 80 to Cloudflare IP ranges. Idempotent.
+# Ports 80 + 443 both need it: 443 for customer HTTPS, 80 for the
+# CF Worker → origin hop (worker can't do mTLS, see cloudflare-worker/).
 #
-# CF publishes its IP ranges at:
-#   https://www.cloudflare.com/ips-v4
-#   https://www.cloudflare.com/ips-v6
+# CF IP ranges: https://www.cloudflare.com/ips-{v4,v6}
 #
-# Without this allowlist, any attacker who discovers our origin IP could
-# bypass CF (and bypass orange-cloud DDoS / WAF / rate limit).
-#
-# Order matters: fetch CF ranges and validate BEFORE mutating UFW. A failed
-# fetch mid-run could otherwise leave the host with default-deny and no
-# allow rules — locking 443 entirely.
+# Docker-mapped ports bypass UFW's filter chain (DNAT happens in
+# PREROUTING), so we ALSO mirror the rules into DOCKER-USER via
+# /etc/ufw/after.rules. Step 5 below.
 
 set -euo pipefail
 
@@ -30,16 +26,13 @@ if [[ -z "$v4" || -z "$v6" ]]; then
 	exit 2
 fi
 
-# ── Step 2: drop ALL prior 443 allow rules ─────────────────────────────
-# Catches both our own Cloudflare-v[46] tagged rules AND any pre-existing
-# broad rules like `ufw allow 443/tcp` that would let traffic bypass CF.
-# Anything other than CF allow on 443 is a regression we re-establish below.
-echo "[ufw-cloudflare] dropping existing 443 allow rules…"
+# ── Step 2: drop prior 443/80 rules so the re-run rebuilds cleanly ─────
+echo "[ufw-cloudflare] dropping existing 443 + 80 allow rules…"
 mapfile -t rule_nums < <(
 	ufw status numbered \
 		| awk -F'[][]' '/^\[/ {
-			# print rule number for any ALLOW IN line that mentions 443
-			if ($0 ~ /443.*ALLOW IN/) print $2
+			# print rule number for any ALLOW IN line on 443 or 80
+			if ($0 ~ /(443|80).*ALLOW IN/) print $2
 		}' \
 		| sort -rn
 )
@@ -56,25 +49,71 @@ ufw default deny incoming >/dev/null
 ufw default allow outgoing >/dev/null
 ufw allow 22/tcp comment 'SSH' >/dev/null
 
-# ── Step 4: add CF allow rules ─────────────────────────────────────────
-# TCP for HTTP/2 + HTTP/1.1, UDP for HTTP/3 (QUIC). Compose maps both.
-echo "[ufw-cloudflare] adding 443 allow rules for CF (TCP + UDP)…"
+# ── Step 4: CF allowlist (443 tcp+udp for HTTP/{2,3}, 80 tcp) ──────────
+echo "[ufw-cloudflare] adding 443 + 80 allow rules for CF…"
 while IFS= read -r ip; do
 	[[ -z "$ip" ]] && continue
 	ufw allow proto tcp from "$ip" to any port 443 comment 'Cloudflare-v4' >/dev/null
 	ufw allow proto udp from "$ip" to any port 443 comment 'Cloudflare-v4' >/dev/null
+	ufw allow proto tcp from "$ip" to any port 80 comment 'Cloudflare-v4' >/dev/null
 done <<< "$v4"
 
 while IFS= read -r ip; do
 	[[ -z "$ip" ]] && continue
 	ufw allow proto tcp from "$ip" to any port 443 comment 'Cloudflare-v6' >/dev/null
 	ufw allow proto udp from "$ip" to any port 443 comment 'Cloudflare-v6' >/dev/null
+	ufw allow proto tcp from "$ip" to any port 80 comment 'Cloudflare-v6' >/dev/null
 done <<< "$v6"
 
-# ── Step 5: enable + reload ────────────────────────────────────────────
+# ── Step 5: mirror the allowlist into DOCKER-USER ──────────────────────
+# Docker bypasses UFW filter; DOCKER-USER is the documented hook.
+# Marker-delimited block in after.rules so re-runs replace cleanly.
+
+BEGIN_MARKER='# BEGIN cf-docker-user (managed by ufw-cloudflare.sh)'
+END_MARKER='# END cf-docker-user'
+
+write_docker_user_block() {
+	local rules_file="$1"
+	local ip_list="$2"
+
+	if grep -qF "$BEGIN_MARKER" "$rules_file"; then
+		echo "[ufw-cloudflare] removing prior managed block from $rules_file…"
+		sed -i "/^$BEGIN_MARKER\$/,/^$END_MARKER\$/d" "$rules_file"
+	fi
+
+	echo "[ufw-cloudflare] writing managed block to $rules_file…"
+	{
+		echo ""
+		echo "$BEGIN_MARKER"
+		echo "*filter"
+		# `:CHAIN - [0:0]` flushes existing rules so re-runs replace.
+		echo ":DOCKER-USER - [0:0]"
+		while IFS= read -r ip; do
+			[[ -z "$ip" ]] && continue
+			echo "-A DOCKER-USER -p tcp -s $ip --dport 443 -j RETURN"
+			echo "-A DOCKER-USER -p udp -s $ip --dport 443 -j RETURN"
+			echo "-A DOCKER-USER -p tcp -s $ip --dport 80 -j RETURN"
+		done <<< "$ip_list"
+		echo "-A DOCKER-USER -p tcp --dport 443 -j DROP"
+		echo "-A DOCKER-USER -p udp --dport 443 -j DROP"
+		echo "-A DOCKER-USER -p tcp --dport 80 -j DROP"
+		# Default Docker fall-through for traffic not on those ports.
+		echo "-A DOCKER-USER -j RETURN"
+		echo "COMMIT"
+		echo "$END_MARKER"
+	} >> "$rules_file"
+}
+
+write_docker_user_block /etc/ufw/after.rules "$v4"
+write_docker_user_block /etc/ufw/after6.rules "$v6"
+
+# ── Step 6: enable + reload ────────────────────────────────────────────
 echo "[ufw-cloudflare] enabling UFW…"
 ufw --force enable >/dev/null
 ufw reload >/dev/null
 
-echo "[ufw-cloudflare] done. Rules:"
+echo "[ufw-cloudflare] done. UFW rules:"
 ufw status | head -60
+echo
+echo "[ufw-cloudflare] DOCKER-USER chain (live, IPv4):"
+iptables -L DOCKER-USER -n --line-numbers | head -20

--- a/services/cf_saas_backend.py
+++ b/services/cf_saas_backend.py
@@ -44,12 +44,17 @@ class CfSaasBackend(HostnameRegistrar, DomainVerifier, EdgeProvisioner):
         custom_domain_repo: CustomDomainRepository,
         cname_target: str,
         dcv_delegation_target: str,
+        worker_origin: str,
     ) -> None:
         self._cf = cf_client
         self._repo = custom_domain_repo
         # Strip dots so misconfigured env vars can't produce `foo..bar`.
         self._cname_target = cname_target.strip(".")
         self._dcv_delegation_target = dcv_delegation_target.strip(".")
+        # Set as custom_origin_server on each Custom Hostname so CF
+        # dispatches traffic to the Worker route (fallback origin alone
+        # doesn't dispatch arbitrary customer hostnames on Free plan).
+        self._worker_origin = worker_origin.strip(".")
 
     # ── HostnameRegistrar ───────────────────────────────────────────────
 
@@ -57,7 +62,11 @@ class CfSaasBackend(HostnameRegistrar, DomainVerifier, EdgeProvisioner):
         self, fqdn: str, *, dcv_method: str | None = None
     ) -> RegistrationResult:
         cf_method = _DCV_METHOD_MAP.get(dcv_method or "cf_delegated_dcv", "txt")
-        result = await self._cf.create_custom_hostname(fqdn, dcv_method=cf_method)
+        result = await self._cf.create_custom_hostname(
+            fqdn,
+            dcv_method=cf_method,
+            custom_origin_server=self._worker_origin,
+        )
         instructions = self._build_dns_instructions(
             fqdn, dcv_method or "cf_delegated_dcv"
         )

--- a/tests/smoke/test_custom_domain_cf_wiring.py
+++ b/tests/smoke/test_custom_domain_cf_wiring.py
@@ -110,3 +110,14 @@ class TestCfConfigValidation:
     def test_cf_zone_id_without_delegation_target_fails(self):
         with pytest.raises(ValueError, match="cf_dcv_delegation_target"):
             CustomDomainSettings(cf_zone_id="zone1", cf_api_token="tok")
+
+    def test_cf_zone_id_with_empty_worker_origin_fails(self):
+        # Empty/whitespace/dots-only worker_origin would silently omit
+        # custom_origin_server and break dispatch — must fail fast.
+        with pytest.raises(ValueError, match="cf_worker_origin"):
+            CustomDomainSettings(
+                cf_zone_id="zone1",
+                cf_api_token="tok",
+                cf_dcv_delegation_target="abc.dcv.cloudflare.com",
+                cf_worker_origin=" . ",
+            )

--- a/tests/unit/infrastructure/test_cloudflare_client.py
+++ b/tests/unit/infrastructure/test_cloudflare_client.py
@@ -88,6 +88,7 @@ class TestCloudflareClient:
             custom_origin_server="customers.spoo.me",
         )
 
+        request.assert_awaited_once()
         body = request.await_args.kwargs["json"]
         assert body["custom_origin_server"] == "customers.spoo.me"
 

--- a/tests/unit/infrastructure/test_cloudflare_client.py
+++ b/tests/unit/infrastructure/test_cloudflare_client.py
@@ -63,6 +63,7 @@ class TestCloudflareClient:
         assert result.status == "pending"
         request.assert_awaited_once()
         kwargs = request.await_args.kwargs
+        # No custom_origin_server when not passed → key omitted from body.
         assert kwargs["json"] == {
             "hostname": "links.acme.com",
             "ssl": {
@@ -76,6 +77,19 @@ class TestCloudflareClient:
             "POST",
             f"{CF_API_BASE}/zones/zone1/custom_hostnames",
         )
+
+    async def test_create_with_custom_origin_server_includes_it_in_payload(self):
+        http, request = _http_client_with_response({"result": _hostname_payload()})
+        client = CloudflareClient(http_client=http, api_token="t", zone_id="z")
+
+        await client.create_custom_hostname(
+            "links.acme.com",
+            dcv_method="txt",
+            custom_origin_server="customers.spoo.me",
+        )
+
+        body = request.await_args.kwargs["json"]
+        assert body["custom_origin_server"] == "customers.spoo.me"
 
     async def test_get_custom_hostname_returns_parsed_result(self):
         http, _ = _http_client_with_response(

--- a/tests/unit/services/test_cf_saas_backend.py
+++ b/tests/unit/services/test_cf_saas_backend.py
@@ -21,6 +21,7 @@ def _backend(
         custom_domain_repo=repo or MagicMock(),
         cname_target="customers.spoo.me",
         dcv_delegation_target="abc.dcv.cloudflare.com",
+        worker_origin="customers.spoo.me",
     )
 
 
@@ -51,9 +52,11 @@ class TestRegister:
         assert cname["value"] == "customers.spoo.me"
         assert delegation["name"] == "_acme-challenge.links.acme.com"
         assert delegation["value"] == "links.acme.com.abc.dcv.cloudflare.com"
-        # CF API was called with the delegated DCV method ("txt").
+        # CF API was called with the delegated DCV method + custom origin.
         cf_client.create_custom_hostname.assert_awaited_once_with(
-            "links.acme.com", dcv_method="txt"
+            "links.acme.com",
+            dcv_method="txt",
+            custom_origin_server="customers.spoo.me",
         )
 
     async def test_delegation_target_with_stray_dots_is_normalised(self):
@@ -73,11 +76,15 @@ class TestRegister:
             custom_domain_repo=MagicMock(),
             cname_target=".customers.spoo.me.",
             dcv_delegation_target=".abc.dcv.cloudflare.com.",
+            worker_origin=".customers.spoo.me.",
         )
         result = await backend.register("links.acme.com", dcv_method="cf_delegated_dcv")
         cname, delegation = result.instructions
         assert cname["value"] == "customers.spoo.me"
         assert delegation["value"] == "links.acme.com.abc.dcv.cloudflare.com"
+        # Worker origin also stripped.
+        kwargs = cf_client.create_custom_hostname.call_args.kwargs
+        assert kwargs["custom_origin_server"] == "customers.spoo.me"
 
     async def test_register_http_dcv_returns_one_record(self):
         cf_client = MagicMock()
@@ -93,7 +100,9 @@ class TestRegister:
         result = await backend.register("links.acme.com", dcv_method="cf_http_dcv")
         assert len(result.instructions) == 1
         cf_client.create_custom_hostname.assert_awaited_once_with(
-            "links.acme.com", dcv_method="http"
+            "links.acme.com",
+            dcv_method="http",
+            custom_origin_server="customers.spoo.me",
         )
 
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce Cloudflare Worker–based dispatching for SaaS custom hostname traffic and wire it through the application configuration and Cloudflare client.

New Features:
- Add Cloudflare Worker that proxies SaaS custom hostname traffic to the fallback origin while preserving the customer Host header.
- Introduce configurable worker origin hostname used as the custom origin server for each Cloudflare SaaS Custom Hostname registration.

Enhancements:
- Extend Cloudflare client and SaaS backend to support an optional per-hostname custom origin server and normalize it similarly to other Cloudflare targets.
- Wire worker-origin configuration into service construction so all new custom hostnames are registered with the dispatch endpoint.

Deployment:
- Add Wrangler configuration and deployment script for the custom-domain dispatcher Cloudflare Worker.

Documentation:
- Add documentation describing the purpose, deployment, verification, and lifecycle of the custom-domain dispatcher Cloudflare Worker.

Tests:
- Expand unit tests to cover custom origin server handling in the Cloudflare client and SaaS backend, including normalization and request payload expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare Worker dispatcher for custom domains with fallback origin routing, worker→origin authentication (unauthenticated requests receive 403), and HTTP routing on port 80 alongside 443.
  * Configuration support for a dedicated worker-origin hostname and related deployment wiring.

* **Documentation**
  * Added Cloudflare Worker README and a deploy script with deployment, verification, and removal steps.

* **Tests**
  * Unit tests added/updated to cover custom-origin behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spoo-me/spoo/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->