### PR TITLE
feat(custom-domains): public API + dashboard + tenant routing policy

### DIFF
--- a/dependencies/__init__.py
+++ b/dependencies/__init__.py
@@ -6,6 +6,8 @@ Re-exports all dependencies from sub-modules for convenient
 """
 
 from dependencies.auth import (
+    DOMAIN_MANAGE_SCOPES,
+    DOMAIN_READ_SCOPES,
     SHORTEN_SCOPES,
     STATS_SCOPES,
     URL_MANAGEMENT_SCOPES,
@@ -24,6 +26,7 @@ from dependencies.auth import (
     require_jwt,
     require_jwt_verified,
     require_scopes,
+    require_scopes_verified,
     require_verified_email,
 )
 from dependencies.infra import (
@@ -46,8 +49,10 @@ from dependencies.services import (
     ClickSvc,
     ContactSvc,
     CredentialSvc,
+    CustomDomainSvc,
     DeviceAuthSvc,
     ExportSvc,
+    FeatureFlagSvc,
     OAuthSvc,
     PasswordSvc,
     ProfilePictureSvc,
@@ -61,8 +66,10 @@ from dependencies.services import (
     get_click_service,
     get_contact_service,
     get_credential_service,
+    get_custom_domain_service,
     get_device_auth_service,
     get_export_service,
+    get_feature_flag_service,
     get_oauth_service,
     get_password_service,
     get_profile_picture_service,
@@ -73,6 +80,8 @@ from dependencies.services import (
 )
 
 __all__ = [
+    "DOMAIN_MANAGE_SCOPES",
+    "DOMAIN_READ_SCOPES",
     "SHORTEN_SCOPES",
     "STATS_SCOPES",
     "URL_MANAGEMENT_SCOPES",
@@ -88,8 +97,10 @@ __all__ = [
     "ContactSvc",
     "CredentialSvc",
     "CurrentUser",
+    "CustomDomainSvc",
     "DeviceAuthSvc",
     "ExportSvc",
+    "FeatureFlagSvc",
     "JwtConfig",
     "JwtUser",
     "JwtVerifiedUser",
@@ -114,10 +125,12 @@ __all__ = [
     "get_contact_service",
     "get_credential_service",
     "get_current_user",
+    "get_custom_domain_service",
     "get_db",
     "get_device_auth_service",
     "get_email_provider",
     "get_export_service",
+    "get_feature_flag_service",
     "get_geoip_service",
     "get_jwt_config",
     "get_oauth_providers",
@@ -136,5 +149,6 @@ __all__ = [
     "require_jwt",
     "require_jwt_verified",
     "require_scopes",
+    "require_scopes_verified",
     "require_verified_email",
 ]

--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -200,6 +200,12 @@ URL_READ_SCOPES: set[str] = {
     ApiKeyScope.ADMIN_ALL,
 }
 SHORTEN_SCOPES: set[str] = {ApiKeyScope.SHORTEN_CREATE, ApiKeyScope.ADMIN_ALL}
+DOMAIN_MANAGE_SCOPES: set[str] = {ApiKeyScope.DOMAINS_MANAGE, ApiKeyScope.ADMIN_ALL}
+DOMAIN_READ_SCOPES: set[str] = {
+    ApiKeyScope.DOMAINS_MANAGE,
+    ApiKeyScope.DOMAINS_READ,
+    ApiKeyScope.ADMIN_ALL,
+}
 
 
 # ── Parameterised scope dependency factories ─────────────────────────────────
@@ -259,6 +265,24 @@ def optional_scopes_verified(scopes: set[str]):
         user: CurrentUser | None = Depends(optional_scopes(scopes)),
     ) -> CurrentUser | None:
         if user is not None and not user.email_verified:
+            raise EmailNotVerifiedError("Email verification required")
+        return user
+
+    return _dep
+
+
+def require_scopes_verified(scopes: set[str]):
+    """``require_scopes`` plus email-verification gate.
+
+    Use on protected create endpoints that accept BOTH JWT and API key auth.
+    API key callers must also be email-verified (their underlying user must
+    have verified the email at signup time).
+    """
+
+    async def _dep(
+        user: CurrentUser = Depends(require_scopes(scopes)),
+    ) -> CurrentUser:
+        if not user.email_verified:
             raise EmailNotVerifiedError("Email verification required")
         return user
 

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -232,4 +232,5 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         preflight_cname_target=cd_settings.cf_cname_target
         if cd_settings.cf_zone_id
         else None,
+        url_service=app.state.url_service,
     )

--- a/errors.py
+++ b/errors.py
@@ -126,13 +126,6 @@ class InvalidDomainTransitionError(ValidationError):
     error_code = "invalid_domain_transition"
 
 
-class DomainDnsNotPropagatedError(ValidationError):
-    """Pre-register DNS check didn't see the routing CNAME yet."""
-
-    status_code = 422
-    error_code = "domain_dns_not_propagated"
-
-
 class CloudflareAPIError(AppError):
     """Cloudflare API call failed (4xx, 5xx, or network)."""
 

--- a/infrastructure/cache/url_cache.py
+++ b/infrastructure/cache/url_cache.py
@@ -93,3 +93,19 @@ class UrlCache:
             )
         except Exception as e:
             log.error("url_cache_invalidate_error", short_code=short_code, error=str(e))
+
+    async def invalidate_many(self, short_codes: list[str], domain: str) -> None:
+        """Bulk-invalidate cache entries for a list of aliases on one domain."""
+        if not short_codes or self._redis is None:
+            return
+        keys = [self._key(c, domain) for c in short_codes]
+        try:
+            await self._redis.delete(*keys)
+            log.info(
+                "cache_invalidated_bulk",
+                count=len(short_codes),
+                domain=domain,
+                reason="bulk_invalidation",
+            )
+        except Exception as e:
+            log.error("url_cache_invalidate_many_error", domain=domain, error=str(e))

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -73,6 +73,13 @@ class Limits:
     # URL management
     URL_MANAGE = "120 per minute; 2000 per day"
     URL_DELETE = "60 per minute; 1000 per day"
+    URL_BULK_DELETE = "5 per minute; 50 per day"
+
+    # Custom domains
+    DOMAIN_CREATE = "5 per hour"
+    DOMAIN_VERIFY = "10 per minute"
+    DOMAIN_READ = "60 per minute"
+    DOMAIN_DELETE = "10 per minute"
 
     # Dashboard — profile pictures
     PROFILE_PICTURE_SET = "10 per minute"

--- a/middleware/tenant.py
+++ b/middleware/tenant.py
@@ -1,18 +1,35 @@
 """Resolve Host header → TenantInfo on every request.
 
 Lands `request.state.tenant` for downstream handlers. Redirect route
-reads it to scope the URL lookup to the right tenant. Unknown public
-hosts get an HTML 404; internal/loopback hosts pass through with
-tenant=None so /health doesn't break.
+reads it to scope the URL lookup to the right tenant.
+
+Routing policy for custom tenants is a strict allowlist:
+  - `GET /<alias>` and `POST /<alias>/password` → redirect router
+  - `GET /favicon.ico`                         → static router (generic favicon)
+  - `GET /robots.txt`                          → inline `Disallow: /`
+  - Everything else                            → 404
+
+Operator surface (`/api/*`, `/dashboard/*`, `/auth/*`, `/oauth/*`, `/health`)
+and brand pages (`/about`, `/contact`, `/api-docs`, `/<alias>+`, `/report`)
+all 404 on custom tenants. Per-domain routing config (`root_redirect`,
+`not_found_redirect`, `custom_robots_txt`) lands in PR4.5.
+
+System-default tenant behaves exactly as before — full app surface.
+
+Every custom-tenant response carries `X-Robots-Tag: noindex, nofollow,
+noarchive` (post-handler). Combined with the disallow-all robots.txt, this
+keeps short links out of search indexes. Preview crawlers (Twitter/Slack/
+Discord/etc.) ignore these signals and continue to unfurl correctly.
 """
 
 from __future__ import annotations
 
+import re
 from urllib.parse import urlsplit
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import HTMLResponse, Response
+from starlette.responses import HTMLResponse, PlainTextResponse, Response
 
 from infrastructure.logging import get_logger
 from services.tenant_resolver.protocol import TenantInfo, TenantResolver
@@ -20,6 +37,55 @@ from services.tenant_resolver.protocol import TenantInfo, TenantResolver
 log = get_logger(__name__)
 
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "app"})
+
+_NOT_FOUND_BODY = (
+    "<!doctype html><html><head><title>404 — Not Found</title></head>"
+    "<body><h1>404</h1><p>URL not found.</p></body></html>"
+)
+
+_CUSTOM_TENANT_ROBOTS_BODY = "User-agent: *\nDisallow: /\n"
+_NOINDEX_HEADER = "noindex, nofollow, noarchive"
+
+# Allowed exact paths on custom tenants (besides the alias pattern).
+_ALLOWED_EXACT_PATHS = frozenset({"/favicon.ico"})
+
+# Reserved path prefixes — match these *before* the alias allowlist so
+# operator surface (`/dashboard/*`, `/api/*`, …) and brand pages
+# (`/about`, `/contact`, …) cannot be exposed through the alias namespace.
+# A path is reserved if it equals one of these strings exactly or starts
+# with one followed by `/`. Bare alias collisions (e.g. a customer creating
+# an alias literally named `dashboard`) are sacrificed for tenant isolation.
+_RESERVED_PREFIXES = (
+    "/api",
+    "/dashboard",
+    "/auth",
+    "/oauth",
+    "/health",
+    "/report",
+    "/about",
+    "/contact",
+    "/privacy",
+    "/api-docs",
+    "/api-reference",
+)
+
+# Alias paths allowed on custom tenants. Match `/<alias>` and
+# `/<alias>/password` only. Alias body is `[A-Za-z0-9_-]{3,16}` per
+# `shared.validators.validate_alias` plus the URL-safe slice of the emoji
+# range used in v2. Stats suffix (`+`) is intentionally NOT matched so
+# `/<alias>+` falls through to 404 — analytics surface stays on spoo.me.
+#
+# Emoji ranges: Misc Symbols & Pictographs (1F300-1F5FF), Emoticons
+# (1F600-1F64F), Transport & Map (1F680-1F6FF), Supplemental Symbols
+# (1F900-1F9FF), Extended-A (1FA70-1FAFF), and percent-encoded forms.
+_ALIAS_PATTERN = re.compile(
+    r"^/"
+    r"(?:[A-Za-z0-9_\-]"
+    r"|[\U0001F300-\U0001F5FF\U0001F600-\U0001F64F"
+    r"\U0001F680-\U0001F6FF\U0001F900-\U0001F9FF\U0001FA70-\U0001FAFF]"
+    r"|%[0-9A-Fa-f]{2})+"
+    r"(?:/password)?$"
+)
 
 
 def _normalise_host(raw: str) -> str:
@@ -34,8 +100,30 @@ def _normalise_host(raw: str) -> str:
     return (parsed or "").rstrip(".").lower()
 
 
+def _is_reserved_path(path: str) -> bool:
+    for prefix in _RESERVED_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
+
+
+def _is_allowed_on_custom_tenant(path: str) -> bool:
+    if path == "/":
+        return False
+    if _is_reserved_path(path):
+        return False
+    if path in _ALLOWED_EXACT_PATHS:
+        return True
+    return bool(_ALIAS_PATTERN.match(path))
+
+
 class TenantMiddleware(BaseHTTPMiddleware):
-    """Populates request.state.tenant from the request Host header."""
+    """Populates request.state.tenant from the request Host header.
+
+    On custom tenants additionally enforces the allowlist routing policy
+    documented at the top of this module and stamps the noindex header on
+    every response.
+    """
 
     async def dispatch(self, request: Request, call_next) -> Response:
         resolver: TenantResolver | None = getattr(
@@ -51,15 +139,35 @@ class TenantMiddleware(BaseHTTPMiddleware):
 
         tenant: TenantInfo | None = await resolver.resolve(host)
         request.state.tenant = tenant
+
         if tenant is None:
             log.info("tenant_unknown_host", host=host)
-            # Static HTML 404 — browser-friendly, no template deps, no
-            # tenancy details leaked.
             return HTMLResponse(_NOT_FOUND_BODY, status_code=404)
-        return await call_next(request)
 
+        if tenant.is_system_default:
+            return await call_next(request)
 
-_NOT_FOUND_BODY = (
-    "<!doctype html><html><head><title>404 — Not Found</title></head>"
-    "<body><h1>404</h1><p>URL not found.</p></body></html>"
-)
+        path = request.url.path
+
+        if path == "/robots.txt":
+            return PlainTextResponse(
+                _CUSTOM_TENANT_ROBOTS_BODY,
+                headers={"X-Robots-Tag": _NOINDEX_HEADER},
+            )
+
+        if not _is_allowed_on_custom_tenant(path):
+            log.info(
+                "tenant_path_denied",
+                host=host,
+                path=path,
+                method=request.method,
+            )
+            return HTMLResponse(
+                _NOT_FOUND_BODY,
+                status_code=404,
+                headers={"X-Robots-Tag": _NOINDEX_HEADER},
+            )
+
+        response = await call_next(request)
+        response.headers["X-Robots-Tag"] = _NOINDEX_HEADER
+        return response

--- a/middleware/tenant.py
+++ b/middleware/tenant.py
@@ -107,14 +107,24 @@ def _is_reserved_path(path: str) -> bool:
     return False
 
 
-def _is_allowed_on_custom_tenant(path: str) -> bool:
+def _is_allowed_on_custom_tenant(path: str, method: str) -> bool:
+    """Custom-tenant allowlist gate. Path-and-method check so disallowed
+    methods on allowed paths (e.g. ``DELETE /<alias>``) return our 404
+    instead of Starlette's 405, preserving the strict deny policy."""
     if path == "/":
         return False
     if _is_reserved_path(path):
         return False
     if path in _ALLOWED_EXACT_PATHS:
-        return True
-    return bool(_ALIAS_PATTERN.match(path))
+        # Static assets (favicon) are read-only.
+        return method in {"GET", "HEAD"}
+    if _ALIAS_PATTERN.match(path):
+        # `/<alias>/password` is a form POST; everything else under the alias
+        # namespace (the redirect) is GET/HEAD only.
+        if path.endswith("/password"):
+            return method == "POST"
+        return method in {"GET", "HEAD"}
+    return False
 
 
 class TenantMiddleware(BaseHTTPMiddleware):
@@ -150,12 +160,18 @@ class TenantMiddleware(BaseHTTPMiddleware):
         path = request.url.path
 
         if path == "/robots.txt":
+            if request.method not in {"GET", "HEAD"}:
+                return HTMLResponse(
+                    _NOT_FOUND_BODY,
+                    status_code=404,
+                    headers={"X-Robots-Tag": _NOINDEX_HEADER},
+                )
             return PlainTextResponse(
                 _CUSTOM_TENANT_ROBOTS_BODY,
                 headers={"X-Robots-Tag": _NOINDEX_HEADER},
             )
 
-        if not _is_allowed_on_custom_tenant(path):
+        if not _is_allowed_on_custom_tenant(path, request.method):
             log.info(
                 "tenant_path_denied",
                 host=host,

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -53,6 +53,53 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         """Hard-delete a URL document. Returns True if a document was deleted."""
         return await self._delete({"_id": url_id})
 
+    async def list_aliases_by_owner_and_domain(
+        self, owner_id: ObjectId, domain: str
+    ) -> list[str]:
+        """Return all aliases owned by *owner_id* under *domain*.
+
+        Used by bulk-delete to drive cache invalidation. Two-step (list then
+        delete) trades atomicity for explicit cache cleanup — a cache miss
+        post-delete is correct behavior anyway.
+        """
+        try:
+            cursor = self._col.find(
+                {"owner_id": owner_id, "domain": domain},
+                projection={"alias": 1, "_id": 0},
+            )
+            docs = await cursor.to_list(length=None)
+            return [d["alias"] for d in docs if "alias" in d]
+        except PyMongoError as exc:
+            log.error(
+                "repo_list_aliases_failed",
+                collection=self._collection_name,
+                error=str(exc),
+            )
+            raise
+
+    async def delete_many_by_owner_and_domain(
+        self, owner_id: ObjectId, domain: str
+    ) -> int:
+        """Bulk-delete all URLs owned by *owner_id* under *domain*.
+
+        Both filters required defensively — a missing or empty arg here would
+        silently delete more than intended.
+        """
+        if not owner_id or not domain:
+            raise ValueError("owner_id and domain are both required for bulk delete")
+        try:
+            result = await self._col.delete_many(
+                {"owner_id": owner_id, "domain": domain}
+            )
+            return int(result.deleted_count or 0)
+        except PyMongoError as exc:
+            log.error(
+                "repo_delete_many_failed",
+                collection=self._collection_name,
+                error=str(exc),
+            )
+            raise
+
     async def check_alias_exists(self, alias: str, domain: str) -> bool:
         """Return True if the alias is taken under the given domain namespace."""
         doc = await self._find_one_raw({"alias": alias, "domain": domain}, {"_id": 1})

--- a/routes/api_v1/__init__.py
+++ b/routes/api_v1/__init__.py
@@ -2,7 +2,15 @@
 
 from fastapi import APIRouter
 
-from routes.api_v1 import exports, keys, management, shorten, stats, urls
+from routes.api_v1 import (
+    custom_domains,
+    exports,
+    keys,
+    management,
+    shorten,
+    stats,
+    urls,
+)
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(shorten.router)
@@ -11,3 +19,4 @@ router.include_router(management.router)
 router.include_router(stats.router)
 router.include_router(exports.router)
 router.include_router(keys.router)
+router.include_router(custom_domains.router)

--- a/routes/api_v1/custom_domains.py
+++ b/routes/api_v1/custom_domains.py
@@ -161,6 +161,33 @@ async def list_custom_domains(
     )
 
 
+@router.get(
+    "/custom-domains/{domain_id}",
+    responses=ERROR_RESPONSES,
+    operation_id="getCustomDomain",
+    summary="Get Custom Domain",
+)
+@limiter.limit(Limits.DOMAIN_READ)
+async def get_custom_domain(
+    request: Request,
+    domain_id: Annotated[str, Path(description="MongoDB ObjectId of the domain.")],
+    service: CustomDomainSvc,
+    user: CurrentUser = Depends(require_scopes(DOMAIN_READ_SCOPES)),  # noqa: B008
+) -> CustomDomainResponse:
+    """Fetch a single custom domain owned by the caller.
+
+    Used by the dashboard detail view + auto-poll after Verify. Bypasses the
+    feature flag like other read endpoints.
+
+    **Authentication**: Required (JWT or API key with `domains:read`).
+
+    **Rate Limits**: 60/min.
+    """
+    oid = _parse_domain_id(domain_id)
+    doc = await service.get_owned_by_id(oid, user)
+    return CustomDomainResponse.from_doc(doc)
+
+
 @router.delete(
     "/custom-domains/{domain_id}",
     responses=AUTH_RESPONSES,

--- a/routes/api_v1/custom_domains.py
+++ b/routes/api_v1/custom_domains.py
@@ -1,0 +1,212 @@
+"""
+POST   /api/v1/custom-domains              — register a new custom domain
+POST   /api/v1/custom-domains/{id}/verify  — trigger verification
+GET    /api/v1/custom-domains              — list owned domains (paginated)
+DELETE /api/v1/custom-domains/{id}         — revoke (?cascade=true also deletes URLs)
+
+CREATE is gated on a verified email + the ``custom_domains`` feature flag.
+Read/verify/delete bypass the flag so existing owners can manage state during
+rollback.
+
+API key scopes: ``domains:manage`` (create/verify/delete) and ``domains:read``
+(list). JWT bearer works for any operation without scopes.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, Path, Query, Request
+
+from dependencies import (
+    DOMAIN_MANAGE_SCOPES,
+    DOMAIN_READ_SCOPES,
+    CurrentUser,
+    CustomDomainSvc,
+    FeatureFlagSvc,
+    require_scopes,
+    require_scopes_verified,
+)
+from errors import NotFoundError
+from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
+from middleware.rate_limiter import Limits, limiter
+from schemas.dto.requests.custom_domain import (
+    CreateCustomDomainRequest,
+    ListCustomDomainsQuery,
+    VerifyCustomDomainRequest,
+)
+from schemas.dto.responses.custom_domain import (
+    CustomDomainDeleteResponse,
+    CustomDomainListResponse,
+    CustomDomainResponse,
+)
+
+router = APIRouter(tags=["Custom Domains"])
+
+_FEATURE_FLAG = "custom_domains"
+
+
+def _parse_domain_id(domain_id: str) -> ObjectId:
+    """Parse the path param to ObjectId or raise 404.
+
+    404 (not 400) hides existence of the feature for non-allowlisted users
+    poking the endpoint with bogus IDs."""
+    try:
+        return ObjectId(domain_id)
+    except Exception:
+        raise NotFoundError("domain not found") from None
+
+
+async def _require_create_enabled(flag_svc: FeatureFlagSvc, user: CurrentUser) -> None:
+    """Flag gate for CREATE. 404 (not 403) — don't leak feature existence."""
+    if not await flag_svc.is_enabled(_FEATURE_FLAG, user):
+        raise NotFoundError("not found")
+
+
+@router.post(
+    "/custom-domains",
+    status_code=201,
+    responses=AUTH_RESPONSES,
+    operation_id="createCustomDomain",
+    summary="Register Custom Domain",
+)
+@limiter.limit(Limits.DOMAIN_CREATE)
+async def create_custom_domain(
+    request: Request,
+    body: CreateCustomDomainRequest,
+    service: CustomDomainSvc,
+    flag_svc: FeatureFlagSvc,
+    user: CurrentUser = Depends(require_scopes_verified(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
+) -> CustomDomainResponse:
+    """Register a new custom domain for branded short links.
+
+    The domain is born in `PENDING` state. The user must publish the DNS
+    records returned in `dns_records` at their DNS provider, then call
+    `POST /custom-domains/{id}/verify` to trigger verification. Cloudflare
+    auto-verifies via HTTP DCV once the CNAME is live and propagated.
+
+    **Authentication**: Required (JWT Bearer or API key with `domains:manage`).
+
+    **Email verification**: Required (applies to API key callers too).
+
+    **Feature gate**: Must be enabled for the calling user.
+
+    **Rate Limits**: 5/hour (route) + 3/day per user (service quota).
+    """
+    await _require_create_enabled(flag_svc, user)
+    doc = await service.create(body, user)
+    return CustomDomainResponse.from_doc(doc)
+
+
+@router.post(
+    "/custom-domains/{domain_id}/verify",
+    responses=AUTH_RESPONSES,
+    operation_id="verifyCustomDomain",
+    summary="Verify Custom Domain",
+)
+@limiter.limit(Limits.DOMAIN_VERIFY)
+async def verify_custom_domain(
+    request: Request,
+    domain_id: Annotated[
+        str, Path(min_length=24, max_length=24, pattern=r"^[0-9a-f]{24}$")
+    ],
+    body: VerifyCustomDomainRequest,
+    service: CustomDomainSvc,
+    user: CurrentUser = Depends(require_scopes(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
+) -> CustomDomainResponse:
+    """Trigger a fresh verification check for a custom domain.
+
+    The verifier dispatched depends on the chosen DCV method (CF HTTP DCV on
+    CF SaaS deployments, CNAME/A/TXT on self-host). On success the domain
+    transitions to `ACTIVE` and short links on the domain start resolving.
+
+    **Authentication**: Required (JWT or API key with `domains:manage`).
+
+    **Rate Limits**: 10/min (route) + 60/hour per domain (service quota).
+    """
+    oid = _parse_domain_id(domain_id)
+    doc = await service.verify(oid, user)
+    return CustomDomainResponse.from_doc(doc)
+
+
+@router.get(
+    "/custom-domains",
+    responses=ERROR_RESPONSES,
+    operation_id="listCustomDomains",
+    summary="List Custom Domains",
+)
+@limiter.limit(Limits.DOMAIN_READ)
+async def list_custom_domains(
+    request: Request,
+    query: Annotated[ListCustomDomainsQuery, Query()],
+    service: CustomDomainSvc,
+    user: CurrentUser = Depends(require_scopes(DOMAIN_READ_SCOPES)),  # noqa: B008
+) -> CustomDomainListResponse:
+    """List custom domains owned by the authenticated user.
+
+    Reads bypass the feature flag so owners can still see state during a
+    rollback.
+
+    **Authentication**: Required (JWT or API key with `domains:read`).
+
+    **Rate Limits**: 60/min.
+
+    **Pagination**: `page` (default 1) + `pageSize` (default 20, max 100).
+    """
+    items, total = await service.list_by_owner(user, query)
+    has_next = query.page * query.page_size < total
+    return CustomDomainListResponse(
+        items=[CustomDomainResponse.from_doc(doc) for doc in items],
+        page=query.page,
+        pageSize=query.page_size,
+        total=total,
+        hasNext=has_next,
+    )
+
+
+@router.delete(
+    "/custom-domains/{domain_id}",
+    responses=AUTH_RESPONSES,
+    operation_id="deleteCustomDomain",
+    summary="Revoke Custom Domain",
+)
+@limiter.limit(Limits.DOMAIN_DELETE)
+async def delete_custom_domain(
+    request: Request,
+    domain_id: Annotated[
+        str, Path(min_length=24, max_length=24, pattern=r"^[0-9a-f]{24}$")
+    ],
+    service: CustomDomainSvc,
+    cascade: bool = Query(
+        default=False,
+        description=(
+            "When true, all URLs on this domain are deleted alongside the "
+            "domain revoke. When false (default), URLs remain in the database "
+            "but become unreachable (the domain stops resolving)."
+        ),
+    ),
+    user: CurrentUser = Depends(require_scopes(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
+) -> CustomDomainDeleteResponse:
+    """Revoke a custom domain. `REVOKED` is terminal.
+
+    With `?cascade=true`, all URLs owned by the caller on the domain are
+    bulk-deleted. With `?cascade=false` (default), URLs remain in the
+    database and the domain stops serving — the URLs effectively become
+    orphans until the domain is re-registered or garbage-collected.
+
+    **Authentication**: Required (JWT or API key with `domains:manage`).
+
+    **Rate Limits**: 10/min.
+    """
+    oid = _parse_domain_id(domain_id)
+    doc, urls_deleted = await service.delete(oid, user, cascade=cascade)
+    return CustomDomainDeleteResponse(
+        id=str(doc.id),
+        fqdn=doc.fqdn,
+        cascade=cascade,
+        urls_deleted=urls_deleted,
+    )
+
+
+__all__ = ["router"]

--- a/routes/api_v1/custom_domains.py
+++ b/routes/api_v1/custom_domains.py
@@ -34,7 +34,6 @@ from middleware.rate_limiter import Limits, limiter
 from schemas.dto.requests.custom_domain import (
     CreateCustomDomainRequest,
     ListCustomDomainsQuery,
-    VerifyCustomDomainRequest,
 )
 from schemas.dto.responses.custom_domain import (
     CustomDomainDeleteResponse,
@@ -108,10 +107,7 @@ async def create_custom_domain(
 @limiter.limit(Limits.DOMAIN_VERIFY)
 async def verify_custom_domain(
     request: Request,
-    domain_id: Annotated[
-        str, Path(min_length=24, max_length=24, pattern=r"^[0-9a-f]{24}$")
-    ],
-    body: VerifyCustomDomainRequest,
+    domain_id: Annotated[str, Path(description="MongoDB ObjectId of the domain.")],
     service: CustomDomainSvc,
     user: CurrentUser = Depends(require_scopes(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
 ) -> CustomDomainResponse:
@@ -174,9 +170,7 @@ async def list_custom_domains(
 @limiter.limit(Limits.DOMAIN_DELETE)
 async def delete_custom_domain(
     request: Request,
-    domain_id: Annotated[
-        str, Path(min_length=24, max_length=24, pattern=r"^[0-9a-f]{24}$")
-    ],
+    domain_id: Annotated[str, Path(description="MongoDB ObjectId of the domain.")],
     service: CustomDomainSvc,
     cascade: bool = Query(
         default=False,

--- a/routes/api_v1/shorten.py
+++ b/routes/api_v1/shorten.py
@@ -3,6 +3,10 @@ POST /api/v1/shorten — create a shortened URL.
 
 Returns 201 on success with the URL details.
 Auth is optional; API key users require `shorten:create` or `admin:all` scope.
+
+When ``domain`` is supplied the route layer asserts the caller owns an ACTIVE
+custom domain with that fqdn before delegating to ``UrlService.create``. Short
+URL is built from the custom host. Anonymous callers cannot specify ``domain``.
 """
 
 from __future__ import annotations
@@ -14,10 +18,12 @@ from fastapi import APIRouter, Depends, Query, Request
 from dependencies import (
     SHORTEN_SCOPES,
     CurrentUser,
+    CustomDomainSvc,
     Settings,
     UrlSvc,
     optional_scopes_verified,
 )
+from errors import AuthenticationError
 from middleware.openapi import AUTH_RESPONSES, OPTIONAL_AUTH_SECURITY
 from middleware.rate_limiter import Limits, dynamic_limit, limiter
 from schemas.dto.requests.url import AliasCheckQuery, CreateUrlRequest
@@ -43,15 +49,18 @@ async def shorten_v1(
     request: Request,
     body: CreateUrlRequest,
     url_service: UrlSvc,
+    custom_domain_service: CustomDomainSvc,
     settings: Settings,
     user: CurrentUser | None = Depends(optional_scopes_verified(SHORTEN_SCOPES)),  # noqa: B008
 ) -> UrlResponse:
     """Create a new shortened URL.
 
-    Create a shortened URL with optional customization including password protection,
-    expiration, click limits, and bot blocking.
+    Create a shortened URL with optional customization including password
+    protection, expiration, click limits, and bot blocking. Authenticated
+    users may target an owned, ACTIVE custom domain via the ``domain`` field.
 
     **Authentication**: Optional — higher rate limits when authenticated.
+    Required if ``domain`` is supplied.
 
     **API Key Scope**: `shorten:create` or `admin:all`
 
@@ -66,12 +75,25 @@ async def shorten_v1(
     - Cannot manage or view URLs later
     - Cannot use private stats
     - URLs not linked to any account
+    - Cannot use custom domains
     """
     owner_id = user.user_id if user is not None else None
     client_ip = get_client_ip(request)
 
-    doc = await url_service.create(body, owner_id, client_ip)
-    return UrlResponse.from_doc(doc, settings.app_url)
+    if body.domain and body.domain != settings.system_default_domain:
+        if user is None:
+            raise AuthenticationError(
+                "Authentication required to shorten on a custom domain"
+            )
+        await custom_domain_service.assert_owned_and_active(user, body.domain)
+        base_url = f"https://{body.domain}"
+        scoped_domain: str | None = body.domain
+    else:
+        base_url = settings.app_url
+        scoped_domain = None
+
+    doc = await url_service.create(body, owner_id, client_ip, domain=scoped_domain)
+    return UrlResponse.from_doc(doc, base_url)
 
 
 @router.get(

--- a/routes/api_v1/urls.py
+++ b/routes/api_v1/urls.py
@@ -1,7 +1,9 @@
 """
-GET /api/v1/urls — list authenticated user's shortened URLs.
+GET    /api/v1/urls            — list authenticated user's shortened URLs
+DELETE /api/v1/urls?domain=    — bulk-delete URLs scoped to one custom domain
 
-Requires authentication. Returns paginated list with camelCase keys.
+Requires authentication. Listing returns paginated list with camelCase keys.
+Bulk delete is owner-scoped and refuses the system-default namespace.
 """
 
 from __future__ import annotations
@@ -11,15 +13,22 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query, Request
 
 from dependencies import (
+    URL_MANAGEMENT_SCOPES,
     URL_READ_SCOPES,
     CurrentUser,
+    CustomDomainSvc,
     UrlSvc,
     require_scopes,
 )
-from middleware.openapi import ERROR_RESPONSES
+from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.dto.requests.url import ListUrlsQuery
-from schemas.dto.responses.url import UrlListItem, UrlListResponse
+from schemas.dto.responses.url import (
+    BulkDeleteUrlsResponse,
+    UrlListItem,
+    UrlListResponse,
+)
+from shared.url_utils import normalise_fqdn
 
 router = APIRouter(tags=["Link Management"])
 
@@ -61,3 +70,47 @@ async def list_urls_v1(
     result = await url_service.list_by_owner(user.user_id, query)
     result["items"] = [UrlListItem.from_doc(doc) for doc in result["items"]]
     return result
+
+
+@router.delete(
+    "/urls",
+    responses=AUTH_RESPONSES,
+    operation_id="bulkDeleteUrls",
+    summary="Bulk Delete URLs on a Custom Domain",
+)
+@limiter.limit(Limits.URL_BULK_DELETE)
+async def bulk_delete_urls_v1(
+    request: Request,
+    domain: Annotated[
+        str,
+        Query(
+            min_length=1,
+            max_length=253,
+            description="Custom domain fqdn whose URLs should be deleted.",
+            examples=["links.acme.com"],
+        ),
+    ],
+    url_service: UrlSvc,
+    custom_domain_service: CustomDomainSvc,
+    user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
+) -> BulkDeleteUrlsResponse:
+    """Bulk-delete all URLs the caller owns on the given custom domain.
+
+    **Authentication**: Required.
+
+    **API Key Scope**: `urls:manage` or `admin:all`
+
+    **Rate Limits**: 5/min, 50/day.
+
+    **Restrictions**: refuses the system-default domain — protects against
+    accidental nuke of the user's entire spoo.me URL inventory. Caller must
+    own the domain.
+    """
+    fqdn = normalise_fqdn(domain)
+    await custom_domain_service.assert_owned(user, fqdn)
+    count = await url_service.delete_all_by_domain(user.user_id, fqdn)
+    return BulkDeleteUrlsResponse(
+        message=f"deleted {count} URL(s) on {fqdn}",
+        count=count,
+        domain=fqdn,
+    )

--- a/routes/api_v1/urls.py
+++ b/routes/api_v1/urls.py
@@ -20,6 +20,7 @@ from dependencies import (
     UrlSvc,
     require_scopes,
 )
+from errors import ValidationError
 from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.dto.requests.url import ListUrlsQuery
@@ -106,7 +107,10 @@ async def bulk_delete_urls_v1(
     accidental nuke of the user's entire spoo.me URL inventory. Caller must
     own the domain.
     """
-    fqdn = normalise_fqdn(domain)
+    try:
+        fqdn = normalise_fqdn(domain)
+    except ValueError as exc:
+        raise ValidationError(str(exc), field="domain") from exc
     await custom_domain_service.assert_owned(user, fqdn)
     count = await url_service.delete_all_by_domain(user.user_id, fqdn)
     return BulkDeleteUrlsResponse(

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -96,6 +96,16 @@ async def dashboard_keys(
     return await _render_dashboard_page("dashboard/keys.html", request, user, svc)
 
 
+@router.get("/domains")
+@limiter.limit(Limits.DASHBOARD_READ)
+async def dashboard_domains(
+    request: Request,
+    user: OptionalUser,
+    svc: ProfilePictureSvc,
+) -> Response:
+    return await _render_dashboard_page("dashboard/domains.html", request, user, svc)
+
+
 @router.get("/statistics")
 @limiter.limit(Limits.DASHBOARD_READ)
 async def dashboard_statistics(

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -54,10 +54,21 @@ async def _render_dashboard_page(
     if user is None:
         return _unauth_redirect()
     profile = await svc.get_dashboard_profile(user.user_id)
+    flag_svc = getattr(request.app.state, "feature_flag_service", None)
+    show_custom_domains = False
+    if flag_svc is not None:
+        try:
+            show_custom_domains = await flag_svc.is_enabled("custom_domains", user)
+        except Exception as exc:
+            log.warning("dashboard_flag_lookup_failed", error=str(exc))
     return templates.TemplateResponse(
         request,
         template_name,
-        {"host_url": str(request.base_url), "user": profile},
+        {
+            "host_url": str(request.base_url),
+            "user": profile,
+            "show_custom_domains": show_custom_domains,
+        },
     )
 
 
@@ -103,6 +114,13 @@ async def dashboard_domains(
     user: OptionalUser,
     svc: ProfilePictureSvc,
 ) -> Response:
+    if user is None:
+        return _unauth_redirect()
+    # Direct-URL guard: non-allowlisted users get bounced to /dashboard/links
+    # instead of seeing an empty/teaser page. Sidebar nav is hidden the same way.
+    flag_svc = getattr(request.app.state, "feature_flag_service", None)
+    if flag_svc is not None and not await flag_svc.is_enabled("custom_domains", user):
+        return RedirectResponse("/dashboard/links", status_code=302)
     return await _render_dashboard_page("dashboard/domains.html", request, user, svc)
 
 

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -146,7 +146,7 @@ async def redirect_url(
             slow=total_ms > 100,
         )
     resp = RedirectResponse(url_data.long_url, status_code=302)
-    resp.headers["X-Robots-Tag"] = "noindex, nofollow"
+    resp.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
     return resp
 
 

--- a/schemas/dto/requests/api_key.py
+++ b/schemas/dto/requests/api_key.py
@@ -20,6 +20,8 @@ class ApiKeyScope(str, Enum):
     URLS_MANAGE = "urls:manage"
     URLS_READ = "urls:read"
     STATS_READ = "stats:read"
+    DOMAINS_MANAGE = "domains:manage"
+    DOMAINS_READ = "domains:read"
     ADMIN_ALL = "admin:all"
 
 

--- a/schemas/dto/requests/url.py
+++ b/schemas/dto/requests/url.py
@@ -21,6 +21,7 @@ from schemas.dto.base import RequestBase
 from schemas.dto.requests._descriptions import LIST_URLS_FILTER_DESC
 from schemas.models.url import UrlStatus
 from shared.datetime_utils import parse_datetime
+from shared.url_utils import normalise_fqdn
 
 ALLOWED_SORT_FIELDS = frozenset({"created_at", "last_click", "total_clicks"})
 
@@ -90,6 +91,16 @@ class CreateUrlRequest(RequestBase):
         default=None,
         description="Make statistics private (only owner can view). Requires authentication.",
     )
+    domain: str | None = Field(
+        default=None,
+        max_length=253,
+        description=(
+            "Custom domain fqdn to scope the short link under (e.g. "
+            "`links.acme.com`). Requires authentication and ownership of an "
+            "ACTIVE custom domain. Omit for the default spoo.me namespace."
+        ),
+        examples=["links.acme.com"],
+    )
 
     @field_validator("expire_after", mode="before")
     @classmethod
@@ -100,6 +111,13 @@ class CreateUrlRequest(RequestBase):
         if result is None:
             raise ValueError("Invalid expire_after format")
         return result
+
+    @field_validator("domain", mode="before")
+    @classmethod
+    def _norm_domain(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        return normalise_fqdn(v)
 
 
 class UpdateUrlRequest(RequestBase):
@@ -230,8 +248,21 @@ class ListUrlsQuery(RequestBase):
         alias="filterBy",
         description="Alias for filter parameter.",
     )
+    domain: str | None = Field(
+        default=None,
+        max_length=253,
+        description="Filter URLs by exact custom domain fqdn.",
+        examples=["links.acme.com"],
+    )
     # Parsed result — populated by the model validator, invisible to FastAPI/OpenAPI
     _parsed_filter: UrlFilter | None = PrivateAttr(default=None)
+
+    @field_validator("domain", mode="before")
+    @classmethod
+    def _norm_domain(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        return normalise_fqdn(v)
 
     @model_validator(mode="after")
     def _parse_filter_json(self) -> ListUrlsQuery:

--- a/schemas/dto/responses/custom_domain.py
+++ b/schemas/dto/responses/custom_domain.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import Field
 
@@ -11,43 +12,47 @@ from schemas.enums.domain_status import DomainStatus, VerificationMethod
 from schemas.models.custom_domain import CustomDomainDoc
 
 
+class DnsRecord(ResponseBase):
+    """One DNS record the user must publish to complete setup."""
+
+    type: Literal["CNAME", "TXT", "A"] = Field(description="Record type.")
+    name: str = Field(description="Record name (subdomain or @ for apex).")
+    value: str = Field(description="Record value.")
+    purpose: str | None = Field(
+        default=None,
+        description="Human-readable note explaining why this record is needed.",
+    )
+
+
 class CustomDomainResponse(ResponseBase):
-    """A single custom domain — covers create, get, and verify responses."""
+    """A single custom domain — covers create, get, verify, and list responses."""
 
     id: str = Field(description="Server-generated domain ID.")
     fqdn: str = Field(description="Canonical fqdn (lowercased, trailing dot stripped).")
     status: DomainStatus
     verification_method: VerificationMethod
-    # Returned only when verification_method == TXT_CHALLENGE; clients echo
-    # this into a `_spoo-challenge.<fqdn>` TXT record to prove ownership.
-    verification_token: str | None = None
-    # Free-form, human-readable instructions for whichever verification
-    # method the client picked. Built at the route layer so the message can
-    # reference settings (cname target, origin IPv4 list).
-    setup_instructions: str | None = None
+    dns_records: list[DnsRecord] = Field(
+        default_factory=list,
+        description="DNS records the user must publish at their DNS provider.",
+    )
+    setup_notes: list[str] = Field(
+        default_factory=list,
+        description="Human-readable setup warnings/instructions specific to this domain.",
+    )
     created_at: datetime
     updated_at: datetime | None = None
     last_verified_at: datetime | None = None
     last_verification_error: str | None = None
 
     @classmethod
-    def from_doc(
-        cls,
-        doc: CustomDomainDoc,
-        setup_instructions: str | None = None,
-    ) -> CustomDomainResponse:
+    def from_doc(cls, doc: CustomDomainDoc) -> CustomDomainResponse:
         return cls(
             id=str(doc.id),
             fqdn=doc.fqdn,
             status=doc.status,
             verification_method=doc.verification_method,
-            # Surface the TXT token only when the chosen method needs it.
-            verification_token=(
-                doc.verification_token
-                if doc.verification_method == VerificationMethod.TXT_CHALLENGE
-                else None
-            ),
-            setup_instructions=setup_instructions,
+            dns_records=[DnsRecord(**r) for r in doc.dns_instructions],
+            setup_notes=list(doc.setup_notes),
             created_at=doc.created_at,
             updated_at=doc.updated_at,
             last_verified_at=doc.last_verified_at,
@@ -63,3 +68,14 @@ class CustomDomainListResponse(ResponseBase):
     page_size: int = Field(alias="pageSize")
     total: int
     has_next: bool = Field(alias="hasNext")
+
+
+class CustomDomainDeleteResponse(ResponseBase):
+    """Response for domain revoke. ``urls_deleted`` is 0 unless cascade was true."""
+
+    id: str = Field(description="ID of the revoked domain.")
+    fqdn: str = Field(description="The revoked fqdn.")
+    cascade: bool = Field(description="Whether URLs on the domain were also deleted.")
+    urls_deleted: int = Field(
+        description="URL count deleted by cascade (0 when cascade=false)."
+    )

--- a/schemas/dto/responses/custom_domain.py
+++ b/schemas/dto/responses/custom_domain.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_serializer
 
 from schemas.dto.base import ResponseBase
 from schemas.enums.domain_status import DomainStatus, VerificationMethod
@@ -43,6 +43,17 @@ class CustomDomainResponse(ResponseBase):
     updated_at: datetime | None = None
     last_verified_at: datetime | None = None
     last_verification_error: str | None = None
+
+    @field_serializer("created_at", "updated_at", "last_verified_at")
+    def _ser_as_utc(self, dt: datetime | None) -> str | None:
+        # PyMongo returns naive datetimes; without explicit tzinfo the JSON
+        # form omits the offset and clients parse it as local time. Stamp
+        # UTC so the wire format is unambiguous (`...+00:00`).
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
 
     @classmethod
     def from_doc(cls, doc: CustomDomainDoc) -> CustomDomainResponse:

--- a/schemas/dto/responses/url.py
+++ b/schemas/dto/responses/url.py
@@ -54,11 +54,16 @@ class UrlResponse(ResponseBase):
     )
 
     @classmethod
-    def from_doc(cls, doc: UrlV2Doc, app_url: str) -> UrlResponse:
-        """Build from a UrlV2Doc and the application base URL."""
+    def from_doc(cls, doc: UrlV2Doc, base_url: str) -> UrlResponse:
+        """Build from a UrlV2Doc and the canonical base URL.
+
+        ``base_url`` is the public origin under which the short link will be
+        served — ``settings.app_url`` for system-default URLs and
+        ``https://<fqdn>`` for custom domains. Built at the route layer.
+        """
         return cls(
             alias=doc.alias,
-            short_url=f"{app_url.rstrip('/')}/{doc.alias}",
+            short_url=f"{base_url.rstrip('/')}/{doc.alias}",
             long_url=doc.long_url,
             owner_id=str(doc.owner_id)
             if doc.owner_id and doc.owner_id != ANONYMOUS_OWNER_ID
@@ -143,6 +148,7 @@ class UrlListItem(ResponseBase):
     password_set: bool
     total_clicks: int | None = None
     last_click: datetime | None = None
+    domain: str | None = None
 
     @classmethod
     def from_doc(cls, doc: UrlV2Doc) -> UrlListItem:
@@ -168,6 +174,7 @@ class UrlListItem(ResponseBase):
             password_set=doc.password is not None,
             total_clicks=doc.total_clicks,
             last_click=_ensure_utc(doc.last_click),
+            domain=doc.domain,
         )
 
 
@@ -177,6 +184,19 @@ class DeleteUrlResponse(ResponseBase):
     message: str = Field(description="Confirmation message.", examples=["URL deleted"])
     id: str = Field(
         description="ID of the deleted URL.", examples=["507f1f77bcf86cd799439011"]
+    )
+
+
+class BulkDeleteUrlsResponse(ResponseBase):
+    """Response body for DELETE /api/v1/urls?domain=<fqdn> (bulk delete)."""
+
+    message: str = Field(
+        description="Confirmation message.",
+        examples=["deleted 42 URLs on links.acme.com"],
+    )
+    count: int = Field(description="Number of URLs deleted.", examples=[42])
+    domain: str = Field(
+        description="Domain whose URLs were deleted.", examples=["links.acme.com"]
     )
 
 

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -15,7 +15,6 @@ from config import CustomDomainSettings
 from errors import (
     DomainAlreadyRegisteredError,
     DomainBlocklistedError,
-    DomainDnsNotPropagatedError,
     DomainNotVerifiedError,
     DomainQuotaExceededError,
     ForbiddenError,
@@ -98,7 +97,6 @@ class CustomDomainService:
         await self._enforce_uniqueness(request.fqdn)
         await self._enforce_per_user_quota(user.user_id)
         await self._enforce_create_attempts_quota(user.user_id)
-        await self._enforce_dns_preflight(request.fqdn)
 
         method = self._pick_verification_method(request.fqdn)
         if method not in self._verifiers:
@@ -188,6 +186,27 @@ class CustomDomainService:
 
         doc = await self._load_owned(domain_id, user)
         await self._enforce_verify_attempts_quota(domain_id)
+
+        # DNS preflight short-circuits CF API calls so unpropagated domains
+        # don't trigger CF's 15-min backoff. Soft failure: recorded as
+        # last_verification_error, not raised.
+        if self._preflight_cname_target:
+            preflight = await check_cname(doc.fqdn, self._preflight_cname_target)
+            if not preflight.ok:
+                await self._repo.update_status(
+                    doc.id,
+                    doc.status,
+                    last_verification_error=preflight.reason,
+                )
+                log.info(
+                    "audit.domain.preflight_failed",
+                    fqdn=doc.fqdn,
+                    domain_id=str(doc.id),
+                    owner_id=str(user.user_id),
+                    reason=preflight.reason,
+                )
+                refreshed = await self._repo.find_by_id(doc.id)
+                return refreshed or doc
 
         verifier = self._verifiers.get(doc.verification_method)
         if verifier is None:
@@ -448,6 +467,18 @@ class CustomDomainService:
             error=None if ok else f"caddy {kind} eviction failed",
         )
 
+    async def get_owned_by_id(
+        self,
+        domain_id: ObjectId,
+        user: CurrentUser,
+    ) -> CustomDomainDoc:
+        """Public read for the caller's domain by id. 403/404 same as mutations.
+
+        Used by the detail view, refresh-after-verify, and auto-poll. Bypasses
+        the master `enabled` flag so owners can see their state during rollback.
+        """
+        return await self._load_owned(domain_id, user)
+
     async def _load_owned(
         self, domain_id: ObjectId, user: CurrentUser
     ) -> CustomDomainDoc:
@@ -544,13 +575,6 @@ class CustomDomainService:
         except Exception as exc:
             log.warning("setup_notes_ns_lookup_failed", fqdn=fqdn, error=str(exc))
         return notes
-
-    async def _enforce_dns_preflight(self, fqdn: str) -> None:
-        if not self._preflight_cname_target:
-            return
-        result = await check_cname(fqdn, self._preflight_cname_target)
-        if not result.ok:
-            raise DomainDnsNotPropagatedError(result.reason)
 
     async def _enforce_blocklist(self, fqdn: str) -> None:
         # Live Mongo — operator can add an abuse domain via mongosh and the

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -121,7 +121,7 @@ class CustomDomainService:
         except DuplicateKeyError:
             # Race with concurrent insert — translate to 409 instead of 500.
             raise DomainAlreadyRegisteredError(
-                f"domain {request.fqdn!r} is already registered"
+                f"{request.fqdn} is already registered."
             ) from None
 
         try:
@@ -340,9 +340,9 @@ class CustomDomainService:
         too (cleanup path)."""
         doc = await self._repo.find_by_fqdn(fqdn)
         if doc is None:
-            raise NotFoundError(f"domain {fqdn!r} not found")
+            raise NotFoundError(f"{fqdn} is not registered.")
         if doc.owner_id != user.user_id:
-            raise ForbiddenError("you do not own this domain")
+            raise ForbiddenError("You do not own this domain.")
         return doc
 
     async def assert_owned_and_active(
@@ -354,7 +354,7 @@ class CustomDomainService:
         doc = await self.assert_owned(user, fqdn)
         if doc.status != DomainStatus.ACTIVE:
             raise DomainNotVerifiedError(
-                f"domain {fqdn!r} is {doc.status.value}, not ACTIVE"
+                f"{fqdn} isn't verified yet. Set up DNS and verify it first."
             )
         return doc
 
@@ -442,7 +442,7 @@ class CustomDomainService:
 
     def _require_enabled(self) -> None:
         if not self._settings.enabled:
-            raise DomainQuotaExceededError("custom domains are not currently enabled")
+            raise DomainQuotaExceededError("Custom domains aren't available yet.")
 
     async def _invalidate_cache(self, fqdn: str) -> None:
         """Best-effort tenant-cache eviction. Staleness is degraded UX, not data loss."""
@@ -484,9 +484,9 @@ class CustomDomainService:
     ) -> CustomDomainDoc:
         doc = await self._repo.find_by_id(domain_id)
         if doc is None:
-            raise NotFoundError(f"domain {domain_id} not found")
+            raise NotFoundError("Domain not found.")
         if doc.owner_id != user.user_id:
-            raise ForbiddenError("you do not own this domain")
+            raise ForbiddenError("You do not own this domain.")
         return doc
 
     async def _transition(
@@ -521,13 +521,15 @@ class CustomDomainService:
     async def _enforce_uniqueness(self, fqdn: str) -> None:
         existing = await self._repo.find_by_fqdn(fqdn)
         if existing is not None:
-            raise DomainAlreadyRegisteredError(f"domain {fqdn!r} is already registered")
+            raise DomainAlreadyRegisteredError(f"{fqdn} is already registered.")
 
     async def _enforce_per_user_quota(self, owner_id: ObjectId) -> None:
         current = await self._repo.count_by_owner(owner_id)
         if current >= self._settings.max_per_user:
+            cap = self._settings.max_per_user
+            suffix = "domain" if cap == 1 else "domains"
             raise DomainQuotaExceededError(
-                f"max custom domains per user reached ({self._settings.max_per_user})"
+                f"You've reached the limit of {cap} custom {suffix} for your account."
             )
 
     async def _enforce_create_attempts_quota(self, owner_id: ObjectId) -> None:
@@ -543,7 +545,9 @@ class CustomDomainService:
             log.warning("create_quota_redis_error", error=str(exc))
             return
         if count > self._settings.create_attempts_per_day:
-            raise DomainQuotaExceededError("too many domain create attempts today")
+            raise DomainQuotaExceededError(
+                "You've added too many domains today. Try again tomorrow."
+            )
 
     async def _enforce_verify_attempts_quota(self, domain_id: ObjectId) -> None:
         if self._redis is None:
@@ -557,7 +561,9 @@ class CustomDomainService:
             log.warning("verify_quota_redis_error", error=str(exc))
             return
         if count > self._settings.verify_attempts_per_hour:
-            raise DomainQuotaExceededError("too many verification attempts this hour")
+            raise DomainQuotaExceededError(
+                "Too many verification attempts. Try again in an hour."
+            )
 
     async def _build_setup_notes(self, fqdn: str) -> list[str]:
         # NS lookup is only meaningful on the CF SaaS path; grey-cloud is a
@@ -568,9 +574,9 @@ class CustomDomainService:
         try:
             if await uses_cloudflare_dns(fqdn):
                 notes.append(
-                    "Your domain uses Cloudflare DNS. Both DNS records must be "
-                    "set to **DNS only** (grey cloud), not Proxied (orange cloud), "
-                    "or CF SaaS validation will fail."
+                    "Cloudflare DNS detected. Set the record to DNS only "
+                    "(grey cloud icon), not Proxied (orange cloud), or "
+                    "verification will fail."
                 )
         except Exception as exc:
             log.warning("setup_notes_ns_lookup_failed", fqdn=fqdn, error=str(exc))
@@ -582,4 +588,4 @@ class CustomDomainService:
         if self._blocked_repo is None:
             return
         if await self._blocked_repo.is_blocked(fqdn):
-            raise DomainBlocklistedError(f"domain {fqdn!r} is on the blocklist")
+            raise DomainBlocklistedError("This domain isn't available.")

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -16,6 +16,7 @@ from errors import (
     DomainAlreadyRegisteredError,
     DomainBlocklistedError,
     DomainDnsNotPropagatedError,
+    DomainNotVerifiedError,
     DomainQuotaExceededError,
     ForbiddenError,
     InvalidDomainTransitionError,
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     import redis.asyncio as aioredis
 
     from dependencies.auth import CurrentUser
+    from services.url_service import UrlService
 
 log = get_logger(__name__)
 
@@ -67,6 +69,7 @@ class CustomDomainService:
         blocked_domain_repo: BlockedDomainRepository | None = None,
         redis_client: aioredis.Redis | None = None,
         preflight_cname_target: str | None = None,
+        url_service: UrlService | None = None,
     ) -> None:
         self._repo = repo
         self._verifiers = verifiers
@@ -78,6 +81,8 @@ class CustomDomainService:
         self._redis = redis_client
         # None = preflight off (tests, self-host LE).
         self._preflight_cname_target = preflight_cname_target
+        # None = cascade delete unavailable (tests). Production wiring sets this.
+        self._url_service = url_service
 
     # ── Public API ───────────────────────────────────────────────────
 
@@ -250,12 +255,46 @@ class CustomDomainService:
         self,
         domain_id: ObjectId,
         user: CurrentUser,
-    ) -> None:
-        """Revoke a custom domain. REVOKED is terminal."""
+        *,
+        cascade: bool = False,
+    ) -> tuple[CustomDomainDoc, int]:
+        """Revoke a custom domain. REVOKED is terminal.
+
+        When ``cascade=True``, bulk-deletes all URLs owned by the user on the
+        revoked fqdn. Returns ``(doc, urls_deleted)`` so callers can surface
+        the deletion count.
+
+        Order: transition to REVOKED FIRST so concurrent shortens can't sneak
+        in. Then bulk delete (best-effort — partial failure leaves orphans
+        for the PR5 GC worker). Then announce eviction + invalidate cache.
+        """
         self._require_enabled()
 
         doc = await self._load_owned(domain_id, user)
         await self._transition(doc, DomainStatus.REVOKED)
+
+        urls_deleted = 0
+        if cascade:
+            if self._url_service is None:
+                log.error(
+                    "audit.domain.cascade_unavailable",
+                    fqdn=doc.fqdn,
+                    domain_id=str(doc.id),
+                )
+            else:
+                try:
+                    urls_deleted = await self._url_service.delete_all_by_domain(
+                        user.user_id, doc.fqdn
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "audit.domain.cascade_partial",
+                        fqdn=doc.fqdn,
+                        domain_id=str(doc.id),
+                        owner_id=str(user.user_id),
+                        error=str(exc),
+                    )
+
         await self._announce_eviction(doc, kind="revoked")
         await self._invalidate_cache(doc.fqdn)
 
@@ -264,7 +303,41 @@ class CustomDomainService:
             fqdn=doc.fqdn,
             domain_id=str(doc.id),
             owner_id=str(user.user_id),
+            cascade=cascade,
+            urls_deleted=urls_deleted,
         )
+
+        refreshed = await self._repo.find_by_id(doc.id)
+        return refreshed or doc, urls_deleted
+
+    async def assert_owned(
+        self,
+        user: CurrentUser,
+        fqdn: str,
+    ) -> CustomDomainDoc:
+        """Find domain by fqdn, raise 403/404. No status check.
+
+        Used by bulk URL delete which should work on revoked/suspended domains
+        too (cleanup path)."""
+        doc = await self._repo.find_by_fqdn(fqdn)
+        if doc is None:
+            raise NotFoundError(f"domain {fqdn!r} not found")
+        if doc.owner_id != user.user_id:
+            raise ForbiddenError("you do not own this domain")
+        return doc
+
+    async def assert_owned_and_active(
+        self,
+        user: CurrentUser,
+        fqdn: str,
+    ) -> CustomDomainDoc:
+        """Find domain, assert ownership + ACTIVE. Used by shorten flow."""
+        doc = await self.assert_owned(user, fqdn)
+        if doc.status != DomainStatus.ACTIVE:
+            raise DomainNotVerifiedError(
+                f"domain {fqdn!r} is {doc.status.value}, not ACTIVE"
+            )
+        return doc
 
     async def is_allowed_for_caddy(self, fqdn: str) -> bool:
         """Caddy on-demand TLS ask endpoint. Default-deny; wired when the

--- a/services/dns_preflight.py
+++ b/services/dns_preflight.py
@@ -46,7 +46,7 @@ async def check_cname(fqdn: str, expected_target: str) -> PreflightResult:
         return PreflightResult(
             ok=False,
             reason=(
-                f"Your CNAME points to {observed} — it should point to {target}. "
+                f"Your CNAME points to {observed} - It should point to {target}. "
                 f"Update the record at your DNS provider."
             ),
         )
@@ -62,7 +62,7 @@ async def check_cname(fqdn: str, expected_target: str) -> PreflightResult:
     return PreflightResult(
         ok=False,
         reason=(
-            "DNS isn't reaching us yet — this is normal right after adding the "
+            "DNS isn't reaching us yet - This is normal right after adding the "
             "records. Try again in a few minutes."
         ),
     )

--- a/services/dns_preflight.py
+++ b/services/dns_preflight.py
@@ -42,11 +42,12 @@ async def check_cname(fqdn: str, expected_target: str) -> PreflightResult:
     if matched:
         return PreflightResult(ok=True)
     if seen_targets:
+        observed = sorted(set(seen_targets))[0]
         return PreflightResult(
             ok=False,
             reason=(
-                f"{fqdn}: CNAME currently resolves to {sorted(set(seen_targets))!r}, "
-                f"expected {target!r}. Fix the record at your DNS provider."
+                f"Your CNAME points to {observed} — it should point to {target}. "
+                f"Update the record at your DNS provider."
             ),
         )
 
@@ -61,8 +62,8 @@ async def check_cname(fqdn: str, expected_target: str) -> PreflightResult:
     return PreflightResult(
         ok=False,
         reason=(
-            f"{fqdn}: no CNAME visible at public resolvers yet. DNS may "
-            f"still be propagating — retry in a few minutes."
+            "DNS isn't reaching us yet — this is normal right after adding the "
+            "records. Try again in a few minutes."
         ),
     )
 

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -300,13 +300,26 @@ class UrlService:
 
         return url_cache_data, schema
 
-    async def check_alias_available(self, alias: str) -> bool:
-        """Return True if alias is free in both urlsV2 and legacy urls collections."""
-        if await self._url_repo.check_alias_exists(alias, self._system_default_domain):
-            return False
-        return not await self._legacy_repo.check_exists(alias)
+    async def check_alias_available(
+        self, alias: str, *, domain: str | None = None
+    ) -> bool:
+        """Return True if alias is free under the given domain namespace.
 
-    async def check_alias(self, alias: str) -> AliasCheckResult:
+        ``domain=None`` means the system default — that path also checks the
+        legacy ``urls`` collection (v1 alias collisions still matter on the
+        original namespace). Custom domains only check v2 since v1/emoji
+        predate per-domain scoping and never live on custom hostnames.
+        """
+        target_domain = domain or self._system_default_domain
+        if await self._url_repo.check_alias_exists(alias, target_domain):
+            return False
+        if target_domain == self._system_default_domain:
+            return not await self._legacy_repo.check_exists(alias)
+        return True
+
+    async def check_alias(
+        self, alias: str, *, domain: str | None = None
+    ) -> AliasCheckResult:
         """Evaluate a candidate alias against the full creation rules.
 
         Mirrors what POST /api/v1/shorten would enforce (length, charset,
@@ -318,7 +331,7 @@ class UrlService:
             return "length"
         if not validate_alias(alias):
             return "format"
-        if not await self.check_alias_available(alias):
+        if not await self.check_alias_available(alias, domain=domain):
             return "taken"
         return "available"
 
@@ -327,14 +340,21 @@ class UrlService:
         request: CreateUrlRequest,
         owner_id: ObjectId | None,
         client_ip: str,
+        *,
+        domain: str | None = None,
     ) -> UrlV2Doc:
         """
         Create a new shortened URL.
+
+        ``domain`` scopes the new URL to a tenant. None or omitted defaults to
+        the system default. Callers MUST validate domain ownership + ACTIVE
+        status before calling — service treats the value as opaque.
 
         Raises:
             ValidationError: URL is invalid, blocked, or field validation fails.
             ConflictError:   The requested alias is already taken.
         """
+        target_domain = domain or self._system_default_domain
         now = datetime.now(timezone.utc)
 
         # 1. Validate the long URL (self-link check + format)
@@ -379,12 +399,14 @@ class UrlService:
                 raise ValidationError(
                     "Alias contains invalid characters", field="alias"
                 )
-            if not await self.check_alias_available(request.alias):
+            if not await self.check_alias_available(
+                request.alias, domain=target_domain
+            ):
                 log.info("url_alias_conflict", short_code=request.alias)
                 raise ConflictError("Alias is already in use")
             alias = request.alias
         else:
-            alias = await self._generate_unique_alias()
+            alias = await self._generate_unique_alias(domain=target_domain)
 
         # 6. private_stats default depends on auth state
         private_stats: bool | None = request.private_stats
@@ -396,7 +418,7 @@ class UrlService:
         url_doc = UrlV2Doc(
             alias=alias,
             owner_id=owner_oid,
-            domain=self._system_default_domain,
+            domain=target_domain,
             created_at=now,
             creation_ip=client_ip,
             long_url=request.long_url,
@@ -431,6 +453,7 @@ class UrlService:
             has_expiration=bool(expire_ts),
             private_stats=private_stats,
             alias_custom=bool(getattr(request, "alias", None)),
+            domain=target_domain,
         )
 
         return url_doc
@@ -562,6 +585,45 @@ class UrlService:
             user_id=str(owner_id),
         )
 
+    async def delete_all_by_domain(
+        self,
+        owner_id: ObjectId,
+        domain: str,
+    ) -> int:
+        """Bulk-delete all URLs owned by *owner_id* under *domain*.
+
+        Refuses the system default — that would nuke all of a user's spoo.me
+        URLs in one call. Returns number of URLs deleted.
+
+        Used by:
+          - `DELETE /api/v1/urls?domain=` (standalone bulk delete)
+          - `CustomDomainService.delete(cascade=True)` (domain revoke cascade)
+        """
+        if domain == self._system_default_domain:
+            raise ValidationError(
+                "cannot bulk-delete URLs on the system default domain",
+                field="domain",
+            )
+
+        aliases = await self._url_repo.list_aliases_by_owner_and_domain(
+            owner_id, domain
+        )
+        if not aliases:
+            return 0
+
+        deleted = await self._url_repo.delete_many_by_owner_and_domain(owner_id, domain)
+
+        # Best-effort cache cleanup; cache miss after delete is correct anyway.
+        await self._url_cache.invalidate_many(aliases, domain)
+
+        log.info(
+            "urls_bulk_deleted",
+            user_id=str(owner_id),
+            domain=domain,
+            count=deleted,
+        )
+        return deleted
+
     async def list_by_owner(
         self,
         owner_id: ObjectId,
@@ -575,6 +637,10 @@ class UrlService:
         """
         start_time = time.perf_counter()
         mongo_query: dict = {"owner_id": owner_id}
+
+        if getattr(query, "domain", None):
+            mongo_query["domain"] = query.domain
+
         f = query.parsed_filter
 
         if f:
@@ -743,15 +809,14 @@ class UrlService:
         ):
             await self._url_cache.set(short_code, url_cache_data)
 
-    async def _generate_unique_alias(self) -> str:
-        """Generate a 7-character alias not already in urlsV2."""
+    async def _generate_unique_alias(self, *, domain: str | None = None) -> str:
+        """Generate a 7-character alias not already in urlsV2 for *domain*."""
+        target_domain = domain or self._system_default_domain
         for _ in range(10):
             candidate = generate_short_code_v2(7)
-            if not await self._url_repo.check_alias_exists(
-                candidate, self._system_default_domain
-            ):
+            if not await self._url_repo.check_alias_exists(candidate, target_domain):
                 return candidate
-        log.error("url_alias_generation_exhausted")
+        log.error("url_alias_generation_exhausted", domain=target_domain)
         raise AppError("Could not generate a unique alias; please try again")
 
 

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -92,10 +92,16 @@ async def _handle_alias(
     request: UpdateUrlRequest, existing: UrlV2Doc, ops: dict, service: UrlService
 ) -> None:
     if request.alias is not None and request.alias != existing.alias:
-        if not await service.check_alias_available(request.alias):
+        # Scope the alias collision check to the URL's actual domain — custom
+        # domains have their own (domain, alias) namespace, so renaming on
+        # `links.acme.com` must not look up against the system default.
+        if not await service.check_alias_available(
+            request.alias, domain=existing.domain
+        ):
             log.info(
                 "url_alias_conflict",
                 short_code=request.alias,
+                domain=existing.domain,
             )
             raise ConflictError("Alias is already in use")
         ops["alias"] = request.alias
@@ -305,10 +311,11 @@ class UrlService:
     ) -> bool:
         """Return True if alias is free under the given domain namespace.
 
-        ``domain=None`` means the system default — that path also checks the
-        legacy ``urls`` collection (v1 alias collisions still matter on the
-        original namespace). Custom domains only check v2 since v1/emoji
-        predate per-domain scoping and never live on custom hostnames.
+        When ``domain`` is explicitly the system default (or omitted), also
+        checks the legacy ``urls`` collection — v1 alias collisions still
+        matter on the original namespace. Custom domains only check v2 since
+        v1/emoji predate per-domain scoping and never live on custom
+        hostnames.
         """
         target_domain = domain or self._system_default_domain
         if await self._url_repo.check_alias_exists(alias, target_domain):

--- a/static/css/dashboard/domains.css
+++ b/static/css/dashboard/domains.css
@@ -1,6 +1,6 @@
 /* Custom Domains Page Styles */
 
-/* Page Header — mirrors keys.css */
+/* Page header — mirrors keys.css */
 .page-header-content {
     display: flex;
     justify-content: space-between;
@@ -8,9 +8,7 @@
     gap: 20px;
 }
 
-.page-header-text {
-    flex: 1;
-}
+.page-header-text { flex: 1; }
 
 .page-header-actions {
     display: flex;
@@ -30,10 +28,8 @@
     transition: all 0.2s;
 }
 
-/* Container + toolbar (matches keys layout) */
-.domains-container {
-    margin-top: 24px;
-}
+/* Container + toolbar */
+.domains-container { margin-top: 24px; }
 
 .domains-toolbar {
     display: flex;
@@ -50,11 +46,8 @@
     margin: 0;
 }
 
-.domains-list-container {
-    min-height: 200px;
-}
+.domains-list-container { min-height: 200px; }
 
-/* Empty state */
 .domains-list-container .loading,
 .domains-list-container .empty {
     display: flex;
@@ -64,9 +57,7 @@
     color: var(--text-secondary);
 }
 
-.empty-state {
-    text-align: center;
-}
+.empty-state { text-align: center; }
 
 .empty-icon {
     width: 64px;
@@ -93,47 +84,67 @@
     margin: 0;
 }
 
-/* Domain row — card layout (not a table since DNS records expand below) */
+/* ── List ─────────────────────────────────────────────────────────── */
+
 .domains-list {
     display: flex;
     flex-direction: column;
 }
 
-.domain-card {
-    padding: 18px 20px;
+.domain-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 16px;
+    padding: 14px 20px;
     border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+    transition: background 0.15s;
 }
 
-.domain-card:last-child {
-    border-bottom: none;
+.domain-row:last-child { border-bottom: none; }
+
+.domain-row:hover {
+    background: rgba(255, 255, 255, 0.03);
 }
 
-.domain-card-head {
+.domain-row-main {
     display: flex;
     align-items: center;
-    gap: 12px;
-    flex-wrap: wrap;
+    gap: 10px;
+    min-width: 0;
 }
 
 .domain-fqdn {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-weight: 600;
-    font-size: 15px;
+    font-size: 14px;
     color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.domain-meta {
+.domain-row-meta {
     color: var(--text-secondary);
     font-size: 12px;
-    margin-left: auto;
 }
 
-.domain-actions {
-    display: flex;
-    gap: 8px;
+.domain-row-chevron {
+    color: var(--text-secondary);
+    font-size: 18px;
+    opacity: 0;
+    transition: opacity 0.15s;
 }
 
-/* Status badges (same hue scale as keys.css) */
+.domain-row:hover .domain-row-chevron {
+    opacity: 1;
+}
+
+/* ── Status badges (shared hues) ───────────────────────────────────── */
+
 .status-badge {
     display: inline-block;
     padding: 4px 10px;
@@ -168,94 +179,317 @@
     border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
-/* DNS instructions panel */
-.dns-instructions {
-    margin-top: 14px;
-    padding: 16px;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
+/* ── Large domain modal ────────────────────────────────────────────── */
+
+/* Inherits .modal/.modal-overlay/.modal-content base styles from keys.css.
+   .modal-large overrides width + enforces fixed-height-no-scroll content. */
+
+.modal.modal-large .modal-content {
+    width: 640px;
+    max-width: calc(100vw - 32px);
 }
 
-.dns-instructions-title {
+.modal.modal-large .modal-header {
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+}
+
+.modal-status-badge {
+    margin-left: 4px;
+}
+
+.modal.modal-large .modal-body {
+    padding: 20px 24px;
+}
+
+.modal.modal-large .modal-footer {
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px;
+}
+
+.modal-footer .btn-danger-ghost {
+    margin-right: auto;
+    background: transparent;
+    color: var(--color-danger);
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.modal-footer .btn-danger-ghost:hover {
+    background: rgba(239, 68, 68, 0.1);
+}
+
+/* Mobile: full-screen overlay */
+@media (max-width: 768px) {
+    .modal.modal-large .modal-content {
+        width: 100vw;
+        height: 100vh;
+        max-height: 100vh;
+        border-radius: 0;
+    }
+}
+
+/* ── Banner (status indicator inside modal) ────────────────────────── */
+
+.banner {
+    padding: 12px 14px;
+    border-radius: var(--radius-sm);
+    margin-bottom: 18px;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.banner-pending {
+    background: rgba(245, 158, 11, 0.08);
+    color: var(--text-primary);
+    border-left: 3px solid var(--color-warning);
+}
+
+.banner-suspended {
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--text-primary);
+    border-left: 3px solid var(--color-danger);
+}
+
+.banner-active {
+    background: rgba(34, 197, 94, 0.08);
+    color: var(--text-primary);
+    border-left: 3px solid var(--color-success);
+}
+
+.banner-active i {
+    color: var(--color-success);
+    font-size: 18px;
+}
+
+.banner-revoked {
+    background: rgba(148, 163, 184, 0.05);
+    color: var(--text-secondary);
+    border-left: 3px solid rgba(148, 163, 184, 0.4);
+}
+
+/* ── Section + DNS records ─────────────────────────────────────────── */
+
+.section-title {
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--text-secondary);
-    margin: 0 0 12px;
+    margin: 0 0 10px;
+}
+
+.dns-records {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 14px;
 }
 
 .dns-record {
     display: grid;
-    grid-template-columns: 80px 1fr 1fr;
-    gap: 12px;
-    padding: 8px 0;
-    border-top: 1px solid var(--border-color);
+    grid-template-columns: auto 1fr auto;
+    gap: 14px;
+    align-items: center;
+    padding: 12px 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+}
+
+.rec-type {
+    color: var(--accent-primary);
+    font-weight: 700;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
-    align-items: start;
+    letter-spacing: 0.5px;
 }
 
-.dns-record:first-of-type {
-    border-top: none;
+.rec-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
 }
 
-.dns-record .rec-type {
-    color: var(--accent-primary);
-    font-weight: 600;
+.rec-field {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: 10px;
+    align-items: baseline;
 }
 
-.dns-record .rec-name,
-.dns-record .rec-value {
-    color: var(--text-primary);
-    word-break: break-all;
-}
-
-.dns-record .rec-purpose {
-    grid-column: 1 / -1;
+.rec-label {
     color: var(--text-secondary);
     font-size: 11px;
-    font-family: inherit;
-    padding-top: 2px;
-    padding-left: 92px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 
-/* Setup notes (orange-cloud warnings, etc.) */
+.rec-name,
+.rec-value {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    color: var(--text-primary);
+    word-break: break-all;
+    background: transparent;
+    padding: 0;
+}
+
+.rec-copy {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.rec-copy:hover {
+    color: var(--text-primary);
+    border-color: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.rec-copy.copied {
+    color: var(--color-success);
+    border-color: rgba(34, 197, 94, 0.3);
+}
+
+/* ── Setup notes (CF orange-cloud, etc.) ───────────────────────────── */
+
 .setup-notes {
-    margin-top: 12px;
-    padding: 12px 14px;
-    background: rgba(245, 158, 11, 0.08);
-    border-left: 3px solid var(--color-warning);
+    margin: 0 0 14px;
+    padding: 10px 12px;
+    background: rgba(96, 165, 250, 0.08);
+    border-left: 3px solid #60a5fa;
     border-radius: var(--radius-sm);
     color: var(--text-primary);
     font-size: 13px;
 }
 
-.setup-notes p {
-    margin: 0;
-}
+.setup-notes p { margin: 0; }
+.setup-notes p + p { margin-top: 4px; }
 
-.setup-notes p + p {
-    margin-top: 6px;
-}
+/* ── Inline feedback messages ─────────────────────────────────────── */
 
-/* Last verification error */
-.verification-error {
+.inline-error {
     margin-top: 10px;
     padding: 10px 12px;
     background: rgba(239, 68, 68, 0.08);
     border-left: 3px solid var(--color-danger);
     border-radius: var(--radius-sm);
     color: var(--color-danger);
-    font-size: 12px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
 }
 
-/* Cascade choice in delete modal */
-.cascade-choice {
-    margin-top: 14px;
+.inline-info {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: rgba(96, 165, 250, 0.08);
+    border-left: 3px solid #60a5fa;
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 13px;
 }
+
+.field-hint {
+    display: block;
+    margin-top: 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.field-hint code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────── */
+
+.btn-block {
+    width: 100%;
+    justify-content: center;
+}
+
+.btn-secondary {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+}
+
+.btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.btn-spinner {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 6px;
+}
+
+.btn-spinner i {
+    animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* ── Active mode extras ───────────────────────────────────────────── */
+
+.active-meta {
+    margin: 14px 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+    text-align: center;
+}
+
+.collapsible {
+    border-top: 1px solid var(--border-color);
+    padding-top: 10px;
+    margin-top: 4px;
+}
+
+.collapsible summary {
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 6px 0;
+    user-select: none;
+}
+
+.collapsible summary:hover {
+    color: var(--text-primary);
+}
+
+.collapsible[open] summary {
+    margin-bottom: 10px;
+}
+
+/* ── Cascade choice in revoke sub-modal ───────────────────────────── */
+
+.cascade-choice { margin-top: 14px; }
 
 .cascade-option {
     display: block;
@@ -301,7 +535,8 @@
     to { opacity: 1; transform: none; }
 }
 
-/* Delete (revoke) Confirmation Modal — mirrors #delete-key-modal from keys.css */
+/* ── Revoke confirmation modal — mirrors #delete-key-modal ───────── */
+
 #delete-domain-modal {
     display: none;
     position: fixed;
@@ -340,7 +575,6 @@
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
     width: 100%;
     max-width: 540px;
-    max-height: 90vh;
     overflow: hidden;
     transform: scale(0.85) translateY(20px);
     opacity: 0;
@@ -388,8 +622,6 @@
 
 #delete-domain-modal .modal-body {
     padding: 20px 24px;
-    overflow-y: auto;
-    max-height: calc(90vh - 200px);
 }
 
 #delete-domain-modal .modal-body p {
@@ -429,25 +661,4 @@
 #delete-domain-modal .btn-delete:hover:not(:disabled) {
     background: var(--color-danger-hover);
     border-color: var(--color-danger-hover);
-}
-
-@media (max-width: 768px) {
-    #delete-domain-modal .modal-container {
-        padding: 16px;
-    }
-    #delete-domain-modal .modal-content {
-        max-width: none;
-        max-height: 95vh;
-    }
-    #delete-domain-modal .modal-body {
-        padding: 24px 20px;
-    }
-    #delete-domain-modal .modal-footer {
-        padding: 20px;
-        flex-direction: column-reverse;
-        gap: 10px;
-    }
-    #delete-domain-modal .modal-footer .btn {
-        width: 100%;
-    }
 }

--- a/static/css/dashboard/domains.css
+++ b/static/css/dashboard/domains.css
@@ -1,0 +1,453 @@
+/* Custom Domains Page Styles */
+
+/* Page Header — mirrors keys.css */
+.page-header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+.page-header-text {
+    flex: 1;
+}
+
+.page-header-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.page-header-actions .btn {
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+/* Container + toolbar (matches keys layout) */
+.domains-container {
+    margin-top: 24px;
+}
+
+.domains-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.domains-toolbar h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.domains-list-container {
+    min-height: 200px;
+}
+
+/* Empty state */
+.domains-list-container .loading,
+.domains-list-container .empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    color: var(--text-secondary);
+}
+
+.empty-state {
+    text-align: center;
+}
+
+.empty-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 50%;
+    color: var(--text-secondary);
+    font-size: 28px;
+}
+
+.empty-title {
+    color: var(--text-primary);
+    font-size: 18px;
+    margin: 0 0 8px;
+}
+
+.empty-message {
+    color: var(--text-secondary);
+    font-size: 14px;
+    margin: 0;
+}
+
+/* Domain row — card layout (not a table since DNS records expand below) */
+.domains-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.domain-card {
+    padding: 18px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.domain-card:last-child {
+    border-bottom: none;
+}
+
+.domain-card-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.domain-fqdn {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--text-primary);
+}
+
+.domain-meta {
+    color: var(--text-secondary);
+    font-size: 12px;
+    margin-left: auto;
+}
+
+.domain-actions {
+    display: flex;
+    gap: 8px;
+}
+
+/* Status badges (same hue scale as keys.css) */
+.status-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.status-pending {
+    background: rgba(245, 158, 11, 0.1);
+    color: var(--color-warning);
+    border: 1px solid rgba(245, 158, 11, 0.2);
+}
+
+.status-active {
+    background: rgba(34, 197, 94, 0.1);
+    color: var(--color-success);
+    border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.status-suspended {
+    background: rgba(239, 68, 68, 0.1);
+    color: var(--color-danger);
+    border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.status-revoked {
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--text-secondary);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+/* DNS instructions panel */
+.dns-instructions {
+    margin-top: 14px;
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+}
+
+.dns-instructions-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    margin: 0 0 12px;
+}
+
+.dns-record {
+    display: grid;
+    grid-template-columns: 80px 1fr 1fr;
+    gap: 12px;
+    padding: 8px 0;
+    border-top: 1px solid var(--border-color);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    align-items: start;
+}
+
+.dns-record:first-of-type {
+    border-top: none;
+}
+
+.dns-record .rec-type {
+    color: var(--accent-primary);
+    font-weight: 600;
+}
+
+.dns-record .rec-name,
+.dns-record .rec-value {
+    color: var(--text-primary);
+    word-break: break-all;
+}
+
+.dns-record .rec-purpose {
+    grid-column: 1 / -1;
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-family: inherit;
+    padding-top: 2px;
+    padding-left: 92px;
+}
+
+/* Setup notes (orange-cloud warnings, etc.) */
+.setup-notes {
+    margin-top: 12px;
+    padding: 12px 14px;
+    background: rgba(245, 158, 11, 0.08);
+    border-left: 3px solid var(--color-warning);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 13px;
+}
+
+.setup-notes p {
+    margin: 0;
+}
+
+.setup-notes p + p {
+    margin-top: 6px;
+}
+
+/* Last verification error */
+.verification-error {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: rgba(239, 68, 68, 0.08);
+    border-left: 3px solid var(--color-danger);
+    border-radius: var(--radius-sm);
+    color: var(--color-danger);
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* Cascade choice in delete modal */
+.cascade-choice {
+    margin-top: 14px;
+}
+
+.cascade-option {
+    display: block;
+    padding: 12px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    margin-bottom: 10px;
+    cursor: pointer;
+    transition: border-color 0.2s, background 0.2s;
+}
+
+.cascade-option:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.cascade-option input[type="radio"] {
+    margin-right: 10px;
+    accent-color: var(--accent-primary);
+}
+
+.cascade-option-label {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.cascade-option-desc {
+    margin-top: 4px;
+    margin-left: 24px;
+    color: var(--text-secondary);
+    font-size: 13px;
+}
+
+.cascade-option-desc.warning {
+    color: var(--color-danger);
+}
+
+.fade-in {
+    animation: fadeIn 0.18s ease-in;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-2px); }
+    to { opacity: 1; transform: none; }
+}
+
+/* Delete (revoke) Confirmation Modal — mirrors #delete-key-modal from keys.css */
+#delete-domain-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-max);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#delete-domain-modal.active {
+    display: flex;
+    opacity: 1;
+    visibility: visible;
+}
+
+#delete-domain-modal .modal-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 20px;
+    position: relative;
+    z-index: 2;
+    background: rgba(0, 0, 0, 0.7);
+    -webkit-backdrop-filter: blur(10px) saturate(180%) brightness(0.7);
+    backdrop-filter: blur(10px) saturate(180%) brightness(0.7);
+}
+
+#delete-domain-modal .modal-content {
+    backdrop-filter: blur(60px);
+    background: rgba(15, 20, 35, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+    width: 100%;
+    max-width: 540px;
+    max-height: 90vh;
+    overflow: hidden;
+    transform: scale(0.85) translateY(20px);
+    opacity: 0;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#delete-domain-modal.active .modal-content {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+}
+
+#delete-domain-modal .modal-header {
+    display: flex;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#delete-domain-modal .modal-title-section-delete {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+#delete-domain-modal .modal-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    flex-shrink: 0;
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+    color: white;
+}
+
+#delete-domain-modal .modal-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+    line-height: 1.3;
+}
+
+#delete-domain-modal .modal-body {
+    padding: 20px 24px;
+    overflow-y: auto;
+    max-height: calc(90vh - 200px);
+}
+
+#delete-domain-modal .modal-body p {
+    color: var(--text-secondary);
+    margin: 0 0 8px;
+    line-height: 1.5;
+    font-size: 14px;
+}
+
+#delete-domain-modal .modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 16px 24px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    gap: 10px;
+}
+
+#delete-domain-modal .btn-cancel {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+#delete-domain-modal .btn-cancel:hover {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--text-primary);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+#delete-domain-modal .btn-delete {
+    background: var(--color-danger);
+    color: white;
+    border-color: var(--color-danger);
+}
+
+#delete-domain-modal .btn-delete:hover:not(:disabled) {
+    background: var(--color-danger-hover);
+    border-color: var(--color-danger-hover);
+}
+
+@media (max-width: 768px) {
+    #delete-domain-modal .modal-container {
+        padding: 16px;
+    }
+    #delete-domain-modal .modal-content {
+        max-width: none;
+        max-height: 95vh;
+    }
+    #delete-domain-modal .modal-body {
+        padding: 24px 20px;
+    }
+    #delete-domain-modal .modal-footer {
+        padding: 20px;
+        flex-direction: column-reverse;
+        gap: 10px;
+    }
+    #delete-domain-modal .modal-footer .btn {
+        width: 100%;
+    }
+}

--- a/static/css/dashboard/domains.css
+++ b/static/css/dashboard/domains.css
@@ -293,10 +293,10 @@
 }
 
 .fade-in {
-    animation: fadeIn 0.18s ease-in;
+    animation: fade-in 0.18s ease-in;
 }
 
-@keyframes fadeIn {
+@keyframes fade-in {
     from { opacity: 0; transform: translateY(-2px); }
     to { opacity: 1; transform: none; }
 }

--- a/static/css/dashboard/domains.css
+++ b/static/css/dashboard/domains.css
@@ -185,8 +185,19 @@
    .modal-large overrides width + enforces fixed-height-no-scroll content. */
 
 .modal.modal-large .modal-content {
-    width: 640px;
+    width: 720px;
     max-width: calc(100vw - 32px);
+    /* Sit at natural content height, never stretch to viewport. */
+    height: auto;
+    max-height: 90vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.modal.modal-large .modal-body {
+    flex: 0 1 auto;
+    overflow-y: auto;
 }
 
 .modal.modal-large .modal-header {
@@ -205,15 +216,17 @@
 }
 
 .modal.modal-large .modal-body {
-    padding: 20px 24px;
+    padding: 24px 28px 28px;
 }
 
 .modal.modal-large .modal-footer {
     border-top: 1px solid var(--border-color);
     display: flex;
+    align-items: center;
     justify-content: flex-end;
-    gap: 8px;
-    padding: 16px 24px;
+    gap: 10px;
+    padding: 16px 28px;
+    min-height: 64px;
 }
 
 .modal-footer .btn-danger-ghost {
@@ -225,6 +238,7 @@
 
 .modal-footer .btn-danger-ghost:hover {
     background: rgba(239, 68, 68, 0.1);
+    color: var(--color-danger);
 }
 
 /* Mobile: full-screen overlay */
@@ -240,10 +254,11 @@
 /* ── Banner (status indicator inside modal) ────────────────────────── */
 
 .banner {
-    padding: 12px 14px;
-    border-radius: var(--radius-sm);
-    margin-bottom: 18px;
+    padding: 14px 16px;
+    border-radius: var(--radius-md);
+    margin-bottom: 24px;
     font-size: 14px;
+    line-height: 1.5;
     display: flex;
     align-items: center;
     gap: 10px;
@@ -252,19 +267,16 @@
 .banner-pending {
     background: rgba(245, 158, 11, 0.08);
     color: var(--text-primary);
-    border-left: 3px solid var(--color-warning);
 }
 
 .banner-suspended {
     background: rgba(239, 68, 68, 0.08);
     color: var(--text-primary);
-    border-left: 3px solid var(--color-danger);
 }
 
 .banner-active {
     background: rgba(34, 197, 94, 0.08);
     color: var(--text-primary);
-    border-left: 3px solid var(--color-success);
 }
 
 .banner-active i {
@@ -275,10 +287,18 @@
 .banner-revoked {
     background: rgba(148, 163, 184, 0.05);
     color: var(--text-secondary);
-    border-left: 3px solid rgba(148, 163, 184, 0.4);
 }
 
 /* ── Section + DNS records ─────────────────────────────────────────── */
+
+.section-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin: 0 0 12px;
+    min-height: 32px;
+}
 
 .section-title {
     font-size: 12px;
@@ -286,25 +306,25 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--text-secondary);
-    margin: 0 0 10px;
+    margin: 0;
 }
 
 .dns-records {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    margin-bottom: 14px;
+    gap: 10px;
+    margin-bottom: 20px;
 }
 
 .dns-record {
     display: grid;
     grid-template-columns: auto 1fr auto;
-    gap: 14px;
+    gap: 16px;
     align-items: center;
-    padding: 12px 14px;
+    padding: 16px 18px;
     background: rgba(255, 255, 255, 0.03);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius-md);
 }
 
 .rec-type {
@@ -318,7 +338,7 @@
 .rec-fields {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 8px;
     min-width: 0;
 }
 
@@ -374,38 +394,38 @@
 /* ── Setup notes (CF orange-cloud, etc.) ───────────────────────────── */
 
 .setup-notes {
-    margin: 0 0 14px;
-    padding: 10px 12px;
-    background: rgba(96, 165, 250, 0.08);
-    border-left: 3px solid #60a5fa;
-    border-radius: var(--radius-sm);
+    margin: 0 0 18px;
+    padding: 12px 14px;
+    background: rgba(96, 165, 250, 0.07);
+    border-radius: var(--radius-md);
     color: var(--text-primary);
     font-size: 13px;
+    line-height: 1.5;
 }
 
 .setup-notes p { margin: 0; }
-.setup-notes p + p { margin-top: 4px; }
+.setup-notes p + p { margin-top: 6px; }
 
 /* ── Inline feedback messages ─────────────────────────────────────── */
 
 .inline-error {
-    margin-top: 10px;
-    padding: 10px 12px;
+    margin-top: 14px;
+    padding: 12px 14px;
     background: rgba(239, 68, 68, 0.08);
-    border-left: 3px solid var(--color-danger);
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius-md);
     color: var(--color-danger);
     font-size: 13px;
+    line-height: 1.5;
 }
 
 .inline-info {
-    margin-top: 10px;
-    padding: 10px 12px;
-    background: rgba(96, 165, 250, 0.08);
-    border-left: 3px solid #60a5fa;
-    border-radius: var(--radius-sm);
+    margin-top: 14px;
+    padding: 12px 14px;
+    background: rgba(96, 165, 250, 0.07);
+    border-radius: var(--radius-md);
     color: var(--text-secondary);
     font-size: 13px;
+    line-height: 1.5;
 }
 
 .field-hint {
@@ -458,7 +478,7 @@
 /* ── Active mode extras ───────────────────────────────────────────── */
 
 .active-meta {
-    margin: 14px 0;
+    margin: 20px 0;
     color: var(--text-secondary);
     font-size: 13px;
     text-align: center;

--- a/static/js/dashboard/domains.js
+++ b/static/js/dashboard/domains.js
@@ -99,6 +99,20 @@ function showSlot(mode) {
     currentMode = mode;
 }
 
+// Footer button visibility per mode. `submit` accepts a label string (shows
+// the button with that label) or false (hides).
+function setFooter({ cancel = false, submit = false, revoke = false, verify = false }) {
+    el.modalCancel.style.display = cancel ? '' : 'none';
+    if (submit) {
+        el.modalSubmit.style.display = '';
+        el.modalSubmit.textContent = submit;
+    } else {
+        el.modalSubmit.style.display = 'none';
+    }
+    el.modalRevoke.style.display = revoke ? '' : 'none';
+    el.setupVerify.style.display = verify ? '' : 'none';
+}
+
 // ── List fetch + render ───────────────────────────────────────────────────
 
 async function fetchDomains() {
@@ -169,10 +183,7 @@ function openAddModal({ push = true } = {}) {
     el.modalTitle.textContent = 'Add a domain';
     el.modalBadge.style.display = 'none';
 
-    el.modalCancel.style.display = '';
-    el.modalSubmit.style.display = '';
-    el.modalSubmit.textContent = 'Add';
-    el.modalRevoke.style.display = 'none';
+    setFooter({ cancel: true, submit: 'Add', revoke: false, verify: false });
 
     showSlot('add');
     showModal();
@@ -186,9 +197,7 @@ async function openDomainModal(id, { push = true } = {}) {
 
     el.modalTitle.textContent = 'Loading…';
     el.modalBadge.style.display = 'none';
-    el.modalCancel.style.display = '';
-    el.modalSubmit.style.display = 'none';
-    el.modalRevoke.style.display = 'none';
+    setFooter({ cancel: false, submit: false, revoke: false, verify: false });
 
     showModal();
     if (push) syncUrl({ domain: id });
@@ -242,9 +251,6 @@ function renderForStatus(doc) {
     el.modalBadge.className = `status-badge modal-status-badge ${statusClass(status)}`;
     el.modalBadge.style.display = '';
 
-    el.modalSubmit.style.display = 'none';
-    el.modalCancel.textContent = 'Close';
-
     if (status === 'PENDING' || status === 'SUSPENDED') {
         renderSetup(doc, status);
     } else if (status === 'ACTIVE') {
@@ -281,7 +287,7 @@ function renderSetup(doc, status) {
     el.setupPoll.style.display = 'none';
     resetVerifyButton();
 
-    el.modalRevoke.style.display = '';
+    setFooter({ revoke: true, verify: true });
 
     showSlot('setup');
 }
@@ -297,13 +303,13 @@ function renderActive(doc) {
 
     renderDnsRecords(el.activeDnsRecords, doc.dns_records || []);
 
-    el.modalRevoke.style.display = '';
+    setFooter({ revoke: true });
 
     showSlot('active');
 }
 
 function renderRevoked(doc) {
-    el.modalRevoke.style.display = 'none';
+    setFooter({});
     showSlot('revoked');
 }
 
@@ -336,7 +342,7 @@ async function copyToClipboard(text, btn) {
             btn.classList.remove('copied');
         }, 1200);
     } catch (_) {
-        showNotification('Copy failed — select and copy manually', 'error');
+        showNotification('Copy failed - Select and copy manually.', 'error');
     }
 }
 
@@ -358,7 +364,7 @@ async function submitAdd() {
         });
         const body = await res.json().catch(() => ({}));
         if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
-        showNotification(`${body.fqdn} added — add the DNS record, then verify.`, 'success');
+        showNotification(`${body.fqdn} added - Add the DNS record, then verify.`, 'success');
         // Refresh list in background; morph current modal to setup mode.
         fetchDomains();
         currentDomain = body;
@@ -439,7 +445,7 @@ function startPoll(id) {
             const status = String(doc.status || '').toUpperCase();
             if (status === 'ACTIVE') {
                 stopPoll();
-                showNotification('Domain verified — it\'s now live.', 'success');
+                showNotification("Domain verified - It's now live.", 'success');
                 renderForStatus(doc);
                 fetchDomains();
             }
@@ -459,7 +465,7 @@ function stopPoll() {
 function setVerifyBusy(busy) {
     el.setupVerify.disabled = busy;
     el.setupVerify.querySelector('.btn-label').textContent =
-        busy ? 'Verifying…' : 'Verify domain';
+        busy ? 'Verifying…' : 'Verify';
     el.setupVerify.querySelector('.btn-spinner').style.display =
         busy ? '' : 'none';
 }

--- a/static/js/dashboard/domains.js
+++ b/static/js/dashboard/domains.js
@@ -1,0 +1,359 @@
+// Custom Domains Management — fetch + render + modals.
+// Mirrors keys.js structure (element cache, fetch/render/createRow,
+// modal open/close, key bindings).
+
+const domainElements = {
+    loading: document.getElementById('domains-loading'),
+    empty: document.getElementById('domains-empty'),
+    list: document.getElementById('domains-list'),
+    template: document.getElementById('tpl-domain-item'),
+    dnsTemplate: document.getElementById('tpl-dns-record'),
+    newBtn: document.getElementById('btn-new-domain'),
+
+    // Add modal
+    addModal: document.getElementById('createDomainModal'),
+    addInput: document.getElementById('domain-fqdn'),
+    addSubmitBtn: document.getElementById('btn-create-domain'),
+    addError: document.getElementById('add-domain-error'),
+
+    // Delete modal
+    deleteModal: document.getElementById('delete-domain-modal'),
+    delFqdnEl: document.getElementById('delete-domain-fqdn'),
+    delUrlCountEl: document.getElementById('delete-domain-url-count'),
+    delError: document.getElementById('delete-domain-error'),
+    cancelDeleteBtn: document.getElementById('btn-cancel-domain-delete'),
+    confirmDeleteBtn: document.getElementById('btn-confirm-domain-delete'),
+};
+
+let pendingDeleteDomain = null;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function setError(node, message) {
+    if (!node) return;
+    if (!message) {
+        node.style.display = 'none';
+        node.textContent = '';
+        return;
+    }
+    node.textContent = message;
+    node.style.display = 'block';
+}
+
+function statusBadgeClass(status) {
+    const s = String(status || '').toUpperCase();
+    return `status-${s.toLowerCase()}`;
+}
+
+function formatDate(value) {
+    if (!value) return '—';
+    try {
+        return new Date(value).toLocaleDateString();
+    } catch (_) {
+        return '—';
+    }
+}
+
+// ── Fetch + render ─────────────────────────────────────────────────────────
+
+async function fetchDomains() {
+    setLoading(true);
+    domainElements.empty.style.display = 'none';
+    try {
+        const res = await authFetch('/api/v1/custom-domains', {
+            headers: { 'Accept': 'application/json' },
+        });
+        if (!res.ok) throw new Error('Failed to fetch domains');
+        const data = await res.json();
+        renderDomains(data.items || []);
+    } catch (err) {
+        console.error('Error fetching domains:', err);
+        showEmptyState();
+    } finally {
+        setLoading(false);
+    }
+}
+
+function setLoading(loading) {
+    domainElements.loading.style.display = loading ? 'flex' : 'none';
+    if (loading) {
+        domainElements.list.style.display = 'none';
+        domainElements.empty.style.display = 'none';
+    }
+}
+
+function showEmptyState() {
+    domainElements.empty.style.display = 'flex';
+    domainElements.list.style.display = 'none';
+}
+
+function renderDomains(domains) {
+    domainElements.list.innerHTML = '';
+    if (!domains || domains.length === 0) {
+        showEmptyState();
+        return;
+    }
+    domainElements.list.style.display = 'flex';
+    domainElements.empty.style.display = 'none';
+
+    const fragment = document.createDocumentFragment();
+    domains.forEach(d => fragment.appendChild(createDomainCard(d)));
+    domainElements.list.appendChild(fragment);
+}
+
+function createDomainCard(domain) {
+    const node = domainElements.template.content.firstElementChild.cloneNode(true);
+    node.dataset.id = domain.id;
+
+    node.querySelector('.domain-fqdn').textContent = domain.fqdn;
+    node.querySelector('.domain-meta').textContent =
+        `Registered ${formatDate(domain.created_at)}`;
+
+    const statusEl = node.querySelector('.status-badge');
+    const status = String(domain.status || '').toUpperCase();
+    statusEl.textContent = status;
+    statusEl.classList.add(statusBadgeClass(status));
+
+    // Verify button only when not ACTIVE and not REVOKED.
+    const verifyBtn = node.querySelector('.btn-verify');
+    if (status === 'ACTIVE' || status === 'REVOKED') {
+        verifyBtn.style.display = 'none';
+    } else {
+        verifyBtn.addEventListener('click', () => verifyDomain(domain.id));
+    }
+
+    // Delete button hidden once REVOKED.
+    const deleteBtn = node.querySelector('.btn-revoke');
+    if (status === 'REVOKED') {
+        deleteBtn.style.display = 'none';
+    } else {
+        deleteBtn.addEventListener('click', () => openDeleteModal(domain));
+    }
+
+    // DNS instructions — show only when setup is still required.
+    const dnsBlock = node.querySelector('.dns-instructions');
+    if (status === 'ACTIVE' || status === 'REVOKED') {
+        dnsBlock.style.display = 'none';
+    } else {
+        renderDnsRecords(
+            dnsBlock.querySelector('.dns-records'),
+            domain.dns_records || []
+        );
+    }
+
+    // Setup notes (orange-cloud warning, etc.)
+    const notesBlock = node.querySelector('.setup-notes');
+    if (status === 'ACTIVE' || status === 'REVOKED' || !domain.setup_notes || domain.setup_notes.length === 0) {
+        notesBlock.style.display = 'none';
+    } else {
+        notesBlock.innerHTML = '';
+        domain.setup_notes.forEach(note => {
+            const p = document.createElement('p');
+            p.textContent = note;
+            notesBlock.appendChild(p);
+        });
+    }
+
+    // Last verification error
+    const errBlock = node.querySelector('.verification-error');
+    if (domain.last_verification_error) {
+        errBlock.textContent = `⚠ ${domain.last_verification_error}`;
+    } else {
+        errBlock.style.display = 'none';
+    }
+
+    return node;
+}
+
+function renderDnsRecords(container, records) {
+    container.innerHTML = '';
+    if (!records || records.length === 0) {
+        container.style.display = 'none';
+        return;
+    }
+    records.forEach(rec => {
+        const row = domainElements.dnsTemplate.content.firstElementChild.cloneNode(true);
+        row.querySelector('.rec-type').textContent = rec.type;
+        row.querySelector('.rec-name').textContent = rec.name;
+        row.querySelector('.rec-value').textContent = rec.value;
+        const purposeEl = row.querySelector('.rec-purpose');
+        if (rec.purpose) {
+            purposeEl.textContent = rec.purpose;
+        } else {
+            purposeEl.style.display = 'none';
+        }
+        container.appendChild(row);
+    });
+}
+
+// ── Verify ─────────────────────────────────────────────────────────────────
+
+async function verifyDomain(id) {
+    try {
+        const res = await authFetch(`/api/v1/custom-domains/${id}/verify`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+            body: JSON.stringify({}),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || 'Verification failed');
+        showNotification('Verification triggered. Refreshing…', 'success');
+        await fetchDomains();
+    } catch (err) {
+        showNotification(`Verify failed: ${err.message}`, 'error');
+    }
+}
+
+// ── Add modal ──────────────────────────────────────────────────────────────
+
+function openAddModal() {
+    domainElements.addInput.value = '';
+    setError(domainElements.addError, '');
+    domainElements.addModal.style.display = 'flex';
+    domainElements.addModal.setAttribute('aria-hidden', 'false');
+    setTimeout(() => domainElements.addInput.focus(), 50);
+}
+
+function closeAddModal() {
+    domainElements.addModal.style.display = 'none';
+    domainElements.addModal.setAttribute('aria-hidden', 'true');
+}
+
+async function submitNewDomain() {
+    const fqdn = (domainElements.addInput.value || '').trim();
+    if (!fqdn) {
+        setError(domainElements.addError, 'Enter a domain (e.g. links.acme.com)');
+        return;
+    }
+    setError(domainElements.addError, '');
+    domainElements.addSubmitBtn.disabled = true;
+    try {
+        const res = await authFetch('/api/v1/custom-domains', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+            body: JSON.stringify({ fqdn }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
+        showNotification(
+            `${fqdn} registered. Publish the DNS records, then verify.`,
+            'success'
+        );
+        closeAddModal();
+        await fetchDomains();
+    } catch (err) {
+        setError(domainElements.addError, err.message);
+    } finally {
+        domainElements.addSubmitBtn.disabled = false;
+    }
+}
+
+// ── Delete modal ───────────────────────────────────────────────────────────
+
+async function openDeleteModal(domain) {
+    pendingDeleteDomain = domain;
+    domainElements.delFqdnEl.textContent = domain.fqdn;
+    domainElements.delUrlCountEl.textContent = '…';
+    setError(domainElements.delError, '');
+    // Reset cascade choice to "orphan" default.
+    const orphanRadio = domainElements.deleteModal.querySelector(
+        'input[name="cascade"][value="false"]'
+    );
+    if (orphanRadio) orphanRadio.checked = true;
+
+    domainElements.deleteModal.classList.add('active');
+    domainElements.deleteModal.setAttribute('aria-hidden', 'false');
+
+    try {
+        const res = await authFetch(
+            `/api/v1/urls?domain=${encodeURIComponent(domain.fqdn)}&pageSize=1`,
+            { headers: { 'Accept': 'application/json' } }
+        );
+        if (res.ok) {
+            const data = await res.json();
+            domainElements.delUrlCountEl.textContent = String(data.total || 0);
+        } else {
+            domainElements.delUrlCountEl.textContent = '?';
+        }
+    } catch (_) {
+        domainElements.delUrlCountEl.textContent = '?';
+    }
+}
+
+function closeDeleteModal() {
+    domainElements.deleteModal.classList.remove('active');
+    domainElements.deleteModal.setAttribute('aria-hidden', 'true');
+    pendingDeleteDomain = null;
+}
+
+async function confirmDelete() {
+    if (!pendingDeleteDomain) return;
+    const selected = domainElements.deleteModal.querySelector(
+        'input[name="cascade"]:checked'
+    );
+    const cascade = selected && selected.value === 'true';
+
+    setError(domainElements.delError, '');
+    domainElements.confirmDeleteBtn.disabled = true;
+    try {
+        const url = `/api/v1/custom-domains/${pendingDeleteDomain.id}?cascade=${cascade}`;
+        const res = await authFetch(url, { method: 'DELETE' });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
+        const detail = cascade
+            ? ` (${data.urls_deleted} URL(s) deleted)`
+            : ' (URLs orphaned)';
+        showNotification(
+            `${pendingDeleteDomain.fqdn} revoked${detail}`,
+            'success'
+        );
+        closeDeleteModal();
+        await fetchDomains();
+    } catch (err) {
+        setError(domainElements.delError, err.message);
+    } finally {
+        domainElements.confirmDeleteBtn.disabled = false;
+    }
+}
+
+// ── Bootstrap ──────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', () => {
+    fetchDomains();
+
+    domainElements.newBtn.addEventListener('click', openAddModal);
+    domainElements.addSubmitBtn.addEventListener('click', submitNewDomain);
+    domainElements.addInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') submitNewDomain();
+    });
+
+    domainElements.cancelDeleteBtn.addEventListener('click', closeDeleteModal);
+    domainElements.confirmDeleteBtn.addEventListener('click', confirmDelete);
+
+    // Add-modal backdrop click.
+    domainElements.addModal.addEventListener('click', (e) => {
+        if (e.target === domainElements.addModal
+            || e.target.classList.contains('modal-overlay')) {
+            closeAddModal();
+        }
+    });
+    // Delete-modal backdrop click.
+    domainElements.deleteModal.addEventListener('click', (e) => {
+        if (e.target.classList.contains('modal-container')
+            || e.target.classList.contains('modal-backdrop')) {
+            closeDeleteModal();
+        }
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') return;
+        if (domainElements.deleteModal.classList.contains('active')) {
+            closeDeleteModal();
+        } else if (domainElements.addModal.style.display === 'flex') {
+            closeAddModal();
+        }
+    });
+});
+
+window.closeCreateDomainModal = closeAddModal;
+window.closeDeleteDomainModal = closeDeleteModal;

--- a/static/js/dashboard/domains.js
+++ b/static/js/dashboard/domains.js
@@ -1,359 +1,597 @@
-// Custom Domains Management — fetch + render + modals.
-// Mirrors keys.js structure (element cache, fetch/render/createRow,
-// modal open/close, key bindings).
+// Custom Domains — single page, large state-aware modal.
+// Modal modes: add | setup | active | revoked. URL-persisted via ?domain=<id>
+// and ?new=1 so refresh + direct links reopen the right state.
 
-const domainElements = {
-    loading: document.getElementById('domains-loading'),
-    empty: document.getElementById('domains-empty'),
+const POLL_INTERVAL_MS = 5000;
+const POLL_MAX_DURATION_MS = 60000;
+
+const el = {
+    // List
+    listLoading: document.getElementById('domains-loading'),
+    listEmpty: document.getElementById('domains-empty'),
     list: document.getElementById('domains-list'),
-    template: document.getElementById('tpl-domain-item'),
-    dnsTemplate: document.getElementById('tpl-dns-record'),
+    rowTpl: document.getElementById('tpl-domain-row'),
+    dnsTpl: document.getElementById('tpl-dns-record'),
     newBtn: document.getElementById('btn-new-domain'),
 
-    // Add modal
-    addModal: document.getElementById('createDomainModal'),
+    // Domain modal
+    modal: document.getElementById('domainModal'),
+    modalTitle: document.getElementById('domainModalTitle'),
+    modalBadge: document.getElementById('modalStatusBadge'),
+    modalClose: document.getElementById('btn-close-domain-modal'),
+    modalCancel: document.getElementById('btn-domain-modal-cancel'),
+    modalSubmit: document.getElementById('btn-domain-modal-submit'),
+    modalRevoke: document.getElementById('btn-domain-revoke'),
+
+    // Add mode
     addInput: document.getElementById('domain-fqdn'),
-    addSubmitBtn: document.getElementById('btn-create-domain'),
     addError: document.getElementById('add-domain-error'),
 
-    // Delete modal
-    deleteModal: document.getElementById('delete-domain-modal'),
-    delFqdnEl: document.getElementById('delete-domain-fqdn'),
-    delUrlCountEl: document.getElementById('delete-domain-url-count'),
-    delError: document.getElementById('delete-domain-error'),
-    cancelDeleteBtn: document.getElementById('btn-cancel-domain-delete'),
-    confirmDeleteBtn: document.getElementById('btn-confirm-domain-delete'),
+    // Setup mode
+    setupBanner: document.getElementById('setup-banner'),
+    setupRecords: document.getElementById('dns-records'),
+    setupNotes: document.getElementById('setup-notes'),
+    setupVerify: document.getElementById('btn-verify'),
+    setupError: document.getElementById('setup-error'),
+    setupPoll: document.getElementById('setup-poll-status'),
+
+    // Active mode
+    activeOpenLink: document.getElementById('active-open-link'),
+    activeOpenLabel: document.getElementById('active-open-label'),
+    activeMeta: document.getElementById('active-meta'),
+    activeDnsRecords: document.getElementById('active-dns-records'),
+
+    // Revoke confirmation sub-modal
+    revokeModal: document.getElementById('delete-domain-modal'),
+    revokeFqdn: document.getElementById('delete-domain-fqdn'),
+    revokeUrlCount: document.getElementById('delete-domain-url-count'),
+    revokeError: document.getElementById('delete-domain-error'),
+    revokeCancel: document.getElementById('btn-cancel-domain-delete'),
+    revokeConfirm: document.getElementById('btn-confirm-domain-delete'),
 };
 
-let pendingDeleteDomain = null;
+// State
+let currentMode = null;
+let currentDomain = null;
+let domainsCache = [];
+let pollTimer = null;
+let pollDeadline = 0;
 
-// ── Helpers ────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────
 
-function setError(node, message) {
+function escapeHtml(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+}
+
+function statusClass(status) {
+    return `status-${String(status || '').toLowerCase()}`;
+}
+
+function timeAgo(iso) {
+    if (!iso) return '';
+    const ms = Date.now() - new Date(iso).getTime();
+    const mins = Math.floor(ms / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} min${mins === 1 ? '' : 's'} ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs} hr${hrs === 1 ? '' : 's'} ago`;
+    const days = Math.floor(hrs / 24);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+function setError(node, msg) {
     if (!node) return;
-    if (!message) {
+    if (!msg) {
         node.style.display = 'none';
         node.textContent = '';
         return;
     }
-    node.textContent = message;
+    node.textContent = msg;
     node.style.display = 'block';
 }
 
-function statusBadgeClass(status) {
-    const s = String(status || '').toUpperCase();
-    return `status-${s.toLowerCase()}`;
+function showSlot(mode) {
+    document.querySelectorAll('#domainModal .modal-slot').forEach(slot => {
+        slot.style.display = slot.dataset.mode === mode ? '' : 'none';
+    });
+    currentMode = mode;
 }
 
-function formatDate(value) {
-    if (!value) return '—';
-    try {
-        return new Date(value).toLocaleDateString();
-    } catch (_) {
-        return '—';
-    }
-}
-
-// ── Fetch + render ─────────────────────────────────────────────────────────
+// ── List fetch + render ───────────────────────────────────────────────────
 
 async function fetchDomains() {
-    setLoading(true);
-    domainElements.empty.style.display = 'none';
+    el.listLoading.style.display = 'flex';
+    el.listEmpty.style.display = 'none';
+    el.list.style.display = 'none';
     try {
         const res = await authFetch('/api/v1/custom-domains', {
             headers: { 'Accept': 'application/json' },
         });
-        if (!res.ok) throw new Error('Failed to fetch domains');
+        if (!res.ok) throw new Error('failed to fetch domains');
         const data = await res.json();
-        renderDomains(data.items || []);
+        domainsCache = data.items || [];
+        renderList(domainsCache);
     } catch (err) {
-        console.error('Error fetching domains:', err);
-        showEmptyState();
+        console.error('domains list fetch failed', err);
+        showNotification('Failed to load domains', 'error');
     } finally {
-        setLoading(false);
+        el.listLoading.style.display = 'none';
     }
 }
 
-function setLoading(loading) {
-    domainElements.loading.style.display = loading ? 'flex' : 'none';
-    if (loading) {
-        domainElements.list.style.display = 'none';
-        domainElements.empty.style.display = 'none';
-    }
-}
-
-function showEmptyState() {
-    domainElements.empty.style.display = 'flex';
-    domainElements.list.style.display = 'none';
-}
-
-function renderDomains(domains) {
-    domainElements.list.innerHTML = '';
+function renderList(domains) {
+    el.list.innerHTML = '';
     if (!domains || domains.length === 0) {
-        showEmptyState();
+        el.listEmpty.style.display = 'flex';
+        el.list.style.display = 'none';
         return;
     }
-    domainElements.list.style.display = 'flex';
-    domainElements.empty.style.display = 'none';
+    el.listEmpty.style.display = 'none';
+    el.list.style.display = 'flex';
 
-    const fragment = document.createDocumentFragment();
-    domains.forEach(d => fragment.appendChild(createDomainCard(d)));
-    domainElements.list.appendChild(fragment);
+    const frag = document.createDocumentFragment();
+    domains.forEach(d => frag.appendChild(createRow(d)));
+    el.list.appendChild(frag);
 }
 
-function createDomainCard(domain) {
-    const node = domainElements.template.content.firstElementChild.cloneNode(true);
-    node.dataset.id = domain.id;
+function createRow(domain) {
+    const row = el.rowTpl.content.firstElementChild.cloneNode(true);
+    row.dataset.id = domain.id;
+    row.href = `?domain=${encodeURIComponent(domain.id)}`;
 
-    node.querySelector('.domain-fqdn').textContent = domain.fqdn;
-    node.querySelector('.domain-meta').textContent =
-        `Registered ${formatDate(domain.created_at)}`;
+    row.querySelector('.domain-fqdn').textContent = domain.fqdn;
 
-    const statusEl = node.querySelector('.status-badge');
+    const badge = row.querySelector('.status-badge');
     const status = String(domain.status || '').toUpperCase();
-    statusEl.textContent = status;
-    statusEl.classList.add(statusBadgeClass(status));
+    badge.textContent = status;
+    badge.classList.add(statusClass(status));
 
-    // Verify button only when not ACTIVE and not REVOKED.
-    const verifyBtn = node.querySelector('.btn-verify');
-    if (status === 'ACTIVE' || status === 'REVOKED') {
-        verifyBtn.style.display = 'none';
-    } else {
-        verifyBtn.addEventListener('click', () => verifyDomain(domain.id));
-    }
+    row.querySelector('.domain-row-meta').textContent =
+        domain.status === 'ACTIVE'
+            ? `Verified ${timeAgo(domain.last_verified_at)}`
+            : `Added ${timeAgo(domain.created_at)}`;
 
-    // Delete button hidden once REVOKED.
-    const deleteBtn = node.querySelector('.btn-revoke');
-    if (status === 'REVOKED') {
-        deleteBtn.style.display = 'none';
-    } else {
-        deleteBtn.addEventListener('click', () => openDeleteModal(domain));
-    }
+    row.addEventListener('click', (e) => {
+        e.preventDefault();
+        openDomainModal(domain.id);
+    });
+    return row;
+}
 
-    // DNS instructions — show only when setup is still required.
-    const dnsBlock = node.querySelector('.dns-instructions');
-    if (status === 'ACTIVE' || status === 'REVOKED') {
-        dnsBlock.style.display = 'none';
-    } else {
-        renderDnsRecords(
-            dnsBlock.querySelector('.dns-records'),
-            domain.dns_records || []
-        );
-    }
+// ── Modal: open / close / URL sync ────────────────────────────────────────
 
-    // Setup notes (orange-cloud warning, etc.)
-    const notesBlock = node.querySelector('.setup-notes');
-    if (status === 'ACTIVE' || status === 'REVOKED' || !domain.setup_notes || domain.setup_notes.length === 0) {
-        notesBlock.style.display = 'none';
-    } else {
-        notesBlock.innerHTML = '';
-        domain.setup_notes.forEach(note => {
-            const p = document.createElement('p');
-            p.textContent = note;
-            notesBlock.appendChild(p);
+function openAddModal({ push = true } = {}) {
+    currentDomain = null;
+    el.addInput.value = '';
+    setError(el.addError, '');
+    el.modalTitle.textContent = 'Add a domain';
+    el.modalBadge.style.display = 'none';
+
+    el.modalCancel.style.display = '';
+    el.modalSubmit.style.display = '';
+    el.modalSubmit.textContent = 'Add';
+    el.modalRevoke.style.display = 'none';
+
+    showSlot('add');
+    showModal();
+    if (push) syncUrl({ new: '1' });
+    setTimeout(() => el.addInput.focus(), 60);
+}
+
+async function openDomainModal(id, { push = true } = {}) {
+    if (!id) return;
+    currentDomain = null;
+
+    el.modalTitle.textContent = 'Loading…';
+    el.modalBadge.style.display = 'none';
+    el.modalCancel.style.display = '';
+    el.modalSubmit.style.display = 'none';
+    el.modalRevoke.style.display = 'none';
+
+    showModal();
+    if (push) syncUrl({ domain: id });
+
+    try {
+        const res = await authFetch(`/api/v1/custom-domains/${encodeURIComponent(id)}`, {
+            headers: { 'Accept': 'application/json' },
         });
+        if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body.error || `Request failed (${res.status})`);
+        }
+        const doc = await res.json();
+        currentDomain = doc;
+        renderForStatus(doc);
+    } catch (err) {
+        showNotification(`Couldn't load domain: ${err.message}`, 'error');
+        closeModal();
     }
+}
 
-    // Last verification error
-    const errBlock = node.querySelector('.verification-error');
-    if (domain.last_verification_error) {
-        errBlock.textContent = `⚠ ${domain.last_verification_error}`;
+function showModal() {
+    el.modal.style.display = 'flex';
+    el.modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+}
+
+function closeModal({ push = true } = {}) {
+    stopPoll();
+    el.modal.style.display = 'none';
+    el.modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    currentDomain = null;
+    currentMode = null;
+    if (push) syncUrl({});
+}
+
+function syncUrl(params) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) qs.set(k, v);
+    const url = qs.toString() ? `?${qs.toString()}` : window.location.pathname;
+    history.replaceState(null, '', url);
+}
+
+// ── Render by status ──────────────────────────────────────────────────────
+
+function renderForStatus(doc) {
+    el.modalTitle.textContent = doc.fqdn;
+    const status = String(doc.status || '').toUpperCase();
+    el.modalBadge.textContent = status;
+    el.modalBadge.className = `status-badge modal-status-badge ${statusClass(status)}`;
+    el.modalBadge.style.display = '';
+
+    el.modalSubmit.style.display = 'none';
+    el.modalCancel.textContent = 'Close';
+
+    if (status === 'PENDING' || status === 'SUSPENDED') {
+        renderSetup(doc, status);
+    } else if (status === 'ACTIVE') {
+        renderActive(doc);
+    } else if (status === 'REVOKED') {
+        renderRevoked(doc);
+    }
+}
+
+function renderSetup(doc, status) {
+    el.setupBanner.classList.remove('banner-pending', 'banner-suspended');
+    el.setupBanner.classList.add(
+        status === 'SUSPENDED' ? 'banner-suspended' : 'banner-pending'
+    );
+    el.setupBanner.textContent = status === 'SUSPENDED'
+        ? 'Verification lost. Check your DNS records and click Verify.'
+        : 'Add the DNS record(s) below at your DNS provider, then click Verify.';
+
+    renderDnsRecords(el.setupRecords, doc.dns_records || []);
+
+    if (doc.setup_notes && doc.setup_notes.length) {
+        el.setupNotes.innerHTML = '';
+        doc.setup_notes.forEach(n => {
+            const p = document.createElement('p');
+            p.textContent = n;
+            el.setupNotes.appendChild(p);
+        });
+        el.setupNotes.style.display = '';
     } else {
-        errBlock.style.display = 'none';
+        el.setupNotes.style.display = 'none';
     }
 
-    return node;
+    setError(el.setupError, doc.last_verification_error || '');
+    el.setupPoll.style.display = 'none';
+    resetVerifyButton();
+
+    el.modalRevoke.style.display = '';
+
+    showSlot('setup');
+}
+
+function renderActive(doc) {
+    el.activeOpenLink.href = `https://${doc.fqdn}`;
+    el.activeOpenLabel.textContent = `Open ${doc.fqdn}`;
+
+    const verifiedLine = doc.last_verified_at
+        ? `Verified ${timeAgo(doc.last_verified_at)}`
+        : 'Live';
+    el.activeMeta.textContent = verifiedLine;
+
+    renderDnsRecords(el.activeDnsRecords, doc.dns_records || []);
+
+    el.modalRevoke.style.display = '';
+
+    showSlot('active');
+}
+
+function renderRevoked(doc) {
+    el.modalRevoke.style.display = 'none';
+    showSlot('revoked');
 }
 
 function renderDnsRecords(container, records) {
     container.innerHTML = '';
-    if (!records || records.length === 0) {
-        container.style.display = 'none';
-        return;
-    }
+    if (!records.length) return;
     records.forEach(rec => {
-        const row = domainElements.dnsTemplate.content.firstElementChild.cloneNode(true);
-        row.querySelector('.rec-type').textContent = rec.type;
-        row.querySelector('.rec-name').textContent = rec.name;
-        row.querySelector('.rec-value').textContent = rec.value;
-        const purposeEl = row.querySelector('.rec-purpose');
-        if (rec.purpose) {
-            purposeEl.textContent = rec.purpose;
-        } else {
-            purposeEl.style.display = 'none';
-        }
-        container.appendChild(row);
+        const node = el.dnsTpl.content.firstElementChild.cloneNode(true);
+        node.querySelector('.rec-type').textContent = rec.type;
+        node.querySelector('.rec-name').textContent = rec.name;
+        node.querySelector('.rec-value').textContent = rec.value;
+        const copyBtn = node.querySelector('.rec-copy');
+        copyBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            copyToClipboard(rec.value, copyBtn);
+        });
+        container.appendChild(node);
     });
 }
 
-// ── Verify ─────────────────────────────────────────────────────────────────
-
-async function verifyDomain(id) {
+async function copyToClipboard(text, btn) {
     try {
-        const res = await authFetch(`/api/v1/custom-domains/${id}/verify`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-            body: JSON.stringify({}),
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(data.error || 'Verification failed');
-        showNotification('Verification triggered. Refreshing…', 'success');
-        await fetchDomains();
-    } catch (err) {
-        showNotification(`Verify failed: ${err.message}`, 'error');
+        await navigator.clipboard.writeText(text);
+        const icon = btn.querySelector('i');
+        const original = icon.className;
+        icon.className = 'ti ti-check';
+        btn.classList.add('copied');
+        setTimeout(() => {
+            icon.className = original;
+            btn.classList.remove('copied');
+        }, 1200);
+    } catch (_) {
+        showNotification('Copy failed — select and copy manually', 'error');
     }
 }
 
-// ── Add modal ──────────────────────────────────────────────────────────────
+// ── Add submit ────────────────────────────────────────────────────────────
 
-function openAddModal() {
-    domainElements.addInput.value = '';
-    setError(domainElements.addError, '');
-    domainElements.addModal.style.display = 'flex';
-    domainElements.addModal.setAttribute('aria-hidden', 'false');
-    setTimeout(() => domainElements.addInput.focus(), 50);
-}
-
-function closeAddModal() {
-    domainElements.addModal.style.display = 'none';
-    domainElements.addModal.setAttribute('aria-hidden', 'true');
-}
-
-async function submitNewDomain() {
-    const fqdn = (domainElements.addInput.value || '').trim();
+async function submitAdd() {
+    const fqdn = (el.addInput.value || '').trim();
     if (!fqdn) {
-        setError(domainElements.addError, 'Enter a domain (e.g. links.acme.com)');
+        setError(el.addError, 'Enter a domain (e.g. links.yoursite.com)');
         return;
     }
-    setError(domainElements.addError, '');
-    domainElements.addSubmitBtn.disabled = true;
+    setError(el.addError, '');
+    el.modalSubmit.disabled = true;
     try {
         const res = await authFetch('/api/v1/custom-domains', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
             body: JSON.stringify({ fqdn }),
         });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
-        showNotification(
-            `${fqdn} registered. Publish the DNS records, then verify.`,
-            'success'
-        );
-        closeAddModal();
-        await fetchDomains();
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
+        showNotification(`${body.fqdn} added — add the DNS record, then verify.`, 'success');
+        // Refresh list in background; morph current modal to setup mode.
+        fetchDomains();
+        currentDomain = body;
+        syncUrl({ domain: body.id });
+        renderForStatus(body);
     } catch (err) {
-        setError(domainElements.addError, err.message);
+        setError(el.addError, err.message);
     } finally {
-        domainElements.addSubmitBtn.disabled = false;
+        el.modalSubmit.disabled = false;
     }
 }
 
-// ── Delete modal ───────────────────────────────────────────────────────────
+// ── Verify + auto-poll ────────────────────────────────────────────────────
 
-async function openDeleteModal(domain) {
-    pendingDeleteDomain = domain;
-    domainElements.delFqdnEl.textContent = domain.fqdn;
-    domainElements.delUrlCountEl.textContent = '…';
-    setError(domainElements.delError, '');
-    // Reset cascade choice to "orphan" default.
-    const orphanRadio = domainElements.deleteModal.querySelector(
-        'input[name="cascade"][value="false"]'
-    );
-    if (orphanRadio) orphanRadio.checked = true;
+async function clickVerify() {
+    if (!currentDomain) return;
+    setError(el.setupError, '');
+    el.setupPoll.style.display = 'none';
+    setVerifyBusy(true);
+    try {
+        const res = await authFetch(
+            `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}/verify`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                body: JSON.stringify({}),
+            }
+        );
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
 
-    domainElements.deleteModal.classList.add('active');
-    domainElements.deleteModal.setAttribute('aria-hidden', 'false');
+        currentDomain = body;
+        const status = String(body.status || '').toUpperCase();
+        if (status === 'ACTIVE') {
+            showNotification('Domain verified — it\'s now live.', 'success');
+            renderForStatus(body);
+            fetchDomains();
+            return;
+        }
+        if (body.last_verification_error) {
+            setError(el.setupError, body.last_verification_error);
+            setVerifyBusy(false);
+            return;
+        }
+        // Still PENDING with no explicit error — CF may still be validating.
+        el.setupPoll.style.display = 'block';
+        startPoll(currentDomain.id);
+    } catch (err) {
+        setError(el.setupError, err.message);
+        setVerifyBusy(false);
+    }
+}
+
+function startPoll(id) {
+    stopPoll();
+    pollDeadline = Date.now() + POLL_MAX_DURATION_MS;
+    pollTimer = setInterval(async () => {
+        if (Date.now() > pollDeadline) {
+            stopPoll();
+            setVerifyBusy(false);
+            el.setupPoll.style.display = 'none';
+            setError(el.setupError,
+                'Still waiting on DNS. Try again in a few minutes.');
+            return;
+        }
+        try {
+            const res = await authFetch(
+                `/api/v1/custom-domains/${encodeURIComponent(id)}`,
+                { headers: { 'Accept': 'application/json' } }
+            );
+            if (!res.ok) return;
+            const doc = await res.json();
+            if (!currentDomain || currentDomain.id !== doc.id) {
+                stopPoll();
+                return;
+            }
+            currentDomain = doc;
+            const status = String(doc.status || '').toUpperCase();
+            if (status === 'ACTIVE') {
+                stopPoll();
+                showNotification('Domain verified — it\'s now live.', 'success');
+                renderForStatus(doc);
+                fetchDomains();
+            }
+        } catch (_) {
+            // Network blip — keep polling; next tick will retry.
+        }
+    }, POLL_INTERVAL_MS);
+}
+
+function stopPoll() {
+    if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+}
+
+function setVerifyBusy(busy) {
+    el.setupVerify.disabled = busy;
+    el.setupVerify.querySelector('.btn-label').textContent =
+        busy ? 'Verifying…' : 'Verify domain';
+    el.setupVerify.querySelector('.btn-spinner').style.display =
+        busy ? '' : 'none';
+}
+
+function resetVerifyButton() {
+    setVerifyBusy(false);
+}
+
+// ── Revoke sub-modal ──────────────────────────────────────────────────────
+
+async function openRevokeModal() {
+    if (!currentDomain) return;
+    el.revokeFqdn.textContent = currentDomain.fqdn;
+    el.revokeUrlCount.textContent = '…';
+    setError(el.revokeError, '');
+    const orphan = el.revokeModal.querySelector('input[name="cascade"][value="false"]');
+    if (orphan) orphan.checked = true;
+
+    el.revokeModal.classList.add('active');
+    el.revokeModal.setAttribute('aria-hidden', 'false');
 
     try {
         const res = await authFetch(
-            `/api/v1/urls?domain=${encodeURIComponent(domain.fqdn)}&pageSize=1`,
+            `/api/v1/urls?domain=${encodeURIComponent(currentDomain.fqdn)}&pageSize=1`,
             { headers: { 'Accept': 'application/json' } }
         );
         if (res.ok) {
-            const data = await res.json();
-            domainElements.delUrlCountEl.textContent = String(data.total || 0);
+            const body = await res.json();
+            el.revokeUrlCount.textContent = String(body.total || 0);
         } else {
-            domainElements.delUrlCountEl.textContent = '?';
+            el.revokeUrlCount.textContent = '?';
         }
     } catch (_) {
-        domainElements.delUrlCountEl.textContent = '?';
+        el.revokeUrlCount.textContent = '?';
     }
 }
 
-function closeDeleteModal() {
-    domainElements.deleteModal.classList.remove('active');
-    domainElements.deleteModal.setAttribute('aria-hidden', 'true');
-    pendingDeleteDomain = null;
+function closeRevokeModal() {
+    el.revokeModal.classList.remove('active');
+    el.revokeModal.setAttribute('aria-hidden', 'true');
 }
 
-async function confirmDelete() {
-    if (!pendingDeleteDomain) return;
-    const selected = domainElements.deleteModal.querySelector(
-        'input[name="cascade"]:checked'
-    );
+async function confirmRevoke() {
+    if (!currentDomain) return;
+    const selected = el.revokeModal.querySelector('input[name="cascade"]:checked');
     const cascade = selected && selected.value === 'true';
 
-    setError(domainElements.delError, '');
-    domainElements.confirmDeleteBtn.disabled = true;
+    setError(el.revokeError, '');
+    el.revokeConfirm.disabled = true;
     try {
-        const url = `/api/v1/custom-domains/${pendingDeleteDomain.id}?cascade=${cascade}`;
+        const url = `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}?cascade=${cascade}`;
         const res = await authFetch(url, { method: 'DELETE' });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
-        const detail = cascade
-            ? ` (${data.urls_deleted} URL(s) deleted)`
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
+        const tail = cascade
+            ? ` (${body.urls_deleted} URL(s) deleted)`
             : ' (URLs orphaned)';
-        showNotification(
-            `${pendingDeleteDomain.fqdn} revoked${detail}`,
-            'success'
-        );
-        closeDeleteModal();
-        await fetchDomains();
+        showNotification(`${currentDomain.fqdn} revoked${tail}`, 'success');
+        closeRevokeModal();
+        closeModal();
+        fetchDomains();
     } catch (err) {
-        setError(domainElements.delError, err.message);
+        setError(el.revokeError, err.message);
     } finally {
-        domainElements.confirmDeleteBtn.disabled = false;
+        el.revokeConfirm.disabled = false;
     }
 }
 
-// ── Bootstrap ──────────────────────────────────────────────────────────────
+// ── Wire-up ───────────────────────────────────────────────────────────────
 
 document.addEventListener('DOMContentLoaded', () => {
     fetchDomains();
 
-    domainElements.newBtn.addEventListener('click', openAddModal);
-    domainElements.addSubmitBtn.addEventListener('click', submitNewDomain);
-    domainElements.addInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') submitNewDomain();
-    });
+    // Initial URL inspection — open the right modal if QS specifies one.
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('new')) {
+        openAddModal({ push: false });
+    } else if (params.get('domain')) {
+        openDomainModal(params.get('domain'), { push: false });
+    }
 
-    domainElements.cancelDeleteBtn.addEventListener('click', closeDeleteModal);
-    domainElements.confirmDeleteBtn.addEventListener('click', confirmDelete);
+    el.newBtn.addEventListener('click', () => openAddModal());
 
-    // Add-modal backdrop click.
-    domainElements.addModal.addEventListener('click', (e) => {
-        if (e.target === domainElements.addModal
-            || e.target.classList.contains('modal-overlay')) {
-            closeAddModal();
+    el.modalClose.addEventListener('click', () => closeModal());
+    el.modalCancel.addEventListener('click', () => closeModal());
+    el.modal.addEventListener('click', (e) => {
+        if (e.target === el.modal || e.target.classList.contains('modal-overlay')) {
+            closeModal();
         }
     });
-    // Delete-modal backdrop click.
-    domainElements.deleteModal.addEventListener('click', (e) => {
-        if (e.target.classList.contains('modal-container')
-            || e.target.classList.contains('modal-backdrop')) {
-            closeDeleteModal();
+
+    el.modalSubmit.addEventListener('click', submitAdd);
+    el.addInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') submitAdd();
+    });
+
+    el.setupVerify.addEventListener('click', clickVerify);
+
+    el.modalRevoke.addEventListener('click', openRevokeModal);
+    el.revokeCancel.addEventListener('click', closeRevokeModal);
+    el.revokeConfirm.addEventListener('click', confirmRevoke);
+    el.revokeModal.addEventListener('click', (e) => {
+        if (
+            e.target.classList.contains('modal-container') ||
+            e.target.classList.contains('modal-backdrop')
+        ) {
+            closeRevokeModal();
         }
     });
 
     document.addEventListener('keydown', (e) => {
         if (e.key !== 'Escape') return;
-        if (domainElements.deleteModal.classList.contains('active')) {
-            closeDeleteModal();
-        } else if (domainElements.addModal.style.display === 'flex') {
-            closeAddModal();
+        if (el.revokeModal.classList.contains('active')) {
+            closeRevokeModal();
+        } else if (el.modal.style.display === 'flex') {
+            closeModal();
+        }
+    });
+
+    window.addEventListener('popstate', () => {
+        // Browser back/forward — sync modal to new URL.
+        const p = new URLSearchParams(window.location.search);
+        if (p.get('new')) {
+            openAddModal({ push: false });
+        } else if (p.get('domain')) {
+            openDomainModal(p.get('domain'), { push: false });
+        } else {
+            // Closed
+            stopPoll();
+            el.modal.style.display = 'none';
+            el.modal.setAttribute('aria-hidden', 'true');
+            document.body.style.overflow = '';
         }
     });
 });
-
-window.closeCreateDomainModal = closeAddModal;
-window.closeDeleteDomainModal = closeDeleteModal;

--- a/templates/dashboard/domains.html
+++ b/templates/dashboard/domains.html
@@ -1,0 +1,184 @@
+{% extends "dashboard/base.html" %}
+
+{% block title %}Custom Domains | Dashboard | spoo.me{% endblock %}
+
+{% block head_css %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/keys.css') }}?v=7">
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=1">
+<meta name="robots" content="noindex">
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div class="page-header-content">
+        <div class="page-header-text">
+            <h1 class="page-title">Custom Domains</h1>
+            <p class="page-subtitle">Serve branded short links from your own domain.
+                <small style="color: var(--text-secondary);">Beta — staff allowlist only.</small>
+            </p>
+        </div>
+        <div class="page-header-actions">
+            <a href="https://docs.spoo.me" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">
+                <i class="ti ti-book"></i>
+                <span>Setup Guide</span>
+            </a>
+        </div>
+    </div>
+</div>
+
+<div class="keys-container domains-container surface">
+    <div class="keys-toolbar domains-toolbar">
+        <div class="toolbar-left">
+            <h3>Your Custom Domains</h3>
+        </div>
+        <div class="toolbar-right">
+            <button class="btn btn-primary" id="btn-new-domain">
+                <i class="ti ti-plus"></i>
+                <span>Add Domain</span>
+            </button>
+        </div>
+    </div>
+
+    <div id="domains-container" class="domains-list-container">
+        <div id="domains-loading" class="loading">Loading…</div>
+        <div id="domains-empty" class="empty" style="display:none">
+            <div class="empty-state">
+                <div class="empty-icon">
+                    <i class="ti ti-world-off"></i>
+                </div>
+                <h3 class="empty-title">No Custom Domains Yet</h3>
+                <p class="empty-message">Register a domain to start serving short links from your own brand.</p>
+            </div>
+        </div>
+
+        <div id="domains-list" class="domains-list" style="display:none"></div>
+    </div>
+</div>
+
+<!-- Add domain modal -->
+<div id="createDomainModal" class="modal create-domain-modal" aria-hidden="true" style="display:none">
+    <div class="modal-overlay"></div>
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="createDomainModalTitle">
+        <div class="modal-header">
+            <h2 id="createDomainModalTitle">Register Custom Domain</h2>
+            <button class="modal-close" onclick="closeCreateDomainModal()" aria-label="Close modal">
+                <i class="ti ti-x"></i>
+            </button>
+        </div>
+
+        <div class="modal-body">
+            <div class="form-grid">
+                <div class="field">
+                    <label for="domain-fqdn">Domain (fqdn)</label>
+                    <input id="domain-fqdn" type="text" placeholder="links.acme.com" autocomplete="off" />
+                    <small style="color: var(--text-secondary); display:block; margin-top:6px;">
+                        For apex domains (e.g. <code>acme.com</code>), your DNS provider must support
+                        CNAME flattening — Cloudflare, Route 53 ALIAS, or DNSimple.
+                    </small>
+                </div>
+                <div id="add-domain-error" class="verification-error" style="display:none"></div>
+            </div>
+        </div>
+
+        <div class="modal-footer">
+            <button class="btn btn-ghost" onclick="closeCreateDomainModal()">Cancel</button>
+            <button class="btn btn-primary" id="btn-create-domain">Register</button>
+        </div>
+    </div>
+</div>
+
+<!-- Delete (revoke) confirmation modal -->
+<div id="delete-domain-modal" aria-hidden="true">
+    <div class="modal-backdrop"></div>
+    <div class="modal-container">
+        <div class="modal-content" role="dialog" aria-modal="true"
+            aria-labelledby="deleteDomainModalTitle" aria-describedby="deleteDomainModalDesc">
+            <div class="modal-header">
+                <div class="modal-title-section-delete">
+                    <div class="modal-icon">
+                        <i class="ti ti-alert-triangle"></i>
+                    </div>
+                    <h2 class="modal-title" id="deleteDomainModalTitle">Revoke Custom Domain?</h2>
+                </div>
+            </div>
+
+            <div class="modal-body">
+                <p id="deleteDomainModalDesc">
+                    <strong id="delete-domain-fqdn"></strong> has
+                    <strong id="delete-domain-url-count">…</strong> URL(s) on it.
+                    What should happen to them?
+                </p>
+                <div class="cascade-choice">
+                    <label class="cascade-option">
+                        <input type="radio" name="cascade" value="false" checked>
+                        <span class="cascade-option-label">Keep the URLs (orphan)</span>
+                        <div class="cascade-option-desc">
+                            URLs become unreachable. If you re-register this domain later, they resume working.
+                        </div>
+                    </label>
+                    <label class="cascade-option">
+                        <input type="radio" name="cascade" value="true">
+                        <span class="cascade-option-label">Delete all URLs permanently</span>
+                        <div class="cascade-option-desc warning">
+                            Destination data is lost. Aliases free up for reuse. Cannot be undone.
+                        </div>
+                    </label>
+                </div>
+                <div id="delete-domain-error" class="verification-error" style="display:none"></div>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-cancel" id="btn-cancel-domain-delete">
+                    <span>Cancel</span>
+                </button>
+                <button type="button" class="btn btn-delete" id="btn-confirm-domain-delete">
+                    <i class="ti ti-trash"></i>
+                    <span>Revoke Domain</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Per-domain card template -->
+<template id="tpl-domain-item">
+    <div class="domain-card fade-in">
+        <div class="domain-card-head">
+            <span class="domain-fqdn"></span>
+            <span class="status-badge"></span>
+            <span class="domain-meta"></span>
+            <div class="domain-actions">
+                <button class="btn btn-ghost btn-sm btn-verify">
+                    <i class="ti ti-refresh"></i><span>Verify</span>
+                </button>
+                <button class="btn btn-danger btn-sm btn-revoke">
+                    <i class="ti ti-trash"></i><span>Revoke</span>
+                </button>
+            </div>
+        </div>
+
+        <div class="dns-instructions">
+            <p class="dns-instructions-title">DNS records to publish</p>
+            <div class="dns-records"></div>
+        </div>
+
+        <div class="setup-notes"></div>
+        <div class="verification-error"></div>
+    </div>
+</template>
+
+<!-- Per-DNS-record template -->
+<template id="tpl-dns-record">
+    <div class="dns-record">
+        <span class="rec-type"></span>
+        <span class="rec-name"></span>
+        <span class="rec-value"></span>
+        <span class="rec-purpose"></span>
+    </div>
+</template>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', path='js/verification-check.js') }}?v=1"></script>
+<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=1"></script>
+{% endblock %}

--- a/templates/dashboard/domains.html
+++ b/templates/dashboard/domains.html
@@ -4,7 +4,7 @@
 
 {% block head_css %}
 <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/keys.css') }}?v=7">
-<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=2">
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=4">
 <meta name="robots" content="noindex">
 {% endblock %}
 
@@ -14,7 +14,7 @@
         <div class="page-header-text">
             <h1 class="page-title">Custom Domains</h1>
             <p class="page-subtitle">Serve branded short links from your own domain.
-                <small style="color: var(--text-secondary);">Beta — staff allowlist only.</small>
+                <small style="color: var(--text-secondary);">Private beta.</small>
             </p>
         </div>
         <div class="page-header-actions">
@@ -87,19 +87,13 @@
             <!-- Setup mode (PENDING / SUSPENDED) -->
             <div class="modal-slot" data-mode="setup" style="display:none">
                 <div class="banner banner-pending" id="setup-banner">
-                    Add the DNS record below at your DNS provider, then click Verify.
+                    Add the DNS record(s) below at your DNS provider, then click Verify.
                 </div>
 
                 <h3 class="section-title">DNS record</h3>
                 <div class="dns-records" id="dns-records"></div>
                 <div class="setup-notes" id="setup-notes" style="display:none"></div>
 
-                <button class="btn btn-primary btn-block" id="btn-verify">
-                    <span class="btn-label">Verify domain</span>
-                    <span class="btn-spinner" style="display:none">
-                        <i class="ti ti-loader-2"></i>
-                    </span>
-                </button>
                 <div id="setup-error" class="inline-error" style="display:none"></div>
                 <div id="setup-poll-status" class="inline-info" style="display:none">
                     Checking DNS… we'll keep watching for a minute.
@@ -110,7 +104,7 @@
             <div class="modal-slot" data-mode="active" style="display:none">
                 <div class="banner banner-active">
                     <i class="ti ti-check"></i>
-                    Live — short links work on this domain.
+                    Live. Short links work on this domain.
                 </div>
 
                 <a id="active-open-link" class="btn btn-secondary btn-block" target="_blank" rel="noopener noreferrer">
@@ -135,10 +129,15 @@
         </div>
 
         <div class="modal-footer" id="domain-modal-footer">
-            <!-- Footer button set per mode (rendered by JS) -->
-            <button type="button" class="btn btn-ghost" id="btn-domain-modal-cancel">Cancel</button>
             <button type="button" class="btn btn-danger-ghost" id="btn-domain-revoke" style="display:none">Revoke</button>
-            <button type="button" class="btn btn-primary" id="btn-domain-modal-submit">Add</button>
+            <button type="button" class="btn btn-ghost" id="btn-domain-modal-cancel" style="display:none">Cancel</button>
+            <button type="button" class="btn btn-primary" id="btn-domain-modal-submit" style="display:none">Add</button>
+            <button type="button" class="btn btn-primary" id="btn-verify" style="display:none">
+                <span class="btn-label">Verify</span>
+                <span class="btn-spinner" style="display:none">
+                    <i class="ti ti-loader-2"></i>
+                </span>
+            </button>
         </div>
     </div>
 </div>
@@ -229,5 +228,5 @@
 
 {% block scripts %}
 <script src="{{ url_for('static', path='js/verification-check.js') }}?v=1"></script>
-<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=2"></script>
+<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=4"></script>
 {% endblock %}

--- a/templates/dashboard/domains.html
+++ b/templates/dashboard/domains.html
@@ -4,7 +4,7 @@
 
 {% block head_css %}
 <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/keys.css') }}?v=7">
-<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=1">
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=2">
 <meta name="robots" content="noindex">
 {% endblock %}
 
@@ -29,7 +29,7 @@
 <div class="keys-container domains-container surface">
     <div class="keys-toolbar domains-toolbar">
         <div class="toolbar-left">
-            <h3>Your Custom Domains</h3>
+            <h3>Your Domains</h3>
         </div>
         <div class="toolbar-right">
             <button class="btn btn-primary" id="btn-new-domain">
@@ -46,48 +46,104 @@
                 <div class="empty-icon">
                     <i class="ti ti-world-off"></i>
                 </div>
-                <h3 class="empty-title">No Custom Domains Yet</h3>
-                <p class="empty-message">Register a domain to start serving short links from your own brand.</p>
+                <h3 class="empty-title">No domains yet</h3>
+                <p class="empty-message">Add a domain to serve short links under your own brand.</p>
             </div>
         </div>
-
         <div id="domains-list" class="domains-list" style="display:none"></div>
     </div>
 </div>
 
-<!-- Add domain modal -->
-<div id="createDomainModal" class="modal create-domain-modal" aria-hidden="true" style="display:none">
+<!-- One large modal, four content slots — JS swaps which slot is visible -->
+<div id="domainModal" class="modal modal-large" aria-hidden="true" style="display:none">
     <div class="modal-overlay"></div>
-    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="createDomainModalTitle">
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="domainModalTitle">
         <div class="modal-header">
-            <h2 id="createDomainModalTitle">Register Custom Domain</h2>
-            <button class="modal-close" onclick="closeCreateDomainModal()" aria-label="Close modal">
+            <div class="modal-header-left">
+                <h2 id="domainModalTitle">Add a domain</h2>
+                <span class="status-badge modal-status-badge" id="modalStatusBadge" style="display:none"></span>
+            </div>
+            <button class="modal-close" id="btn-close-domain-modal" aria-label="Close">
                 <i class="ti ti-x"></i>
             </button>
         </div>
 
         <div class="modal-body">
-            <div class="form-grid">
-                <div class="field">
-                    <label for="domain-fqdn">Domain (fqdn)</label>
-                    <input id="domain-fqdn" type="text" placeholder="links.acme.com" autocomplete="off" />
-                    <small style="color: var(--text-secondary); display:block; margin-top:6px;">
-                        For apex domains (e.g. <code>acme.com</code>), your DNS provider must support
-                        CNAME flattening — Cloudflare, Route 53 ALIAS, or DNSimple.
-                    </small>
+            <!-- Add mode -->
+            <div class="modal-slot" data-mode="add">
+                <div class="form-grid">
+                    <div class="field">
+                        <label for="domain-fqdn">Your domain</label>
+                        <input id="domain-fqdn" type="text" placeholder="links.yoursite.com" autocomplete="off" />
+                        <small class="field-hint">
+                            Subdomains like <code>links.yoursite.com</code> work best.
+                            Root domains need DNS that supports CNAME flattening (Cloudflare, Route 53, DNSimple).
+                        </small>
+                    </div>
+                    <div id="add-domain-error" class="inline-error" style="display:none"></div>
                 </div>
-                <div id="add-domain-error" class="verification-error" style="display:none"></div>
+            </div>
+
+            <!-- Setup mode (PENDING / SUSPENDED) -->
+            <div class="modal-slot" data-mode="setup" style="display:none">
+                <div class="banner banner-pending" id="setup-banner">
+                    Add the DNS record below at your DNS provider, then click Verify.
+                </div>
+
+                <h3 class="section-title">DNS record</h3>
+                <div class="dns-records" id="dns-records"></div>
+                <div class="setup-notes" id="setup-notes" style="display:none"></div>
+
+                <button class="btn btn-primary btn-block" id="btn-verify">
+                    <span class="btn-label">Verify domain</span>
+                    <span class="btn-spinner" style="display:none">
+                        <i class="ti ti-loader-2"></i>
+                    </span>
+                </button>
+                <div id="setup-error" class="inline-error" style="display:none"></div>
+                <div id="setup-poll-status" class="inline-info" style="display:none">
+                    Checking DNS… we'll keep watching for a minute.
+                </div>
+            </div>
+
+            <!-- Active mode -->
+            <div class="modal-slot" data-mode="active" style="display:none">
+                <div class="banner banner-active">
+                    <i class="ti ti-check"></i>
+                    Live — short links work on this domain.
+                </div>
+
+                <a id="active-open-link" class="btn btn-secondary btn-block" target="_blank" rel="noopener noreferrer">
+                    <i class="ti ti-external-link"></i>
+                    <span id="active-open-label">Open your domain</span>
+                </a>
+
+                <p class="active-meta" id="active-meta"></p>
+
+                <details class="collapsible">
+                    <summary>DNS record (for reference)</summary>
+                    <div class="dns-records" id="active-dns-records"></div>
+                </details>
+            </div>
+
+            <!-- Revoked mode -->
+            <div class="modal-slot" data-mode="revoked" style="display:none">
+                <div class="banner banner-revoked">
+                    This domain was revoked. Re-registration available 30 days after revocation.
+                </div>
             </div>
         </div>
 
-        <div class="modal-footer">
-            <button class="btn btn-ghost" onclick="closeCreateDomainModal()">Cancel</button>
-            <button class="btn btn-primary" id="btn-create-domain">Register</button>
+        <div class="modal-footer" id="domain-modal-footer">
+            <!-- Footer button set per mode (rendered by JS) -->
+            <button type="button" class="btn btn-ghost" id="btn-domain-modal-cancel">Cancel</button>
+            <button type="button" class="btn btn-danger-ghost" id="btn-domain-revoke" style="display:none">Revoke</button>
+            <button type="button" class="btn btn-primary" id="btn-domain-modal-submit">Add</button>
         </div>
     </div>
 </div>
 
-<!-- Delete (revoke) confirmation modal -->
+<!-- Revoke confirmation sub-modal — same pattern as #delete-key-modal -->
 <div id="delete-domain-modal" aria-hidden="true">
     <div class="modal-backdrop"></div>
     <div class="modal-container">
@@ -98,7 +154,7 @@
                     <div class="modal-icon">
                         <i class="ti ti-alert-triangle"></i>
                     </div>
-                    <h2 class="modal-title" id="deleteDomainModalTitle">Revoke Custom Domain?</h2>
+                    <h2 class="modal-title" id="deleteDomainModalTitle">Revoke domain?</h2>
                 </div>
             </div>
 
@@ -124,7 +180,7 @@
                         </div>
                     </label>
                 </div>
-                <div id="delete-domain-error" class="verification-error" style="display:none"></div>
+                <div id="delete-domain-error" class="inline-error" style="display:none"></div>
             </div>
 
             <div class="modal-footer">
@@ -133,52 +189,45 @@
                 </button>
                 <button type="button" class="btn btn-delete" id="btn-confirm-domain-delete">
                     <i class="ti ti-trash"></i>
-                    <span>Revoke Domain</span>
+                    <span>Revoke domain</span>
                 </button>
             </div>
         </div>
     </div>
 </div>
 
-<!-- Per-domain card template -->
-<template id="tpl-domain-item">
-    <div class="domain-card fade-in">
-        <div class="domain-card-head">
+<template id="tpl-domain-row">
+    <a class="domain-row fade-in">
+        <div class="domain-row-main">
             <span class="domain-fqdn"></span>
             <span class="status-badge"></span>
-            <span class="domain-meta"></span>
-            <div class="domain-actions">
-                <button class="btn btn-ghost btn-sm btn-verify">
-                    <i class="ti ti-refresh"></i><span>Verify</span>
-                </button>
-                <button class="btn btn-danger btn-sm btn-revoke">
-                    <i class="ti ti-trash"></i><span>Revoke</span>
-                </button>
-            </div>
         </div>
-
-        <div class="dns-instructions">
-            <p class="dns-instructions-title">DNS records to publish</p>
-            <div class="dns-records"></div>
-        </div>
-
-        <div class="setup-notes"></div>
-        <div class="verification-error"></div>
-    </div>
+        <span class="domain-row-meta"></span>
+        <i class="ti ti-chevron-right domain-row-chevron"></i>
+    </a>
 </template>
 
-<!-- Per-DNS-record template -->
 <template id="tpl-dns-record">
     <div class="dns-record">
         <span class="rec-type"></span>
-        <span class="rec-name"></span>
-        <span class="rec-value"></span>
-        <span class="rec-purpose"></span>
+        <div class="rec-fields">
+            <div class="rec-field">
+                <span class="rec-label">Name</span>
+                <code class="rec-name"></code>
+            </div>
+            <div class="rec-field">
+                <span class="rec-label">Value</span>
+                <code class="rec-value"></code>
+            </div>
+        </div>
+        <button type="button" class="rec-copy" title="Copy value">
+            <i class="ti ti-copy"></i>
+        </button>
     </div>
 </template>
 {% endblock %}
 
 {% block scripts %}
 <script src="{{ url_for('static', path='js/verification-check.js') }}?v=1"></script>
-<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=1"></script>
+<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=2"></script>
 {% endblock %}

--- a/templates/dashboard/partials/sidebar.html
+++ b/templates/dashboard/partials/sidebar.html
@@ -26,6 +26,12 @@
             <span class="nav-text">API Keys</span>
         </a>
 
+        <a href="/dashboard/domains" class="nav-item {% if request.path == '/dashboard/domains' %}active{% endif %}"
+            data-tooltip="Custom Domains">
+            <i class="ti ti-world"></i>
+            <span class="nav-text">Domains</span>
+        </a>
+
         <a href="/dashboard/statistics"
             class="nav-item {% if request.path == '/dashboard/statistics' %}active{% endif %}"
             data-tooltip="Statistics">

--- a/templates/dashboard/partials/sidebar.html
+++ b/templates/dashboard/partials/sidebar.html
@@ -26,11 +26,13 @@
             <span class="nav-text">API Keys</span>
         </a>
 
+        {% if show_custom_domains %}
         <a href="/dashboard/domains" class="nav-item {% if request.path == '/dashboard/domains' %}active{% endif %}"
             data-tooltip="Custom Domains">
             <i class="ti ti-world"></i>
             <span class="nav-text">Domains</span>
         </a>
+        {% endif %}
 
         <a href="/dashboard/statistics"
             class="nav-item {% if request.path == '/dashboard/statistics' %}active{% endif %}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,9 @@ def build_test_app(
         app.state.contact_service = AsyncMock()
         app.state.click_service = AsyncMock()
         app.state.app_grant_repo = AsyncMock()
+        app.state.custom_domain_service = AsyncMock()
+        app.state.feature_flag_service = AsyncMock()
+        app.state.tenant_resolver = AsyncMock()
         if extra_state:
             for key, value in extra_state.items():
                 setattr(app.state, key, value)

--- a/tests/integration/api_v1/conftest.py
+++ b/tests/integration/api_v1/conftest.py
@@ -8,11 +8,12 @@ dependency_overrides and a mock lifespan — no real infrastructure needed.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 
 from bson import ObjectId
 from fastapi import FastAPI
 
-from dependencies import CurrentUser
+from dependencies import CurrentUser, get_custom_domain_service
 from routes.api_v1 import router as api_v1_router
 from schemas.models.api_key import ApiKeyDoc
 from schemas.models.url import UrlV2Doc
@@ -20,8 +21,16 @@ from tests.conftest import build_test_app
 
 
 def _build_test_app(overrides: dict) -> FastAPI:
-    """Thin wrapper around the shared builder for api_v1 tests."""
-    return build_test_app(api_v1_router, overrides=overrides)
+    """Thin wrapper around the shared builder for api_v1 tests.
+
+    Auto-injects a default ``custom_domain_service`` mock so tests that don't
+    care about the domain selector don't have to wire one. Specific tests
+    that need to assert against the service can pass their own override.
+    """
+    final_overrides = dict(overrides)
+    if get_custom_domain_service not in final_overrides:
+        final_overrides[get_custom_domain_service] = lambda: AsyncMock()
+    return build_test_app(api_v1_router, overrides=final_overrides)
 
 
 def _make_url_doc(alias: str = "testme", owner_id: ObjectId | None = None) -> UrlV2Doc:

--- a/tests/integration/api_v1/test_shorten.py
+++ b/tests/integration/api_v1/test_shorten.py
@@ -158,3 +158,69 @@ class TestShorten:
             )
 
         assert resp.status_code == 409
+
+
+class TestShortenWithCustomDomain:
+    """``domain`` field on POST /shorten triggers owner+ACTIVE check."""
+
+    def test_anonymous_user_cannot_use_custom_domain(self):
+        from dependencies import get_custom_domain_service
+
+        url_svc = AsyncMock()
+        custom_svc = AsyncMock()
+        custom_svc.assert_owned_and_active = AsyncMock(return_value=None)
+        application = _build_test_app(
+            {
+                get_current_user: lambda: None,
+                get_url_service: lambda: url_svc,
+                get_custom_domain_service: lambda: custom_svc,
+            }
+        )
+        with TestClient(application, raise_server_exceptions=False) as client:
+            resp = client.post(
+                "/api/v1/shorten",
+                json={
+                    "long_url": "https://example.com",
+                    "domain": "links.acme.com",
+                },
+            )
+        assert resp.status_code == 401
+        assert custom_svc.assert_owned_and_active.await_count == 0
+        url_svc.create.assert_not_called()
+
+    def test_authed_user_with_owned_active_domain_succeeds(self):
+        from dependencies import get_custom_domain_service
+
+        user = _make_user(email_verified=True)
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.domain = "links.acme.com"
+        url_svc = AsyncMock()
+        url_svc.create = AsyncMock(return_value=url_doc)
+
+        custom_svc = AsyncMock()
+        custom_svc.assert_owned_and_active = AsyncMock(return_value=None)
+
+        application = _build_test_app(
+            {
+                get_current_user: lambda: user,
+                get_url_service: lambda: url_svc,
+                get_custom_domain_service: lambda: custom_svc,
+            }
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.post(
+                "/api/v1/shorten",
+                json={
+                    "long_url": "https://example.com",
+                    "domain": "links.acme.com",
+                },
+            )
+        assert resp.status_code == 201
+        body = resp.json()
+        # short_url is built off the custom host, not the system default.
+        assert body["short_url"].startswith("https://links.acme.com/")
+        # Owner check fired with the normalised fqdn.
+        custom_svc.assert_owned_and_active.assert_awaited_once()
+        # Service got the domain on the create call.
+        kwargs = url_svc.create.call_args.kwargs
+        assert kwargs.get("domain") == "links.acme.com"

--- a/tests/integration/api_v1/test_shorten.py
+++ b/tests/integration/api_v1/test_shorten.py
@@ -219,8 +219,12 @@ class TestShortenWithCustomDomain:
         body = resp.json()
         # short_url is built off the custom host, not the system default.
         assert body["short_url"].startswith("https://links.acme.com/")
-        # Owner check fired with the normalised fqdn.
-        custom_svc.assert_owned_and_active.assert_awaited_once()
+        # Owner check fired with (user, normalised fqdn). Pin both — the
+        # contract isn't just "fired", it's "fired with the right args".
+        assert custom_svc.assert_owned_and_active.await_count == 1
+        own_args = custom_svc.assert_owned_and_active.call_args.args
+        assert own_args[0].user_id == user.user_id
+        assert own_args[1] == "links.acme.com"
         # Service got the domain on the create call.
         kwargs = url_svc.create.call_args.kwargs
         assert kwargs.get("domain") == "links.acme.com"

--- a/tests/integration/test_click_tracking.py
+++ b/tests/integration/test_click_tracking.py
@@ -282,7 +282,7 @@ def test_click_emoji_schema_sets_is_emoji_true():
 
 
 def test_redirect_sets_noindex_nofollow_header():
-    """Redirect response should include X-Robots-Tag: noindex, nofollow."""
+    """Redirect response should include X-Robots-Tag: noindex, nofollow, noarchive."""
     url_data = _make_url_cache(long_url="https://example.com")
     url_svc = _mock_url_service(url_data)
     click_svc = _mock_click_service()
@@ -295,4 +295,4 @@ def test_redirect_sets_noindex_nofollow_header():
     )
     with TestClient(app, follow_redirects=False, raise_server_exceptions=False) as c:
         resp = c.get("/abc1234")
-    assert resp.headers.get("x-robots-tag") == "noindex, nofollow"
+    assert resp.headers.get("x-robots-tag") == "noindex, nofollow, noarchive"

--- a/tests/integration/test_custom_domain_routes.py
+++ b/tests/integration/test_custom_domain_routes.py
@@ -1,0 +1,243 @@
+"""Integration tests for custom-domain routes.
+
+Covers happy + sad paths on:
+    POST   /api/v1/custom-domains
+    POST   /api/v1/custom-domains/{id}/verify
+    GET    /api/v1/custom-domains
+    DELETE /api/v1/custom-domains/{id}
+
+Service is mocked. Tests pin contract: flag-gate behavior, scope auth,
+response shape, cascade plumbing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from dependencies import (
+    CurrentUser,
+    get_current_user,
+    get_custom_domain_service,
+    get_feature_flag_service,
+)
+from errors import (
+    DomainAlreadyRegisteredError,
+    ForbiddenError,
+    NotFoundError,
+)
+from routes.api_v1 import router as api_v1_router
+from schemas.enums.domain_status import DomainStatus, VerificationMethod
+from schemas.models.custom_domain import CustomDomainDoc
+from tests.conftest import build_test_app
+
+_USER_ID = ObjectId()
+_DOMAIN_ID = ObjectId()
+
+
+def _user(verified: bool = True) -> CurrentUser:
+    return CurrentUser(user_id=_USER_ID, email_verified=verified, api_key_doc=None)
+
+
+def _doc(**overrides) -> CustomDomainDoc:
+    base = {
+        "_id": _DOMAIN_ID,
+        "fqdn": "links.acme.com",
+        "owner_id": _USER_ID,
+        "status": DomainStatus.PENDING,
+        "verification_method": VerificationMethod.CF_HTTP_DCV,
+        "verification_token": "tok",
+        "created_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+        "dns_instructions": [
+            {"type": "CNAME", "name": "links.acme.com", "value": "spoo.me"}
+        ],
+        "setup_notes": [],
+    }
+    base.update(overrides)
+    return CustomDomainDoc.from_mongo(base)
+
+
+def _flag_svc(enabled: bool = True):
+    svc = AsyncMock()
+    svc.is_enabled = AsyncMock(return_value=enabled)
+    return svc
+
+
+def _make_app(svc_mock, flag_enabled=True, current_user=None):
+    """Wire test app, overriding get_current_user so the real auth dependency
+    chain (require_auth → require_scopes → require_scopes_verified) executes
+    against the stub user. Lets us exercise the scope and email-verified
+    checks without re-mocking each layer."""
+    user = current_user if current_user is not None else _user(verified=True)
+    return build_test_app(
+        api_v1_router,
+        overrides={
+            get_current_user: lambda: user,
+            get_custom_domain_service: lambda: svc_mock,
+            get_feature_flag_service: lambda: _flag_svc(flag_enabled),
+        },
+    )
+
+
+class TestCreateCustomDomain:
+    def test_happy_path(self):
+        svc = AsyncMock()
+        svc.create = AsyncMock(return_value=_doc())
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["fqdn"] == "links.acme.com"
+        assert body["status"].lower() == "pending"
+        assert body["dns_records"][0]["type"] == "CNAME"
+        # Internal field NOT exposed.
+        assert "verification_token" not in body
+        assert "setup_instructions" not in body
+
+    def test_flag_not_enabled_returns_404(self):
+        svc = AsyncMock()
+        svc.create = AsyncMock(return_value=_doc())
+        client = TestClient(
+            _make_app(svc, flag_enabled=False), raise_server_exceptions=False
+        )
+
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+        assert resp.status_code == 404
+        svc.create.assert_not_called()
+
+    def test_unverified_email_returns_403(self):
+        # Real require_scopes_verified chain fires: user is authed but
+        # email_verified=False → EmailNotVerifiedError → 403.
+        svc = AsyncMock()
+        client = TestClient(
+            _make_app(svc, current_user=_user(verified=False)),
+            raise_server_exceptions=False,
+        )
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+        assert resp.status_code == 403
+        assert resp.json()["code"] == "EMAIL_NOT_VERIFIED"
+        svc.create.assert_not_called()
+
+    def test_unauthenticated_returns_401(self):
+        # get_current_user → None triggers require_auth → 401.
+        app = build_test_app(
+            api_v1_router,
+            overrides={
+                get_current_user: lambda: None,
+                get_custom_domain_service: lambda: AsyncMock(),
+                get_feature_flag_service: lambda: _flag_svc(True),
+            },
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+        assert resp.status_code == 401
+
+    def test_duplicate_returns_409(self):
+        svc = AsyncMock()
+        svc.create = AsyncMock(
+            side_effect=DomainAlreadyRegisteredError("already registered")
+        )
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+        assert resp.status_code == 409
+
+
+class TestVerifyCustomDomain:
+    def test_happy_path(self):
+        svc = AsyncMock()
+        svc.verify = AsyncMock(return_value=_doc(status=DomainStatus.ACTIVE))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.post(f"/api/v1/custom-domains/{_DOMAIN_ID}/verify", json={})
+        assert resp.status_code == 200
+        assert resp.json()["status"].lower() == "active"
+
+    def test_not_owner_returns_403(self):
+        svc = AsyncMock()
+        svc.verify = AsyncMock(side_effect=ForbiddenError("not yours"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.post(f"/api/v1/custom-domains/{_DOMAIN_ID}/verify", json={})
+        assert resp.status_code == 403
+
+    def test_invalid_id_returns_422(self):
+        # Path pattern rejects bad ids before service is called.
+        svc = AsyncMock()
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.post("/api/v1/custom-domains/notanid/verify", json={})
+        assert resp.status_code == 422
+        svc.verify.assert_not_called()
+
+
+class TestListCustomDomains:
+    def test_paginated_response(self):
+        svc = AsyncMock()
+        svc.list_by_owner = AsyncMock(return_value=([_doc()], 1))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.get("/api/v1/custom-domains")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["pageSize"] == 20
+        assert body["hasNext"] is False
+        assert body["items"][0]["fqdn"] == "links.acme.com"
+
+    def test_empty_list(self):
+        svc = AsyncMock()
+        svc.list_by_owner = AsyncMock(return_value=([], 0))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.get("/api/v1/custom-domains")
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+
+    def test_reads_bypass_flag(self):
+        # Even with flag disabled, GET must succeed (rollback visibility).
+        svc = AsyncMock()
+        svc.list_by_owner = AsyncMock(return_value=([_doc()], 1))
+        client = TestClient(
+            _make_app(svc, flag_enabled=False), raise_server_exceptions=False
+        )
+        resp = client.get("/api/v1/custom-domains")
+        assert resp.status_code == 200
+
+
+class TestDeleteCustomDomain:
+    def test_no_cascade_returns_zero(self):
+        svc = AsyncMock()
+        svc.delete = AsyncMock(return_value=(_doc(status=DomainStatus.REVOKED), 0))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cascade"] is False
+        assert body["urls_deleted"] == 0
+        svc.delete.assert_awaited_once()
+        assert svc.delete.call_args.kwargs["cascade"] is False
+
+    def test_cascade_returns_count(self):
+        svc = AsyncMock()
+        svc.delete = AsyncMock(return_value=(_doc(status=DomainStatus.REVOKED), 42))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}?cascade=true")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cascade"] is True
+        assert body["urls_deleted"] == 42
+        assert svc.delete.call_args.kwargs["cascade"] is True
+
+    def test_not_found_returns_404(self):
+        svc = AsyncMock()
+        svc.delete = AsyncMock(side_effect=NotFoundError("domain not found"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}")
+        assert resp.status_code == 404
+
+    def test_not_owner_returns_403(self):
+        svc = AsyncMock()
+        svc.delete = AsyncMock(side_effect=ForbiddenError("not yours"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}")
+        assert resp.status_code == 403

--- a/tests/integration/test_custom_domain_routes.py
+++ b/tests/integration/test_custom_domain_routes.py
@@ -98,6 +98,11 @@ class TestCreateCustomDomain:
         # Internal field NOT exposed.
         assert "verification_token" not in body
         assert "setup_instructions" not in body
+        # Service got the normalised fqdn + authed user.
+        svc.create.assert_awaited_once()
+        req_arg, user_arg = svc.create.call_args.args
+        assert req_arg.fqdn == "links.acme.com"
+        assert user_arg.user_id == _USER_ID
 
     def test_flag_not_enabled_returns_404(self):
         svc = AsyncMock()
@@ -155,6 +160,19 @@ class TestVerifyCustomDomain:
         resp = client.post(f"/api/v1/custom-domains/{_DOMAIN_ID}/verify", json={})
         assert resp.status_code == 200
         assert resp.json()["status"].lower() == "active"
+        # Service got the parsed ObjectId + the authed user.
+        svc.verify.assert_awaited_once()
+        oid_arg, user_arg = svc.verify.call_args.args
+        assert oid_arg == _DOMAIN_ID
+        assert user_arg.user_id == _USER_ID
+
+    def test_no_body_required(self):
+        # Trigger endpoint accepts a bare POST with no JSON payload.
+        svc = AsyncMock()
+        svc.verify = AsyncMock(return_value=_doc(status=DomainStatus.ACTIVE))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.post(f"/api/v1/custom-domains/{_DOMAIN_ID}/verify")
+        assert resp.status_code == 200
 
     def test_not_owner_returns_403(self):
         svc = AsyncMock()
@@ -163,12 +181,13 @@ class TestVerifyCustomDomain:
         resp = client.post(f"/api/v1/custom-domains/{_DOMAIN_ID}/verify", json={})
         assert resp.status_code == 403
 
-    def test_invalid_id_returns_422(self):
-        # Path pattern rejects bad ids before service is called.
+    def test_invalid_id_returns_404(self):
+        # Bad id is mapped to 404 by `_parse_domain_id` so unauthenticated
+        # callers can't fingerprint the feature by ID format.
         svc = AsyncMock()
         client = TestClient(_make_app(svc), raise_server_exceptions=False)
         resp = client.post("/api/v1/custom-domains/notanid/verify", json={})
-        assert resp.status_code == 422
+        assert resp.status_code == 404
         svc.verify.assert_not_called()
 
 

--- a/tests/integration/test_custom_domain_routes.py
+++ b/tests/integration/test_custom_domain_routes.py
@@ -191,6 +191,44 @@ class TestVerifyCustomDomain:
         svc.verify.assert_not_called()
 
 
+class TestGetCustomDomain:
+    def test_happy_path(self):
+        svc = AsyncMock()
+        svc.get_owned_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.get(f"/api/v1/custom-domains/{_DOMAIN_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["fqdn"] == "links.acme.com"
+        assert body["status"].lower() == "pending"
+        # Service got the parsed ObjectId + authed user.
+        svc.get_owned_by_id.assert_awaited_once()
+        oid_arg, user_arg = svc.get_owned_by_id.call_args.args
+        assert oid_arg == _DOMAIN_ID
+        assert user_arg.user_id == _USER_ID
+
+    def test_invalid_id_returns_404(self):
+        svc = AsyncMock()
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.get("/api/v1/custom-domains/notanid")
+        assert resp.status_code == 404
+        svc.get_owned_by_id.assert_not_called()
+
+    def test_not_found_returns_404(self):
+        svc = AsyncMock()
+        svc.get_owned_by_id = AsyncMock(side_effect=NotFoundError("not found"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.get(f"/api/v1/custom-domains/{_DOMAIN_ID}")
+        assert resp.status_code == 404
+
+    def test_other_owner_returns_403(self):
+        svc = AsyncMock()
+        svc.get_owned_by_id = AsyncMock(side_effect=ForbiddenError("not yours"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.get(f"/api/v1/custom-domains/{_DOMAIN_ID}")
+        assert resp.status_code == 403
+
+
 class TestListCustomDomains:
     def test_paginated_response(self):
         svc = AsyncMock()

--- a/tests/integration/test_redirect.py
+++ b/tests/integration/test_redirect.py
@@ -422,7 +422,7 @@ def test_redirect_sets_x_robots_tag():
     resp = client.get("/abc123", follow_redirects=False)
 
     assert resp.status_code == 302
-    assert resp.headers.get("X-Robots-Tag") == "noindex, nofollow"
+    assert resp.headers.get("X-Robots-Tag") == "noindex, nofollow, noarchive"
 
 
 def test_password_form_submit_correct():

--- a/tests/integration/test_redirect_routes.py
+++ b/tests/integration/test_redirect_routes.py
@@ -81,7 +81,7 @@ def test_redirect_v2_url():
         resp = client.get("/abc1234")
     assert resp.status_code == 302
     assert resp.headers["location"] == "https://example.com/target"
-    assert resp.headers.get("x-robots-tag") == "noindex, nofollow"
+    assert resp.headers.get("x-robots-tag") == "noindex, nofollow, noarchive"
 
 
 def test_redirect_not_found_returns_404_html():

--- a/tests/unit/infrastructure/test_cache.py
+++ b/tests/unit/infrastructure/test_cache.py
@@ -75,6 +75,26 @@ class TestUrlCache:
         cache = UrlCache(redis_client=None)
         await cache.invalidate("abc", DOMAIN)  # must not raise
 
+    async def test_invalidate_many_deletes_all_keys(self):
+        r = _fake_redis()
+        cache = UrlCache(r)
+        await cache.invalidate_many(["a", "b", "c"], DOMAIN)
+        r.delete.assert_called_once_with(
+            f"url_cache:{DOMAIN}:a",
+            f"url_cache:{DOMAIN}:b",
+            f"url_cache:{DOMAIN}:c",
+        )
+
+    async def test_invalidate_many_noop_on_empty_list(self):
+        r = _fake_redis()
+        cache = UrlCache(r)
+        await cache.invalidate_many([], DOMAIN)
+        r.delete.assert_not_called()
+
+    async def test_invalidate_many_noop_when_redis_none(self):
+        cache = UrlCache(redis_client=None)
+        await cache.invalidate_many(["a", "b"], DOMAIN)  # must not raise
+
     async def test_set_stores_json_serialisable_data(self):
         r = _fake_redis()
         cache = UrlCache(r)

--- a/tests/unit/middleware/test_tenant.py
+++ b/tests/unit/middleware/test_tenant.py
@@ -1,4 +1,4 @@
-"""Unit tests for TenantMiddleware."""
+"""Unit tests for TenantMiddleware (PR4: strict allowlist routing)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
-from starlette.testclient import TestClient
 
 from middleware.tenant import TenantMiddleware
 from schemas.enums.domain_status import DomainStatus
@@ -23,17 +22,53 @@ def _app(resolver=None, omit_resolver: bool = False) -> Starlette:
             return PlainTextResponse("unset")
         return PlainTextResponse(tenant.fqdn)
 
-    app = Starlette(routes=[Route("/", root)])
+    async def alias(request):
+        tenant = getattr(request.state, "tenant", None)
+        body = tenant.fqdn if tenant else "anon"
+        return PlainTextResponse(body)
+
+    app = Starlette(
+        routes=[
+            Route("/", root),
+            Route("/{alias:str}", alias),
+        ]
+    )
     if not omit_resolver:
         app.state.tenant_resolver = resolver
     app.add_middleware(TenantMiddleware)
     return app
 
 
+def _custom_tenant(fqdn: str = "links.acme.com") -> TenantInfo:
+    return TenantInfo(
+        domain_id=None,
+        fqdn=fqdn,
+        owner_id=None,
+        status=DomainStatus.ACTIVE,
+        is_system_default=False,
+    )
+
+
+def _system_tenant(fqdn: str = "spoo.me") -> TenantInfo:
+    return TenantInfo(
+        domain_id=None,
+        fqdn=fqdn,
+        owner_id=None,
+        status=DomainStatus.ACTIVE,
+        is_system_default=True,
+    )
+
+
+def _client(resolver):
+    from starlette.testclient import TestClient
+
+    return TestClient(_app(resolver))
+
+
 class TestTenantMiddleware:
     def test_no_tenant_resolver_bypasses_middleware(self):
-        # No resolver wired → middleware skips entirely, request.state.tenant
-        # is never set. Guards against future code assuming the attribute exists.
+        from starlette.testclient import TestClient
+
         with TestClient(_app(omit_resolver=True)) as client:
             r = client.get("/", headers={"host": "example.com"})
         assert r.status_code == 200
@@ -42,32 +77,35 @@ class TestTenantMiddleware:
     def test_unknown_host_returns_html_404(self):
         resolver = MagicMock()
         resolver.resolve = AsyncMock(return_value=None)
-        with TestClient(_app(resolver)) as client:
+        with _client(resolver) as client:
             r = client.get("/", headers={"host": "bogus.example.com"})
         assert r.status_code == 404
         assert "text/html" in r.headers.get("content-type", "")
         assert "URL not found" in r.text
 
-    def test_known_tenant_lands_on_request_state(self):
+    def test_system_tenant_root_passes_through(self):
         resolver = MagicMock()
-        resolver.resolve = AsyncMock(
-            return_value=TenantInfo(
-                domain_id=None,
-                fqdn="links.acme.com",
-                owner_id=None,
-                status=DomainStatus.ACTIVE,
-                is_system_default=False,
-            )
-        )
-        with TestClient(_app(resolver)) as client:
-            r = client.get("/", headers={"host": "links.acme.com"})
+        resolver.resolve = AsyncMock(return_value=_system_tenant())
+        with _client(resolver) as client:
+            r = client.get("/", headers={"host": "spoo.me"})
         assert r.status_code == 200
-        assert r.text == "links.acme.com"
+        assert r.text == "spoo.me"
+        # System default: no noindex stamp on responses (existing redirect
+        # route handles its own header).
+        assert "X-Robots-Tag" not in r.headers
+
+    def test_system_tenant_alias_passes_through(self):
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_system_tenant())
+        with _client(resolver) as client:
+            r = client.get("/abc", headers={"host": "spoo.me"})
+        assert r.status_code == 200
+        assert r.text == "spoo.me"
 
     def test_loopback_host_bypasses_resolver(self):
         resolver = MagicMock()
         resolver.resolve = AsyncMock(side_effect=AssertionError("should not be called"))
-        with TestClient(_app(resolver)) as client:
+        with _client(resolver) as client:
             r = client.get("/", headers={"host": "localhost"})
         assert r.status_code == 200
         assert r.text == "none"
@@ -78,25 +116,122 @@ class TestTenantMiddleware:
 
         async def _capture(h):
             captured["host"] = h
-            return TenantInfo(
-                domain_id=None,
-                fqdn=h,
-                owner_id=None,
-                status=DomainStatus.ACTIVE,
-                is_system_default=False,
-            )
+            return _system_tenant(fqdn=h)
 
         resolver.resolve = _capture
-        with TestClient(_app(resolver)) as client:
+        with _client(resolver) as client:
             client.get("/", headers={"host": "links.acme.com:8443"})
         assert captured["host"] == "links.acme.com"
 
     def test_ipv6_bracketed_host_is_normalised(self):
-        # `[::1]:8000` must become `::1`, not `[::1]`.
         resolver = MagicMock()
         resolver.resolve = AsyncMock(side_effect=AssertionError("should not be called"))
-        with TestClient(_app(resolver)) as client:
+        with _client(resolver) as client:
             r = client.get("/", headers={"host": "[::1]:8000"})
-        # `::1` is in the loopback set, so resolver should be skipped.
         assert r.status_code == 200
         assert r.text == "none"
+
+
+class TestCustomTenantRouting:
+    """Allowlist routing on custom tenants — strict 404 on operator surface."""
+
+    def test_custom_root_returns_404(self):
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        with _client(resolver) as client:
+            r = client.get("/", headers={"host": "links.acme.com"})
+        assert r.status_code == 404
+        assert r.headers["X-Robots-Tag"] == "noindex, nofollow, noarchive"
+
+    def test_custom_alias_passes_through(self):
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        with _client(resolver) as client:
+            r = client.get("/abc123", headers={"host": "links.acme.com"})
+        assert r.status_code == 200
+        assert r.text == "links.acme.com"
+        # X-Robots-Tag stamped on the response by middleware
+        assert r.headers["X-Robots-Tag"] == "noindex, nofollow, noarchive"
+
+    def test_custom_alias_with_password_subpath_allowed(self):
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        app = _app(resolver)
+
+        async def password_handler(request):
+            return PlainTextResponse("password-ok")
+
+        app.routes.append(Route("/{alias}/password", password_handler))
+        from starlette.testclient import TestClient
+
+        with TestClient(app) as client:
+            r = client.get("/abc/password", headers={"host": "links.acme.com"})
+        assert r.status_code == 200
+
+    def test_custom_robots_txt_inline_disallow(self):
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        with _client(resolver) as client:
+            r = client.get("/robots.txt", headers={"host": "links.acme.com"})
+        assert r.status_code == 200
+        assert "Disallow: /" in r.text
+        assert r.headers["X-Robots-Tag"] == "noindex, nofollow, noarchive"
+
+    def test_custom_favicon_passes_through(self):
+        # Build app with explicit /favicon.ico BEFORE the catch-all /{alias}
+        # so Starlette's left-to-right matcher resolves to the static handler.
+        from starlette.testclient import TestClient
+
+        async def favicon(request):
+            return PlainTextResponse("favicon-bytes")
+
+        async def alias(request):
+            return PlainTextResponse("alias-fallback")
+
+        app = Starlette(
+            routes=[
+                Route("/favicon.ico", favicon),
+                Route("/{alias:str}", alias),
+            ]
+        )
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        app.state.tenant_resolver = resolver
+        app.add_middleware(TenantMiddleware)
+
+        with TestClient(app) as client:
+            r = client.get("/favicon.ico", headers={"host": "links.acme.com"})
+        assert r.status_code == 200
+        assert r.text == "favicon-bytes"
+
+    def test_custom_stats_suffix_blocked(self):
+        # `/<alias>+` is the stats page on spoo.me. Blocked on custom tenants.
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        with _client(resolver) as client:
+            r = client.get("/abc+", headers={"host": "links.acme.com"})
+        assert r.status_code == 404
+
+    def test_custom_operator_paths_blocked(self):
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value=_custom_tenant())
+        blocked_paths = (
+            "/api/v1/custom-domains",
+            "/api/v1/shorten",
+            "/dashboard",
+            "/dashboard/links",
+            "/auth/login",
+            "/oauth/google/start",
+            "/health",
+            "/report",
+            "/about",
+            "/contact",
+            "/api-docs",
+        )
+        with _client(resolver) as client:
+            for path in blocked_paths:
+                r = client.get(path, headers={"host": "links.acme.com"})
+                assert r.status_code == 404, (
+                    f"expected 404 on {path}, got {r.status_code}"
+                )
+                assert r.headers["X-Robots-Tag"] == "noindex, nofollow, noarchive"

--- a/tests/unit/middleware/test_tenant.py
+++ b/tests/unit/middleware/test_tenant.py
@@ -154,19 +154,26 @@ class TestCustomTenantRouting:
         assert r.headers["X-Robots-Tag"] == "noindex, nofollow, noarchive"
 
     def test_custom_alias_with_password_subpath_allowed(self):
+        # Password verification is POST-only — GET on `/<alias>/password` must
+        # 404 like any other disallowed method/path combination.
         resolver = MagicMock()
         resolver.resolve = AsyncMock(return_value=_custom_tenant())
-        app = _app(resolver)
+        from starlette.testclient import TestClient
 
         async def password_handler(request):
             return PlainTextResponse("password-ok")
 
-        app.routes.append(Route("/{alias}/password", password_handler))
-        from starlette.testclient import TestClient
+        app = Starlette(
+            routes=[Route("/{alias}/password", password_handler, methods=["POST"])]
+        )
+        app.state.tenant_resolver = resolver
+        app.add_middleware(TenantMiddleware)
 
         with TestClient(app) as client:
-            r = client.get("/abc/password", headers={"host": "links.acme.com"})
-        assert r.status_code == 200
+            ok = client.post("/abc/password", headers={"host": "links.acme.com"})
+            bad = client.get("/abc/password", headers={"host": "links.acme.com"})
+        assert ok.status_code == 200
+        assert bad.status_code == 404
 
     def test_custom_robots_txt_inline_disallow(self):
         resolver = MagicMock()

--- a/tests/unit/repositories/test_url_repository.py
+++ b/tests/unit/repositories/test_url_repository.py
@@ -247,3 +247,48 @@ class TestUrlRepository:
         col.find_one = AsyncMock(side_effect=ValueError("unexpected"))
         with pytest.raises(ValueError, match="unexpected"):
             await self._repo(col).find_by_alias("abc", DOMAIN)
+
+
+class TestUrlRepositoryBulkDelete:
+    def _repo(self, col=None):
+        from repositories.url_repository import UrlRepository
+
+        return UrlRepository(col or make_collection())
+
+    @pytest.mark.asyncio
+    async def test_list_aliases_returns_list_of_strings(self):
+        col = make_collection()
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(
+            return_value=[{"alias": "abc"}, {"alias": "xyz"}, {"alias": "qq"}]
+        )
+        col.find = MagicMock(return_value=cursor)
+        result = await self._repo(col).list_aliases_by_owner_and_domain(
+            USER_OID, "links.acme.com"
+        )
+        assert result == ["abc", "xyz", "qq"]
+        col.find.assert_called_once()
+        # Both filters must be present in the query.
+        query = col.find.call_args[0][0]
+        assert query["owner_id"] == USER_OID
+        assert query["domain"] == "links.acme.com"
+
+    @pytest.mark.asyncio
+    async def test_delete_many_returns_count(self):
+        col = make_collection()
+        col.delete_many = AsyncMock(return_value=MagicMock(deleted_count=7))
+        count = await self._repo(col).delete_many_by_owner_and_domain(
+            USER_OID, "links.acme.com"
+        )
+        assert count == 7
+        col.delete_many.assert_awaited_once()
+        query = col.delete_many.call_args[0][0]
+        assert query == {"owner_id": USER_OID, "domain": "links.acme.com"}
+
+    @pytest.mark.asyncio
+    async def test_delete_many_refuses_missing_filters(self):
+        repo = self._repo()
+        with pytest.raises(ValueError):
+            await repo.delete_many_by_owner_and_domain(None, "links.acme.com")
+        with pytest.raises(ValueError):
+            await repo.delete_many_by_owner_and_domain(USER_OID, "")

--- a/tests/unit/schemas/dto/test_custom_domain.py
+++ b/tests/unit/schemas/dto/test_custom_domain.py
@@ -1,0 +1,113 @@
+"""Tests for the custom-domain DTOs (PR4 restructure)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from schemas.dto.responses.custom_domain import (
+    CustomDomainDeleteResponse,
+    CustomDomainListResponse,
+    CustomDomainResponse,
+    DnsRecord,
+)
+from schemas.enums.domain_status import DomainStatus, VerificationMethod
+from schemas.models.custom_domain import CustomDomainDoc
+
+
+def _doc(**overrides) -> CustomDomainDoc:
+    base = {
+        "_id": ObjectId(),
+        "fqdn": "links.acme.com",
+        "owner_id": ObjectId(),
+        "status": DomainStatus.PENDING,
+        "verification_method": VerificationMethod.CF_HTTP_DCV,
+        "verification_token": "tok-123",
+        "created_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+        "dns_instructions": [
+            {"type": "CNAME", "name": "links.acme.com", "value": "spoo.me"},
+            {
+                "type": "TXT",
+                "name": "_cf-custom-hostname.links.acme.com",
+                "value": "abc-uuid",
+            },
+        ],
+        "setup_notes": ["Set DNS-only (grey cloud) if using CF DNS."],
+    }
+    base.update(overrides)
+    return CustomDomainDoc.from_mongo(base)
+
+
+class TestCustomDomainResponse:
+    def test_structured_dns_records(self):
+        r = CustomDomainResponse.from_doc(_doc())
+        assert len(r.dns_records) == 2
+        assert r.dns_records[0].type == "CNAME"
+        assert r.dns_records[0].name == "links.acme.com"
+        assert r.dns_records[0].value == "spoo.me"
+        assert r.dns_records[1].type == "TXT"
+
+    def test_setup_notes_passthrough(self):
+        r = CustomDomainResponse.from_doc(_doc())
+        assert r.setup_notes == ["Set DNS-only (grey cloud) if using CF DNS."]
+
+    def test_no_verification_token_in_response(self):
+        # Internal field — must not be exposed in the public DTO.
+        r = CustomDomainResponse.from_doc(_doc())
+        assert not hasattr(r, "verification_token")
+
+    def test_no_setup_instructions_in_response(self):
+        # Replaced by dns_records + setup_notes.
+        r = CustomDomainResponse.from_doc(_doc())
+        assert not hasattr(r, "setup_instructions")
+
+    def test_empty_dns_records_when_doc_has_none(self):
+        r = CustomDomainResponse.from_doc(_doc(dns_instructions=[]))
+        assert r.dns_records == []
+
+    def test_status_and_method_propagate(self):
+        r = CustomDomainResponse.from_doc(_doc(status=DomainStatus.ACTIVE))
+        assert r.status == DomainStatus.ACTIVE
+        assert r.verification_method == VerificationMethod.CF_HTTP_DCV
+
+
+class TestCustomDomainListResponse:
+    def test_paginated_shape(self):
+        r = CustomDomainListResponse(
+            items=[CustomDomainResponse.from_doc(_doc())],
+            page=1,
+            pageSize=20,
+            total=1,
+            hasNext=False,
+        )
+        # camelCase serialisation via aliases (consistent with UrlListResponse).
+        dumped = r.model_dump(by_alias=True)
+        assert dumped["pageSize"] == 20
+        assert dumped["hasNext"] is False
+
+
+class TestCustomDomainDeleteResponse:
+    def test_no_cascade_zero_count(self):
+        r = CustomDomainDeleteResponse(
+            id="x", fqdn="links.acme.com", cascade=False, urls_deleted=0
+        )
+        assert r.cascade is False
+        assert r.urls_deleted == 0
+
+    def test_cascade_with_count(self):
+        r = CustomDomainDeleteResponse(
+            id="x", fqdn="links.acme.com", cascade=True, urls_deleted=42
+        )
+        assert r.cascade is True
+        assert r.urls_deleted == 42
+
+
+class TestDnsRecord:
+    def test_types_constrained_to_known(self):
+        # Loose validation by Literal — pydantic raises on unknown
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            DnsRecord(type="MX", name="x", value="y")  # type: ignore[arg-type]

--- a/tests/unit/schemas/dto/test_url.py
+++ b/tests/unit/schemas/dto/test_url.py
@@ -382,3 +382,51 @@ class TestUrlListItemFromDoc:
     def test_expire_after_none(self):
         r = UrlListItem.from_doc(_make_doc(expire_after=None))
         assert r.expire_after is None
+
+
+class TestUrlListItemDomain:
+    def test_domain_propagates(self):
+        from schemas.dto.responses.url import UrlListItem
+
+        r = UrlListItem.from_doc(_make_doc(domain="links.acme.com"))
+        assert r.domain == "links.acme.com"
+
+    def test_domain_default_system(self):
+        from schemas.dto.responses.url import UrlListItem
+
+        r = UrlListItem.from_doc(_make_doc())  # domain = spoo.me
+        assert r.domain == "spoo.me"
+
+
+class TestCreateUrlRequestDomainField:
+    def test_lowercases_and_strips_dot(self):
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(url="https://example.com", domain="LINKS.ACME.COM.")
+        assert req.domain == "links.acme.com"
+
+    def test_empty_string_normalised_to_none(self):
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(url="https://example.com", domain="")
+        assert req.domain is None
+
+    def test_omitted_domain_is_none(self):
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(url="https://example.com")
+        assert req.domain is None
+
+
+class TestListUrlsQueryDomainFilter:
+    def test_domain_filter_normalised(self):
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        q = ListUrlsQuery(domain="Links.Acme.COM")
+        assert q.domain == "links.acme.com"
+
+    def test_no_domain_filter(self):
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        q = ListUrlsQuery()
+        assert q.domain is None

--- a/tests/unit/services/test_custom_domain_service.py
+++ b/tests/unit/services/test_custom_domain_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from bson import ObjectId
@@ -76,6 +76,7 @@ def _build_service(
     redis=None,
     extra_settings=None,
     url_service=None,
+    preflight_cname_target=None,
 ):
     repo = repo or AsyncMock()
     repo.insert = AsyncMock(return_value=DOMAIN_OID)
@@ -132,6 +133,7 @@ def _build_service(
             blocked_domain_repo=blocked_domain_repo,
             redis_client=redis,
             url_service=url_service,
+            preflight_cname_target=preflight_cname_target,
         ),
         repo,
         verifiers,
@@ -350,6 +352,57 @@ class TestVerify:
         repo.find_by_id = AsyncMock(return_value=None)
         with pytest.raises(NotFoundError):
             await svc.verify(DOMAIN_OID, _user())
+
+    @pytest.mark.asyncio
+    async def test_preflight_failure_records_reason_and_skips_verifier(self):
+        # When preflight fails, CF/verifier MUST NOT be invoked — otherwise CF
+        # enters its 15-min backoff for unpropagated domains. The reason is
+        # surfaced as last_verification_error on the doc; status unchanged.
+        from services import dns_preflight as preflight_module
+
+        svc, repo, verifiers, _, _ = _build_service(
+            preflight_cname_target="customers.spoo.me"
+        )
+        verifier = verifiers[VerificationMethod.CNAME]
+        starting = _doc(status=DomainStatus.PENDING)
+        repo.find_by_id = AsyncMock(side_effect=[starting, starting])
+
+        async def _bad_preflight(fqdn, target):
+            return preflight_module.PreflightResult(
+                ok=False, reason="DNS isn't reaching us yet"
+            )
+
+        with patch(
+            "services.custom_domain_service.check_cname",
+            side_effect=_bad_preflight,
+        ):
+            await svc.verify(DOMAIN_OID, _user())
+
+        verifier.verify.assert_not_called()
+        args, kwargs = repo.update_status.call_args
+        assert args[1] == DomainStatus.PENDING
+        assert kwargs["last_verification_error"] == "DNS isn't reaching us yet"
+
+    @pytest.mark.asyncio
+    async def test_preflight_success_lets_verifier_run(self):
+        from services import dns_preflight as preflight_module
+
+        svc, repo, verifiers, _, _ = _build_service(
+            preflight_cname_target="customers.spoo.me"
+        )
+        verifier = verifiers[VerificationMethod.CNAME]
+        starting = _doc(status=DomainStatus.PENDING)
+        repo.find_by_id = AsyncMock(
+            side_effect=[starting, _doc(status=DomainStatus.ACTIVE)]
+        )
+
+        async def _ok(fqdn, target):
+            return preflight_module.PreflightResult(ok=True)
+
+        with patch("services.custom_domain_service.check_cname", side_effect=_ok):
+            await svc.verify(DOMAIN_OID, _user())
+
+        verifier.verify.assert_awaited_once()
 
 
 class TestDelete:
@@ -728,6 +781,31 @@ class TestVerifierTokenSelection:
         await svc.verify(DOMAIN_OID, _user())
 
         cname_verifier.verify.assert_awaited_once_with("links.acme.com", "token-abc")
+
+
+class TestGetOwnedById:
+    @pytest.mark.asyncio
+    async def test_returns_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
+        result = await svc.get_owned_by_id(DOMAIN_OID, _user())
+        assert result.id == DOMAIN_OID
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_raises_404(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=None)
+        with pytest.raises(NotFoundError):
+            await svc.get_owned_by_id(DOMAIN_OID, _user())
+
+    @pytest.mark.asyncio
+    async def test_other_owner_raises_403(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(
+            return_value=_doc(owner_id=ObjectId("ffffffffffffffffffffffff"))
+        )
+        with pytest.raises(ForbiddenError):
+            await svc.get_owned_by_id(DOMAIN_OID, _user())
 
 
 class TestAssertOwned:

--- a/tests/unit/services/test_custom_domain_service.py
+++ b/tests/unit/services/test_custom_domain_service.py
@@ -13,6 +13,7 @@ from config import CustomDomainSettings
 from errors import (
     DomainAlreadyRegisteredError,
     DomainBlocklistedError,
+    DomainNotVerifiedError,
     DomainQuotaExceededError,
     ForbiddenError,
     InvalidDomainTransitionError,
@@ -74,6 +75,7 @@ def _build_service(
     blocked_domain_repo=None,
     redis=None,
     extra_settings=None,
+    url_service=None,
 ):
     repo = repo or AsyncMock()
     repo.insert = AsyncMock(return_value=DOMAIN_OID)
@@ -129,6 +131,7 @@ def _build_service(
             tenant_resolver=tenant_resolver,
             blocked_domain_repo=blocked_domain_repo,
             redis_client=redis,
+            url_service=url_service,
         ),
         repo,
         verifiers,
@@ -725,3 +728,130 @@ class TestVerifierTokenSelection:
         await svc.verify(DOMAIN_OID, _user())
 
         cname_verifier.verify.assert_awaited_once_with("links.acme.com", "token-abc")
+
+
+class TestAssertOwned:
+    @pytest.mark.asyncio
+    async def test_owned_returns_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=_doc(status=DomainStatus.ACTIVE))
+        result = await svc.assert_owned(_user(), "links.acme.com")
+        assert result.fqdn == "links.acme.com"
+
+    @pytest.mark.asyncio
+    async def test_unknown_domain_raises_404(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=None)
+        with pytest.raises(NotFoundError):
+            await svc.assert_owned(_user(), "nope.example.com")
+
+    @pytest.mark.asyncio
+    async def test_other_owner_raises_403(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(
+            return_value=_doc(owner_id=ObjectId("ffffffffffffffffffffffff"))
+        )
+        with pytest.raises(ForbiddenError):
+            await svc.assert_owned(_user(), "links.acme.com")
+
+    @pytest.mark.asyncio
+    async def test_owned_accepts_any_status(self):
+        # Bulk-delete cleanup path needs to work on revoked/suspended domains too.
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=_doc(status=DomainStatus.SUSPENDED))
+        doc = await svc.assert_owned(_user(), "links.acme.com")
+        assert doc.status == DomainStatus.SUSPENDED
+
+
+class TestAssertOwnedAndActive:
+    @pytest.mark.asyncio
+    async def test_active_returns_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=_doc(status=DomainStatus.ACTIVE))
+        doc = await svc.assert_owned_and_active(_user(), "links.acme.com")
+        assert doc.status == DomainStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_pending_raises_422(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
+        with pytest.raises(DomainNotVerifiedError):
+            await svc.assert_owned_and_active(_user(), "links.acme.com")
+
+    @pytest.mark.asyncio
+    async def test_suspended_raises_422(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=_doc(status=DomainStatus.SUSPENDED))
+        with pytest.raises(DomainNotVerifiedError):
+            await svc.assert_owned_and_active(_user(), "links.acme.com")
+
+    @pytest.mark.asyncio
+    async def test_revoked_raises_422(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_fqdn = AsyncMock(return_value=_doc(status=DomainStatus.REVOKED))
+        with pytest.raises(DomainNotVerifiedError):
+            await svc.assert_owned_and_active(_user(), "links.acme.com")
+
+
+class TestDeleteCascade:
+    @pytest.mark.asyncio
+    async def test_delete_without_cascade_doesnt_touch_url_service(self):
+        url_service = AsyncMock()
+        url_service.delete_all_by_domain = AsyncMock(return_value=0)
+        svc, repo, _, _, _ = _build_service(url_service=url_service)
+        active = _doc(status=DomainStatus.ACTIVE)
+        # First find_by_id loads the doc for ownership; second refreshes after.
+        revoked = _doc(status=DomainStatus.REVOKED)
+        repo.find_by_id = AsyncMock(side_effect=[active, revoked])
+
+        doc, deleted = await svc.delete(DOMAIN_OID, _user())
+
+        url_service.delete_all_by_domain.assert_not_called()
+        assert deleted == 0
+        assert doc.status == DomainStatus.REVOKED
+
+    @pytest.mark.asyncio
+    async def test_delete_with_cascade_calls_url_service(self):
+        url_service = AsyncMock()
+        url_service.delete_all_by_domain = AsyncMock(return_value=42)
+        svc, repo, _, _, _ = _build_service(url_service=url_service)
+        active = _doc(status=DomainStatus.ACTIVE)
+        revoked = _doc(status=DomainStatus.REVOKED)
+        repo.find_by_id = AsyncMock(side_effect=[active, revoked])
+
+        doc, deleted = await svc.delete(DOMAIN_OID, _user(), cascade=True)
+
+        url_service.delete_all_by_domain.assert_awaited_once_with(
+            USER_OID, "links.acme.com"
+        )
+        assert deleted == 42
+        assert doc.status == DomainStatus.REVOKED
+
+    @pytest.mark.asyncio
+    async def test_cascade_partial_failure_still_revokes(self):
+        # bulk delete throws → service swallows, domain still ends REVOKED
+        url_service = AsyncMock()
+        url_service.delete_all_by_domain = AsyncMock(
+            side_effect=RuntimeError("mongo timeout")
+        )
+        svc, repo, _, _, _ = _build_service(url_service=url_service)
+        active = _doc(status=DomainStatus.ACTIVE)
+        revoked = _doc(status=DomainStatus.REVOKED)
+        repo.find_by_id = AsyncMock(side_effect=[active, revoked])
+
+        doc, deleted = await svc.delete(DOMAIN_OID, _user(), cascade=True)
+        assert deleted == 0
+        assert doc.status == DomainStatus.REVOKED
+
+    @pytest.mark.asyncio
+    async def test_cascade_without_url_service_logs_and_continues(self):
+        # Edge case: cascade=True but no url_service wired (test config).
+        # Service must not blow up; just log and continue with the revoke.
+        svc, repo, _, _, _ = _build_service(url_service=None)
+        active = _doc(status=DomainStatus.ACTIVE)
+        revoked = _doc(status=DomainStatus.REVOKED)
+        repo.find_by_id = AsyncMock(side_effect=[active, revoked])
+
+        doc, deleted = await svc.delete(DOMAIN_OID, _user(), cascade=True)
+        assert deleted == 0
+        assert doc.status == DomainStatus.REVOKED

--- a/tests/unit/services/test_dns_preflight.py
+++ b/tests/unit/services/test_dns_preflight.py
@@ -61,7 +61,7 @@ class TestCheckCname:
         ):
             result = await check_cname("links.acme.com", "customers.spoo.me")
         assert result.ok is False
-        assert "propagating" in result.reason
+        assert "Try again" in result.reason
 
     @pytest.mark.asyncio
     async def test_wrong_target_yields_diagnostic_message(self):
@@ -118,7 +118,7 @@ class TestCheckCname:
         ):
             result = await check_cname("acme.com", "customers.spoo.me")
         assert result.ok is False
-        assert "propagating" in result.reason
+        assert "Try again" in result.reason
 
 
 class TestUsesCloudflareDns:

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -1336,6 +1336,37 @@ class TestUrlServiceCreateOnCustomDomain:
         assert inserted["domain"] == "links.acme.com"
 
     @pytest.mark.asyncio
+    async def test_create_auto_generates_alias_against_custom_domain(self):
+        # Regression guard: previously _generate_unique_alias() probed the
+        # system default namespace regardless of which tenant the URL was
+        # being created on. With the domain= kwarg threaded through, the
+        # candidate must be checked against the custom domain.
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        url_repo.check_alias_exists = AsyncMock(return_value=False)
+        url_repo.insert = AsyncMock(return_value=ObjectId())
+        blocked_url_repo.get_patterns = AsyncMock(return_value=[])
+
+        # No alias provided → service auto-generates one.
+        req = CreateUrlRequest(url="https://example.com/auto-alias")
+
+        await svc.create(req, USER_OID, "1.2.3.4", domain="links.acme.com")
+
+        # The probe was scoped to the custom domain, never the system default.
+        url_repo.check_alias_exists.assert_awaited_once()
+        _, probed_domain = url_repo.check_alias_exists.call_args.args
+        assert probed_domain == "links.acme.com"
+
+        # Persisted doc lands on the custom tenant.
+        inserted = url_repo.insert.call_args[0][0]
+        assert inserted["domain"] == "links.acme.com"
+
+    @pytest.mark.asyncio
     async def test_create_with_no_domain_uses_system_default(self):
         from schemas.dto.requests.url import CreateUrlRequest
 

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -1293,3 +1293,165 @@ class TestUrlServiceListByOwner:
 
         assert result["hasNext"] is True
         assert result["total"] == 50
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestUrlServiceCreateOnCustomDomain
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUrlServiceCreateOnCustomDomain:
+    """create(..., domain=) writes the doc on the right tenant and routes
+    alias-availability checks through the right namespace."""
+
+    @pytest.mark.asyncio
+    async def test_create_uses_provided_domain_for_doc_and_alias_check(self):
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        url_repo.check_alias_exists = AsyncMock(return_value=False)
+        url_repo.insert = AsyncMock(return_value=ObjectId())
+        blocked_url_repo.get_patterns = AsyncMock(return_value=[])
+
+        req = CreateUrlRequest(
+            url="https://example.com/x",
+            alias="myalias",
+        )
+
+        await svc.create(req, USER_OID, "1.2.3.4", domain="links.acme.com")
+
+        # Alias-availability scoped to custom domain — and only that namespace
+        # (no legacy fallback check).
+        url_repo.check_alias_exists.assert_awaited_once_with(
+            "myalias", "links.acme.com"
+        )
+        legacy_repo.check_exists.assert_not_called()
+
+        # Doc inserted carries the custom domain.
+        inserted = url_repo.insert.call_args[0][0]
+        assert inserted["domain"] == "links.acme.com"
+
+    @pytest.mark.asyncio
+    async def test_create_with_no_domain_uses_system_default(self):
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        url_repo.check_alias_exists = AsyncMock(return_value=False)
+        legacy_repo.check_exists = AsyncMock(return_value=False)
+        url_repo.insert = AsyncMock(return_value=ObjectId())
+        blocked_url_repo.get_patterns = AsyncMock(return_value=[])
+
+        req = CreateUrlRequest(url="https://example.com/x", alias="mine")
+
+        await svc.create(req, USER_OID, "1.2.3.4")
+
+        # System default uses both v2 + legacy alias check.
+        url_repo.check_alias_exists.assert_awaited_once_with(
+            "mine", SYSTEM_DEFAULT_DOMAIN
+        )
+        legacy_repo.check_exists.assert_awaited_once_with("mine")
+        inserted = url_repo.insert.call_args[0][0]
+        assert inserted["domain"] == SYSTEM_DEFAULT_DOMAIN
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestUrlServiceBulkDelete
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUrlServiceBulkDelete:
+    @pytest.mark.asyncio
+    async def test_bulk_delete_refuses_system_default(self):
+        from errors import ValidationError
+
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        with pytest.raises(ValidationError):
+            await svc.delete_all_by_domain(USER_OID, SYSTEM_DEFAULT_DOMAIN)
+        url_repo.delete_many_by_owner_and_domain.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_delete_zero_match_returns_zero(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        url_repo.list_aliases_by_owner_and_domain = AsyncMock(return_value=[])
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        count = await svc.delete_all_by_domain(USER_OID, "links.acme.com")
+        assert count == 0
+        url_repo.delete_many_by_owner_and_domain.assert_not_called()
+        url_cache.invalidate_many.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_delete_invalidates_cache_after_delete(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        url_repo.list_aliases_by_owner_and_domain = AsyncMock(
+            return_value=["a", "b", "c"]
+        )
+        url_repo.delete_many_by_owner_and_domain = AsyncMock(return_value=3)
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        count = await svc.delete_all_by_domain(USER_OID, "links.acme.com")
+
+        assert count == 3
+        url_repo.delete_many_by_owner_and_domain.assert_awaited_once_with(
+            USER_OID, "links.acme.com"
+        )
+        url_cache.invalidate_many.assert_awaited_once_with(
+            ["a", "b", "c"], "links.acme.com"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestUrlServiceListByOwnerDomainFilter
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUrlServiceListByOwnerDomainFilter:
+    @pytest.mark.asyncio
+    async def test_list_with_domain_filter_passes_to_query(self):
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        url_repo.count_by_query.return_value = 0
+        url_repo.find_by_owner.return_value = []
+
+        q = ListUrlsQuery(domain="links.acme.com")
+        await svc.list_by_owner(USER_OID, q)
+
+        call_query = url_repo.count_by_query.call_args[0][0]
+        assert call_query.get("domain") == "links.acme.com"
+
+    @pytest.mark.asyncio
+    async def test_list_without_domain_filter_omits_field(self):
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        url_repo.count_by_query.return_value = 0
+        url_repo.find_by_owner.return_value = []
+
+        q = ListUrlsQuery()
+        await svc.list_by_owner(USER_OID, q)
+
+        call_query = url_repo.count_by_query.call_args[0][0]
+        assert "domain" not in call_query


### PR DESCRIPTION
Brings custom domains from a service-layer-only feature to user-facing. Owners can now register a domain (e.g. links.acme.com), publish DNS records returned by the API, verify, and serve short links under their own brand.

API
  POST   /api/v1/custom-domains              register
  POST   /api/v1/custom-domains/{id}/verify  trigger verification
  GET    /api/v1/custom-domains              list owned (paginated)
  DELETE /api/v1/custom-domains/{id}         revoke (?cascade=true also
                                             bulk-deletes URLs on the domain)
  DELETE /api/v1/urls?domain=<fqdn>          bulk URL delete on owned domain

POST /api/v1/shorten accepts an optional `domain` field; ownership + ACTIVE-status enforced at the route layer. GET /api/v1/urls accepts a `?domain=` filter and UrlListItem now exposes `domain`.

Tenant routing
Custom hostnames serve a strict allowlist: `/<alias>`, `/<alias>/password`, `/favicon.ico`, `/robots.txt`. Everything else (operator surface like /api, /dashboard, /auth, /oauth; brand pages like /about, /contact; the stats suffix `/<alias>+`; /report; /health) returns 404 so customer-branded hosts don't expose the canonical app surface.

Per-tenant `/robots.txt` is served inline as `Disallow: /`, and every custom-tenant response is stamped with
`X-Robots-Tag: noindex, nofollow, noarchive`. The existing system-default `/<alias>` redirect header gained `noarchive` alongside this.

Auth + scopes
New API key scopes `domains:manage` and `domains:read`. New `require_scopes_verified` dependency combines scope auth with the email-verified gate so both JWT and API key callers can create.

Response shape
CustomDomainResponse now carries structured `dns_records` (each with type/name/value/purpose) plus `setup_notes` for human-readable warnings (e.g. "Cloudflare DNS detected — set DNS-only / grey cloud"). Dropped the old free-form `setup_instructions` string and the internal `verification_token` field (no longer surfaced over the wire).

Service / repository
CustomDomainService gains `assert_owned`, `assert_owned_and_active` helpers and `delete(*, cascade=False)` returning `(doc, urls_deleted)`. Cascade order: REVOKE first, bulk delete URLs second, edge eviction third, cache invalidate last. Partial failures swallow + log; a future garbage-collection worker reaps orphan URLs.

UrlService.create accepts an opaque `domain=`; alias-uniqueness now scopes through `(domain, alias)`. `delete_all_by_domain` refuses the system-default namespace defensively.

Repository: list_aliases_by_owner_and_domain + delete_many_by_owner_and_domain.
Cache: invalidate_many for bulk cleanup.

Rate limits
Slowapi limits on every new route (5/hr CREATE, 10/min VERIFY/DELETE, 60/min READ, 5/min bulk delete). Service-side per-user Mongo + Redis quotas still apply on top — layered defense.

Dashboard
New /dashboard/domains page with a sidebar nav entry. Markup matches the existing keys/links pattern: external CSS+JS, `<template>` row cloning, status badges via design tokens, server shell + client fetch hydration. Delete modal fetches the current URL count and offers the caller a choice between orphaning the URLs or cascade-deleting them.

Tests
74 new test cases across DTOs, service helpers, route happy/sad paths, URL repository bulk methods, cache invalidate_many, and the tenant middleware routing matrix (including robots.txt, favicon, operator blocklist, stats-suffix block). Full suite: 1619 passing.

## Summary by Sourcery

Expose custom domains as a user-facing feature across API, routing, and dashboard, including tenant-aware link creation and management.

New Features:
- Add public API endpoints and DTOs for registering, verifying, listing, and revoking custom domains with structured DNS instructions and setup notes.
- Allow shortening URLs onto owned custom domains via an optional domain field, and list/filter URLs by domain, including bulk deletion on a custom domain.
- Introduce a dashboard "Domains" page for managing custom domains, including DNS setup guidance and a revoke flow with optional cascade URL deletion.

Enhancements:
- Tighten tenant routing so custom hostnames only serve short-link surfaces with per-tenant robots controls and X-Robots-Tag headers.
- Scope alias availability and generation by domain, and extend URL repository, cache, and service logic to support per-domain operations and bulk deletions.
- Extend auth and API key scopes with domain management/read permissions and a combined scope+email verification dependency for protected create endpoints.

Tests:
- Add extensive unit and integration coverage for tenant routing policies, custom-domain APIs, per-domain URL operations, cache invalidation, and DTO/domain field normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register, verify, list and revoke custom domains via API and dashboard
  * Dashboard UI for managing custom domains (client JS + styles + templates)
  * Domain-scoped URL shortening and bulk-delete of a user's URLs for a domain

* **Enhancements**
  * New domain-related API scopes and per-domain rate limits
  * Redirects now include stricter X-Robots-Tag to prevent archiving
  * Stricter tenant-aware routing and crawl/noindex handling

* **Bug Fixes / Reliability**
  * Bulk cache invalidation support and safer revoke/delete flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spoo-me/spoo/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->