### PR TITLE
feat(custom-domains): lifecycle fixes + add/manage flow redesign

### DIFF
--- a/config.py
+++ b/config.py
@@ -150,15 +150,9 @@ class CustomDomainSettings(BaseSettings):
     # (every create raises QuotaExceeded with no log signal that the cause
     # is config, not abuse). Validators below fail container startup instead.
     max_per_user: int = Field(default=1, ge=1)
-    create_attempts_per_day: int = Field(default=3, ge=1)
     # Generous because CF's own DCV cadence can take 5-15 min per probe;
     # legitimate users may poll many times during initial activation.
     verify_attempts_per_hour: int = Field(default=60, ge=1)
-
-    # Re-register cooldown after a user revokes their own domain — discourages
-    # rapid hostname-cycling abuse against the LE rate limit. Zero allowed
-    # (disables the cooldown); negative meaningless.
-    re_register_cooldown_days: int = Field(default=30, ge=0)
 
     # Background re-verify worker tunables.
     # interval=0 would busy-loop the worker; batch=0 wastes a tick;

--- a/repositories/custom_domain_repository.py
+++ b/repositories/custom_domain_repository.py
@@ -52,6 +52,18 @@ class CustomDomainRepository(BaseRepository[CustomDomainDoc]):
             {"fqdn": _canonical(fqdn), "status": DomainStatus.ACTIVE}
         )
 
+    async def find_blocking_by_fqdn(self, fqdn: str) -> CustomDomainDoc | None:
+        """Find a doc that would block re-registration of *fqdn*.
+
+        Returns any doc whose status is not REVOKED. REVOKED docs are
+        terminal records of past registrations — they don't reserve the
+        fqdn for future use (no cooldown). Used by uniqueness enforcement
+        in the service layer.
+        """
+        return await self._find_one(
+            {"fqdn": _canonical(fqdn), "status": {"$ne": DomainStatus.REVOKED}}
+        )
+
     async def list_by_owner(
         self,
         owner_id: ObjectId,

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -108,11 +108,23 @@ async def ensure_indexes(db: AsyncDatabase) -> None:
     await feature_flags_col.create_index([("name", 1)], unique=True)
 
     # ── custom_domains ────────────────────────────────────────────────
-    # One row per fqdn — uniqueness enforced globally (no two users can claim
-    # the same domain). Owner+created_at supports the dashboard list view.
-    # status+last_verified_at backs the background re-verify worker query.
     custom_domains_col = db["custom_domains"]
-    await custom_domains_col.create_index([("fqdn", 1)], unique=True)
+    # Partial unique on fqdn — REVOKED docs preserved for audit don't reserve
+    # the fqdn. DCV at register-time is the takeover gate.
+    try:
+        await custom_domains_col.drop_index("fqdn_1")
+        log.info("legacy_custom_domain_fqdn_index_dropped", index="fqdn_1")
+    except OperationFailure as e:
+        if getattr(e, "code", None) != 27:
+            raise
+    await custom_domains_col.create_index(
+        [("fqdn", 1)],
+        unique=True,
+        partialFilterExpression={
+            "status": {"$in": ["pending", "verifying", "active", "suspended"]}
+        },
+        name="fqdn_unique_non_revoked",
+    )
     await custom_domains_col.create_index([("owner_id", 1), ("created_at", -1)])
     await custom_domains_col.create_index([("status", 1), ("last_verified_at", 1)])
 

--- a/routes/api_v1/custom_domains.py
+++ b/routes/api_v1/custom_domains.py
@@ -257,7 +257,8 @@ async def remove_custom_domain(
 
     **Responses**:
     - 204 — removed
-    - 404 — domain not found / not owned by caller
+    - 403 — caller does not own this domain
+    - 404 — domain not found (or invalid id)
     - 422 — domain isn't REVOKED
     """
     oid = _parse_domain_id(domain_id)

--- a/routes/api_v1/custom_domains.py
+++ b/routes/api_v1/custom_domains.py
@@ -230,4 +230,39 @@ async def delete_custom_domain(
     )
 
 
+@router.delete(
+    "/custom-domains/{domain_id}/permanent",
+    status_code=204,
+    responses=AUTH_RESPONSES,
+    operation_id="removeCustomDomain",
+    summary="Remove Revoked Custom Domain",
+)
+@limiter.limit(Limits.DOMAIN_DELETE)
+async def remove_custom_domain(
+    request: Request,
+    domain_id: Annotated[str, Path(description="MongoDB ObjectId of the domain.")],
+    service: CustomDomainSvc,
+    user: CurrentUser = Depends(require_scopes(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
+) -> None:
+    """Permanently delete a revoked custom domain to free the account slot.
+
+    Soft-deleted (REVOKED) domains continue to occupy the caller's per-account
+    quota so revoke is reversible and the audit trail stays intact. To free
+    the slot, the caller explicitly removes the doc via this endpoint. Only
+    REVOKED docs are removable — call DELETE first to revoke an active one.
+
+    **Authentication**: Required (JWT or API key with `domains:manage`).
+
+    **Rate Limits**: 10/min.
+
+    **Responses**:
+    - 204 — removed
+    - 404 — domain not found / not owned by caller
+    - 422 — domain isn't REVOKED
+    """
+    oid = _parse_domain_id(domain_id)
+    await service.remove_revoked(oid, user)
+    return None
+
+
 __all__ = ["router"]

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -96,7 +96,6 @@ class CustomDomainService:
         await self._enforce_blocklist(request.fqdn)
         await self._enforce_uniqueness(request.fqdn)
         await self._enforce_per_user_quota(user.user_id)
-        await self._enforce_create_attempts_quota(user.user_id)
 
         method = self._pick_verification_method(request.fqdn)
         if method not in self._verifiers:
@@ -121,7 +120,7 @@ class CustomDomainService:
         except DuplicateKeyError:
             # Race with concurrent insert — translate to 409 instead of 500.
             raise DomainAlreadyRegisteredError(
-                f"{request.fqdn} is already registered."
+                f"{request.fqdn} is registered to another account."
             ) from None
 
         try:
@@ -329,6 +328,36 @@ class CustomDomainService:
         refreshed = await self._repo.find_by_id(doc.id)
         return refreshed or doc, urls_deleted
 
+    async def remove_revoked(
+        self,
+        domain_id: ObjectId,
+        user: CurrentUser,
+    ) -> CustomDomainDoc:
+        """Hard-delete a REVOKED domain doc to free the caller's slot.
+
+        Revoke is soft (audit trail preserved), so the slot stays occupied
+        until the user explicitly reclaims it via this call. Refuses any
+        non-REVOKED status so the caller can't accidentally nuke an active
+        domain — they must Revoke first, then Remove.
+        """
+        self._require_enabled()
+
+        doc = await self._load_owned(domain_id, user)
+        if doc.status != DomainStatus.REVOKED:
+            raise InvalidDomainTransitionError(
+                "Only revoked domains can be removed. Revoke this domain first."
+            )
+
+        await self._repo.delete_by_id(doc.id)
+
+        log.info(
+            "audit.domain.removed",
+            fqdn=doc.fqdn,
+            domain_id=str(doc.id),
+            owner_id=str(user.user_id),
+        )
+        return doc
+
     async def assert_owned(
         self,
         user: CurrentUser,
@@ -519,34 +548,27 @@ class CustomDomainService:
         )
 
     async def _enforce_uniqueness(self, fqdn: str) -> None:
-        existing = await self._repo.find_by_fqdn(fqdn)
+        # REVOKED docs are terminal and don't reserve the fqdn — same posture
+        # as Vercel/Netlify/CF SaaS. DCV at register-time is the security
+        # gate against takeover.
+        existing = await self._repo.find_blocking_by_fqdn(fqdn)
         if existing is not None:
-            raise DomainAlreadyRegisteredError(f"{fqdn} is already registered.")
+            raise DomainAlreadyRegisteredError(
+                f"{fqdn} is registered to another account."
+            )
 
     async def _enforce_per_user_quota(self, owner_id: ObjectId) -> None:
         current = await self._repo.count_by_owner(owner_id)
         if current >= self._settings.max_per_user:
             cap = self._settings.max_per_user
             suffix = "domain" if cap == 1 else "domains"
+            # Revoked docs still count — they hold the slot until the user
+            # explicitly removes them via the Remove action. Surface both
+            # reclamation paths so the user knows what to do.
             raise DomainQuotaExceededError(
-                f"You've reached the limit of {cap} custom {suffix} for your account."
-            )
-
-    async def _enforce_create_attempts_quota(self, owner_id: ObjectId) -> None:
-        # Fails open without Redis; per-user count still bounds totals.
-        if self._redis is None:
-            return
-        key = f"domain_create_attempts:{owner_id}"
-        try:
-            count = await self._redis.incr(key)
-            if count == 1:
-                await self._redis.expire(key, 24 * 3600)
-        except Exception as exc:
-            log.warning("create_quota_redis_error", error=str(exc))
-            return
-        if count > self._settings.create_attempts_per_day:
-            raise DomainQuotaExceededError(
-                "You've added too many domains today. Try again tomorrow."
+                f"You already have {cap} custom {suffix} on this account. "
+                f"Remove a revoked one or revoke an active one before adding "
+                f"another."
             )
 
     async def _enforce_verify_attempts_quota(self, domain_id: ObjectId) -> None:

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -118,9 +118,10 @@ class CustomDomainService:
         try:
             new_id = await self._repo.insert(doc.to_mongo())
         except DuplicateKeyError:
-            # Race with concurrent insert — translate to 409 instead of 500.
+            # Service-level uniqueness check already caught the common cases;
+            # this is the index backstop for concurrent insert races.
             raise DomainAlreadyRegisteredError(
-                f"{request.fqdn} is registered to another account."
+                f"{request.fqdn} is already registered."
             ) from None
 
         try:
@@ -348,7 +349,9 @@ class CustomDomainService:
                 "Only revoked domains can be removed. Revoke this domain first."
             )
 
-        await self._repo.delete_by_id(doc.id)
+        deleted = await self._repo.delete_by_id(doc.id)
+        if not deleted:
+            raise NotFoundError("Domain not found.")
 
         log.info(
             "audit.domain.removed",
@@ -562,13 +565,10 @@ class CustomDomainService:
         if current >= self._settings.max_per_user:
             cap = self._settings.max_per_user
             suffix = "domain" if cap == 1 else "domains"
-            # Revoked docs still count — they hold the slot until the user
-            # explicitly removes them via the Remove action. Surface both
-            # reclamation paths so the user knows what to do.
             raise DomainQuotaExceededError(
                 f"You already have {cap} custom {suffix} on this account. "
-                f"Remove a revoked one or revoke an active one before adding "
-                f"another."
+                f"Remove a revoked one, or revoke an active one and then "
+                f"remove it, before adding another."
             )
 
     async def _enforce_verify_attempts_quota(self, domain_id: ObjectId) -> None:

--- a/static/css/dashboard/domains.css
+++ b/static/css/dashboard/domains.css
@@ -206,9 +206,11 @@
 
 .modal-header-left {
     display: flex;
-    align-items: center;
-    gap: 12px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
     flex: 1;
+    min-width: 0;
 }
 
 .modal-status-badge {
@@ -245,8 +247,8 @@
 @media (max-width: 768px) {
     .modal.modal-large .modal-content {
         width: 100vw;
-        height: 100vh;
-        max-height: 100vh;
+        /* height: 100vh;
+        max-height: 100vh; */
         border-radius: 0;
     }
 }
@@ -681,4 +683,1354 @@
 #delete-domain-modal .btn-delete:hover:not(:disabled) {
     background: var(--color-danger-hover);
     border-color: var(--color-danger-hover);
+}
+/* ── Remove (hard delete) confirmation modal — mirrors #delete-domain-modal ───────── */
+
+#remove-domain-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-max);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#remove-domain-modal.active {
+    display: flex;
+    opacity: 1;
+    visibility: visible;
+}
+
+#remove-domain-modal .modal-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 20px;
+    position: relative;
+    z-index: 2;
+    background: rgba(0, 0, 0, 0.7);
+    -webkit-backdrop-filter: blur(10px) saturate(180%) brightness(0.7);
+    backdrop-filter: blur(10px) saturate(180%) brightness(0.7);
+}
+
+#remove-domain-modal .modal-content {
+    backdrop-filter: blur(60px);
+    background: rgba(15, 20, 35, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+    width: 100%;
+    max-width: 540px;
+    overflow: hidden;
+    transform: scale(0.85) translateY(20px);
+    opacity: 0;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#remove-domain-modal.active .modal-content {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+}
+
+#remove-domain-modal .modal-header {
+    display: flex;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#remove-domain-modal .modal-title-section-delete {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+#remove-domain-modal .modal-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    flex-shrink: 0;
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+    color: white;
+}
+
+#remove-domain-modal .modal-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+    line-height: 1.3;
+}
+
+#remove-domain-modal .modal-body {
+    padding: 20px 24px;
+}
+
+#remove-domain-modal .modal-body p {
+    color: var(--text-secondary);
+    margin: 0 0 8px;
+    line-height: 1.5;
+    font-size: 14px;
+}
+
+#remove-domain-modal .modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 16px 24px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    gap: 10px;
+}
+
+#remove-domain-modal .btn-cancel {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+#remove-domain-modal .btn-cancel:hover {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--text-primary);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+#remove-domain-modal .btn-delete {
+    background: var(--color-danger);
+    color: white;
+    border-color: var(--color-danger);
+}
+
+#remove-domain-modal .btn-delete:hover:not(:disabled) {
+    background: var(--color-danger-hover);
+    border-color: var(--color-danger-hover);
+}
+
+#remove-domain-modal .btn-delete:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#remove-domain-modal .field input {
+    width: 100%;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 13px;
+    transition: border-color 0.15s ease;
+}
+
+#remove-domain-modal .field input:focus {
+    outline: none;
+    border-color: var(--color-danger);
+}
+
+#remove-domain-modal .field label {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 500;
+}
+
+/* ───────────────────────────────────────────────────────────────────────
+ * Part B redesign — 4-step modal, stepper, status panel, management view,
+ * card-as-target revoke, type-to-confirm, confetti.
+ * New template uses .modal.domain-modal (replaces old .modal-large).
+ * ─────────────────────────────────────────────────────────────────────── */
+
+/* ── Modal shell sizing ──────────────────────────────────────────────── */
+
+.modal.domain-modal .modal-content {
+    max-width: calc(100vw - 32px);
+    height: auto;
+    max-height: 90vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: width 0.25s ease, max-width 0.25s ease;
+}
+
+.modal.domain-modal .modal-content[data-size="narrow"] {
+    width: 680px;
+}
+
+.modal.domain-modal .modal-content[data-size="medium"] {
+    width: 820px;
+}
+
+.modal.domain-modal .modal-content[data-size="wide"] {
+    width: 920px;
+}
+
+.modal.domain-modal .modal-header {
+    border-bottom: 1px solid var(--border-color);
+    padding: 18px 24px;
+    display: flex;
+    align-items: center;
+}
+
+.modal.domain-modal .modal-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 24px 28px 28px;
+    min-width: 0;
+}
+
+.modal.domain-modal .modal-footer {
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 14px 24px;
+    min-height: 64px;
+    margin-top: 0;
+}
+
+/* Collapse trailing margin of the last block inside any mode slot — without
+   this, sections with margin-bottom (e.g. settings-section) stack their
+   margin with the body's padding-bottom and the footer's old margin-top,
+   producing a big gap before the footer. */
+.modal.domain-modal .modal-slot > *:last-child {
+    margin-bottom: 0;
+}
+
+.modal-footer-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-left: auto;
+}
+
+.modal-footer-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+@media (max-width: 768px) {
+    .modal.domain-modal .modal-content,
+    .modal.domain-modal .modal-content[data-size="narrow"],
+    .modal.domain-modal .modal-content[data-size="medium"],
+    .modal.domain-modal .modal-content[data-size="wide"] {
+        width: 100vw;
+        max-width: 100vw;
+        /* height: 100vh;
+        max-height: 100vh; */
+        /* border-radius: 0; */
+    }
+}
+
+/* ── Modal shell: rail + body layout ────────────────────────────────── */
+
+.modal-shell {
+    display: flex;
+    flex: 0 1 auto;
+    overflow: hidden;
+}
+
+.modal-shell > .modal-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+}
+
+/* Stepper rail visibility per mode. Hidden by default, shown when
+   data-show-stepper="true" on modal-content. */
+.stepper-rail {
+    display: none;
+    flex: 0 0 200px;
+    padding: 24px 8px 24px 28px;
+    align-self: stretch;
+}
+
+.modal.domain-modal .modal-content[data-show-stepper="true"] .stepper-rail {
+    display: block;
+}
+
+@media (max-width: 768px) {
+    /* Hide rail on mobile — vertical real estate too precious; the active
+       slot's title + footer chevrons carry the progression signal. */
+    .modal.domain-modal .modal-content[data-show-stepper="true"] .stepper-rail {
+        display: none;
+    }
+}
+
+/* ── Stepper ─────────────────────────────────────────────────────────── */
+
+.stepper {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    position: relative;
+}
+
+.stepper-item {
+    position: relative;
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    grid-template-rows: auto;
+    gap: 12px;
+    align-items: start;
+    cursor: default;
+    user-select: none;
+}
+
+.stepper-item.is-completed,
+.stepper-item.is-active {
+    cursor: pointer;
+}
+
+.stepper-rail-line {
+    position: absolute;
+    top: 28px;
+    bottom: -28px;
+    left: 13px;
+    width: 1px;
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.stepper-item:last-child .stepper-rail-line {
+    display: none;
+}
+
+.stepper-item.is-completed .stepper-rail-line {
+    background: rgba(34, 197, 94, 0.2);
+}
+
+.stepper-dot {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+    z-index: 1;
+    transition: all 0.2s;
+}
+
+.stepper-num { display: inline; }
+.stepper-check { display: none; font-size: 14px; }
+
+.stepper-item.is-completed .stepper-dot {
+    background: rgba(34, 197, 94, 0.18);
+    border-color: rgba(34, 197, 94, 0.55);
+    color: #4ade80;
+}
+
+.stepper-item.is-completed .stepper-num { display: none; }
+.stepper-item.is-completed .stepper-check { display: inline; }
+
+.stepper-item.is-active .stepper-dot {
+    background: rgba(168, 85, 247, 0.18);
+    border-color: rgba(168, 85, 247, 0.55);
+    color: #c4b5fd;
+    box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.08);
+}
+
+.stepper-item.is-failed .stepper-dot {
+    background: rgba(239, 68, 68, 0.18);
+    border-color: rgba(239, 68, 68, 0.55);
+    color: #fca5a5;
+}
+
+.stepper-meta {
+    line-height: 1.3;
+    padding-top: 2px;
+}
+
+.stepper-tag {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    margin-bottom: 2px;
+}
+
+.stepper-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.stepper-item.is-pending .stepper-label {
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.stepper-status {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+    padding: 2px 6px;
+    border-radius: 8px;
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.stepper-item.is-active .stepper-status {
+    background: rgba(168, 85, 247, 0.15);
+    color: var(--color-primary, #a855f7);
+}
+
+.stepper-item.is-completed .stepper-status {
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--color-success);
+}
+
+.stepper-item.is-failed .stepper-status {
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--color-danger);
+}
+
+/* ── Slot common ─────────────────────────────────────────────────────── */
+
+.slot-intro {
+    margin-bottom: 20px;
+}
+
+.slot-heading {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.slot-sub {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
+.slot-sub code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    padding: 1px 6px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 4px;
+    color: var(--text-primary);
+}
+
+.slot-lead {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin: 0 0 18px;
+    line-height: 1.5;
+}
+
+/* Modal header — title row + optional sub line per mode */
+.modal-header-titlerow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.modal-header-sub {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin: 4px 0 0;
+    line-height: 1.45;
+}
+
+/* ── DNS records section (Step 2) ────────────────────────────────────── */
+
+.dns-records-section {
+    margin-bottom: 16px;
+}
+
+.dns-records-header {
+    margin-bottom: 14px;
+}
+
+.dns-records-header .section-title {
+    font-size: 13px;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.dns-records-list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.dns-record {
+    display: grid;
+    grid-template-columns: 84px minmax(0, 1.2fr) minmax(0, 2fr);
+    gap: 12px;
+    align-items: stretch;
+    padding: 0;
+    background: transparent;
+    border: none;
+}
+
+.rec-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.rec-cell .rec-cell-box {
+    flex: 1;
+}
+
+.rec-cell-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    padding-left: 2px;
+}
+
+.rec-cell-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 9px 10px 9px 12px;
+    min-width: 0;
+    min-height: 38px;
+    cursor: default;
+}
+
+.rec-cell-box code,
+.rec-cell-box .rec-type-text {
+    cursor: default;  /* not interactive — boxes look like inputs but aren't */
+}
+
+.rec-cell-box-static {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.rec-cell-box code,
+.rec-cell-box .rec-type-text {
+    flex: 1;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    color: var(--text-primary);
+    overflow-x: auto;
+    white-space: nowrap;
+    background: transparent;
+    padding: 0;
+    min-width: 0;
+}
+
+.rec-cell-box .rec-type-text {
+    font-weight: 600;
+    letter-spacing: 0.3px;
+}
+
+.rec-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    opacity: 0.5;
+    font-size: 14px;
+    transition: opacity 0.15s, color 0.15s, background 0.15s;
+    flex-shrink: 0;
+}
+
+.rec-cell-box:hover .rec-copy-btn { opacity: 0.85; }
+
+.rec-copy-btn:hover {
+    opacity: 1;
+    color: #c4b5fd;
+    background: rgba(168, 85, 247, 0.08);
+}
+
+.rec-copy-btn.copied {
+    opacity: 1;
+    color: var(--color-success);
+    background: transparent;
+}
+
+/* ── Setup help link (under DNS records) ─────────────────────────────── */
+
+.setup-help {
+    margin: 18px 0 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.setup-help-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--text-primary);
+    text-decoration: none;
+    margin-left: 4px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.setup-help-link:hover {
+    color: #c4b5fd;
+    border-bottom-color: rgba(168, 85, 247, 0.5);
+}
+
+.setup-help-link i {
+    font-size: 13px;
+    opacity: 0.7;
+}
+
+/* ── Setup notes (e.g. Cloudflare grey-cloud) ────────────────────────── */
+
+.setup-notes {
+    margin-top: 14px;
+    padding: 12px 14px;
+    background: rgba(59, 130, 246, 0.08);
+    border: 1px solid rgba(59, 130, 246, 0.2);
+    border-radius: var(--radius-md);
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.setup-notes p { margin: 0; }
+.setup-notes p + p { margin-top: 6px; }
+
+/* ── Verify status panel (Step 3) ────────────────────────────────────── */
+
+.status-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    margin-bottom: 14px;
+}
+
+.status-row {
+    display: grid;
+    grid-template-columns: 36px 1fr;
+    gap: 14px;
+    align-items: center;
+}
+
+.status-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    border: 1px solid var(--border-color);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.status-icon .ti { display: none; }
+.status-row[data-state="pending"] .status-spinner { display: inline; color: #fbbf24; }
+.status-row[data-state="success"] .status-success { display: inline; color: var(--color-success); }
+.status-row[data-state="fail"] .status-fail { display: inline; color: var(--color-danger); }
+
+.status-row[data-state="success"] .status-icon {
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.35);
+}
+
+.status-row[data-state="fail"] .status-icon {
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.35);
+}
+
+.status-row[data-state="pending"] .status-icon {
+    background: rgba(251, 191, 36, 0.1);
+    border-color: rgba(251, 191, 36, 0.3);
+}
+
+@keyframes spin360 {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.status-spinner.spinning,
+i.spinning {
+    animation: spin360 1.1s linear infinite;
+}
+
+.status-content { min-width: 0; }
+
+.status-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 2px;
+}
+
+.status-message {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.status-row[data-state="success"] .status-message {
+    color: var(--color-success);
+}
+
+.status-row[data-state="fail"] .status-message {
+    color: var(--color-danger);
+}
+
+/* ── Auto-check hint (Verify step) ──────────────────────────────────── */
+
+.auto-check-hint {
+    margin: 12px 0 0;
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+.auto-check-hint strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+/* Footer verify button — icon spins while a check is in flight. */
+#btn-verify-footer {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#btn-verify-footer:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+/* ── (legacy) Poll info / paused — retained in case template re-introduces ─── */
+
+.poll-info {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 14px;
+    background: rgba(168, 85, 247, 0.06);
+    border: 1px dashed rgba(168, 85, 247, 0.25);
+    border-radius: var(--radius-md);
+    margin-bottom: 12px;
+}
+
+.poll-text {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+.poll-paused {
+    padding: 12px 14px;
+    background: rgba(245, 158, 11, 0.08);
+    border: 1px solid rgba(245, 158, 11, 0.22);
+    border-radius: var(--radius-md);
+    margin-bottom: 12px;
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.poll-paused p { margin: 0; }
+
+.btn-link {
+    background: transparent;
+    border: none;
+    padding: 4px 6px;
+    color: var(--color-primary, #a855f7);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 4px;
+    transition: background 0.15s;
+}
+
+.btn-link:hover {
+    background: rgba(168, 85, 247, 0.08);
+}
+
+/* ── Live (Step 4) — Management view ─────────────────────────────────── */
+
+.live-hero {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding-bottom: 18px;
+    margin-bottom: 18px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.live-hero-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.live-hero-check {
+    color: var(--color-success);
+    font-size: 24px;
+}
+
+.btn-icon-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    text-decoration: none;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    transition: all 0.15s;
+    cursor: pointer;
+}
+
+.btn-icon-text:hover {
+    background: rgba(168, 85, 247, 0.1);
+    border-color: rgba(168, 85, 247, 0.3);
+}
+
+.live-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 22px;
+}
+
+.action-card {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    gap: 14px;
+    align-items: center;
+    padding: 14px 16px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    transition: all 0.15s;
+    cursor: pointer;
+}
+
+.action-card:hover {
+    background: rgba(168, 85, 247, 0.06);
+    border-color: rgba(168, 85, 247, 0.3);
+    transform: translateY(-1px);
+}
+
+.action-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(168, 85, 247, 0.1);
+    color: #c4b5fd;
+    font-size: 20px;
+}
+
+.action-text { min-width: 0; }
+
+.action-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 2px;
+}
+
+.action-desc {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+/* Settings sections (routing settings) */
+.settings-section {
+    margin-bottom: 22px;
+    padding: 0;
+    background: transparent;
+    border: none;
+}
+
+.settings-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 14px;
+    margin-bottom: 18px;
+}
+
+.settings-header h3 {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 4px;
+}
+
+.settings-hint {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
+.badge-coming-soon {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 9px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: rgba(168, 85, 247, 0.12);
+    color: #c4b5fd;
+    border: 1px solid rgba(168, 85, 247, 0.25);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.settings-section.settings-disabled .settings-grid {
+    opacity: 0.6;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px 16px;
+    margin-top: 16px;
+}
+
+.setting-field {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+}
+
+.setting-full {
+    grid-column: 1 / -1;
+}
+
+.setting-field label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.setting-field label code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    padding: 1px 4px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 3px;
+}
+
+.setting-field input[type="text"],
+.setting-field textarea {
+    width: 100%;
+    padding: 8px 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+}
+
+.setting-field textarea {
+    resize: vertical;
+    min-height: 64px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+/* ── Diagnostics (collapsed by default in Live view) ─────────────────── */
+
+.diagnostics {
+    margin-bottom: 22px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.diagnostics summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 14px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    user-select: none;
+}
+
+.diagnostics summary::-webkit-details-marker { display: none; }
+
+.diagnostics summary::before {
+    content: '▸';
+    font-size: 10px;
+    color: var(--text-secondary);
+    transition: transform 0.15s;
+    display: inline-block;
+}
+
+.diagnostics[open] summary::before {
+    transform: rotate(90deg);
+}
+
+.diagnostics-body {
+    padding: 4px 16px 16px;
+    border-top: 1px solid var(--border-color);
+}
+
+.diag-records-heading {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin: 18px 0 10px;
+}
+
+.diag-list {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 6px 16px;
+    margin: 10px 0 0;
+    font-size: 13px;
+}
+
+.diag-list dt {
+    color: var(--text-secondary);
+}
+
+.diag-list dd {
+    color: var(--text-primary);
+    margin: 0;
+}
+
+/* ── Danger zone (Live view) ─────────────────────────────────────────── */
+
+.danger-zone {
+    margin-top: 26px;
+    padding: 16px 18px;
+    background: rgba(239, 68, 68, 0.04);
+    border: 1px solid rgba(239, 68, 68, 0.2);
+    border-radius: var(--radius-md);
+}
+
+.danger-header h3 {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-danger);
+    margin: 0 0 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.danger-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.danger-text { flex: 1; min-width: 0; }
+
+.danger-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+}
+
+.danger-desc {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+/* Primary-destructive button — filled red, used in Live "Revoke" and
+   confirmation modals. */
+.btn.btn-danger {
+    background: var(--color-danger);
+    border: 1px solid var(--color-danger);
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.btn.btn-danger:hover:not(:disabled) {
+    background: var(--color-danger-hover, #dc2626);
+    border-color: var(--color-danger-hover, #dc2626);
+}
+
+.btn.btn-danger:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ── Revoked slot ────────────────────────────────────────────────────── */
+
+.banner-revoked {
+    background: rgba(148, 163, 184, 0.06);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    color: var(--text-primary);
+    align-items: flex-start;
+    padding: 14px 16px;
+}
+
+.banner-revoked p {
+    margin: 6px 0 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.banner-icon {
+    font-size: 20px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+    flex-shrink: 0;
+}
+
+.revoked-meta {
+    margin-top: 18px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 12px 16px;
+}
+
+/* ── Revoke sub-modal: card-as-target + type-to-confirm ──────────────── */
+
+.cascade-choice {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 14px;
+}
+
+.cascade-card {
+    text-align: left;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 14px 16px;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+    transition: all 0.15s;
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    gap: 12px;
+    align-items: center;
+    min-height: 96px;
+}
+
+.cascade-text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+/* Non-destructive option: orange/amber highlight on hover + select. */
+.cascade-card:hover {
+    background: rgba(245, 158, 11, 0.06);
+    border-color: rgba(245, 158, 11, 0.3);
+}
+
+.cascade-card.is-selected {
+    background: rgba(245, 158, 11, 0.08);
+    border-color: var(--color-warning);
+    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
+}
+
+/* Destructive option: red on hover + select to signal irreversibility. */
+.cascade-card.cascade-card-destructive:hover {
+    background: rgba(239, 68, 68, 0.06);
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.cascade-card.cascade-card-destructive.is-selected {
+    background: rgba(239, 68, 68, 0.08);
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+.cascade-card-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cascade-card .cascade-icon {
+    font-size: 20px;
+    line-height: 1;
+    color: var(--text-secondary);
+}
+
+.cascade-card.is-selected .cascade-icon,
+.cascade-card[aria-pressed="true"] .cascade-icon {
+    color: var(--color-warning);
+}
+
+.cascade-card.cascade-card-destructive.is-selected .cascade-icon,
+.cascade-card.cascade-card-destructive[aria-pressed="true"] .cascade-icon {
+    color: var(--color-danger);
+}
+
+.cascade-card-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.cascade-card-desc {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.45;
+}
+
+/* destructive variant keeps the same neutral description colour as the
+   non-destructive option — the title + icon + select ring carry the
+   warning signal; red prose on every paragraph reads as already-failed. */
+
+.type-to-confirm-field {
+    margin-top: 16px;
+}
+
+.type-to-confirm-field label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.type-to-confirm-field input {
+    width: 100%;
+    padding: 9px 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.type-to-confirm-field input:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.06);
+}
+
+#delete-domain-modal .modal-content,
+#remove-domain-modal .modal-content {
+    max-width: 680px;
+}
+
+#delete-domain-modal .btn-delete:disabled,
+#remove-domain-modal .btn-delete:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#delete-domain-modal .btn-delete.btn-destructive-strong:not(:disabled) {
+    background: var(--color-danger);
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.18);
+}
+
+/* ── Confetti canvas ─────────────────────────────────────────────────── */
+
+.confetti-canvas {
+    position: fixed;
+    pointer-events: none;
+    z-index: 10000;
+    display: none;
+}
+
+/* ── Action buttons used by stepper / status panel ───────────────────── */
+
+#btn-step-next {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+#btn-step-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    border-color: transparent;
+}
+
+#btn-step-back:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.btn.btn-link-danger {
+    background: transparent;
+    border-color: transparent;
+    color: var(--text-secondary);
+    font-weight: 500;
+    padding: 8px 10px;
+}
+
+.btn.btn-link-danger:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--color-danger);
+}
+
+.btn.btn-link-danger:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }

--- a/static/js/dashboard/domains.js
+++ b/static/js/dashboard/domains.js
@@ -1,9 +1,26 @@
-// Custom Domains — single page, large state-aware modal.
-// Modal modes: add | setup | active | revoked. URL-persisted via ?domain=<id>
-// and ?new=1 so refresh + direct links reopen the right state.
+// Custom Domains — 4-step modal w/ stepper, status panel, confetti.
+//
+// Modes: add | dns | verify | live | revoked
+//   add / revoked → narrow shell, no stepper
+//   dns / verify  → wide shell, vertical stepper rail
+//   live          → medium shell, no stepper, full management view
+//
+// State machine driven by the doc.status from the API:
+//   PENDING   → mode `dns` initially; user advances to `verify` after "I've added the records"
+//   SUSPENDED → mode `dns` with suspended banner (regression from active)
+//   ACTIVE    → mode `live`
+//   REVOKED   → mode `revoked`
+//
+// The "I've added the records" button is purely client-side UX — it doesn't
+// change server state; it just advances the stepper into the verify panel
+// which triggers an immediate verify + starts the auto-poll loop.
 
-const POLL_INTERVAL_MS = 5000;
-const POLL_MAX_DURATION_MS = 60000;
+// ── Tuning ────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 10000;  // Quiet auto-refresh; user can Check now any time
+const FIRST_LIVE_FLAG_KEY = 'domain_first_live_';  // localStorage prefix for confetti dedupe
+
+// ── DOM refs ──────────────────────────────────────────────────────────────
 
 const el = {
     // List
@@ -14,50 +31,90 @@ const el = {
     dnsTpl: document.getElementById('tpl-dns-record'),
     newBtn: document.getElementById('btn-new-domain'),
 
-    // Domain modal
+    // Modal shell
     modal: document.getElementById('domainModal'),
+    modalContent: document.querySelector('#domainModal .modal-content'),
     modalTitle: document.getElementById('domainModalTitle'),
+    modalSub: document.getElementById('domainModalSub'),
     modalBadge: document.getElementById('modalStatusBadge'),
     modalClose: document.getElementById('btn-close-domain-modal'),
-    modalCancel: document.getElementById('btn-domain-modal-cancel'),
-    modalSubmit: document.getElementById('btn-domain-modal-submit'),
-    modalRevoke: document.getElementById('btn-domain-revoke'),
+    modalFooter: document.getElementById('domain-modal-footer'),
 
-    // Add mode
+    // Footer buttons
+    btnCancel: document.getElementById('btn-domain-modal-cancel'),
+    btnSubmit: document.getElementById('btn-domain-modal-submit'),
+    btnStepBack: document.getElementById('btn-step-back'),
+    btnStepNext: document.getElementById('btn-step-next'),
+    btnCancelRegistration: document.getElementById('btn-cancel-registration'),
+    btnRemove: document.getElementById('btn-domain-remove'),
+
+    // Stepper
+    stepper: document.getElementById('stepper'),
+    stepperItems: document.querySelectorAll('#stepper .stepper-item'),
+
+    // Add slot
     addInput: document.getElementById('domain-fqdn'),
     addError: document.getElementById('add-domain-error'),
 
-    // Setup mode
-    setupBanner: document.getElementById('setup-banner'),
-    setupRecords: document.getElementById('dns-records'),
+    // DNS slot
+    dnsSub: document.getElementById('dns-sub'),
+    dnsRecords: document.getElementById('dns-records'),
     setupNotes: document.getElementById('setup-notes'),
-    setupVerify: document.getElementById('btn-verify'),
-    setupError: document.getElementById('setup-error'),
-    setupPoll: document.getElementById('setup-poll-status'),
+    dnsError: document.getElementById('dns-error'),
 
-    // Active mode
-    activeOpenLink: document.getElementById('active-open-link'),
-    activeOpenLabel: document.getElementById('active-open-label'),
-    activeMeta: document.getElementById('active-meta'),
-    activeDnsRecords: document.getElementById('active-dns-records'),
+    // Verify slot
+    statusRowDns: document.getElementById('status-row-dns'),
+    statusRowSsl: document.getElementById('status-row-ssl'),
+    statusDnsMessage: document.getElementById('status-dns-message'),
+    statusSslMessage: document.getElementById('status-ssl-message'),
+    btnVerifyFooter: document.getElementById('btn-verify-footer'),
+    verifyError: document.getElementById('verify-error'),
 
-    // Revoke confirmation sub-modal
+    // Live slot
+    liveHeroFqdn: document.getElementById('live-hero-fqdn'),
+    liveOpenIconLink: document.getElementById('live-open-icon-link'),
+    liveShortenCta: document.getElementById('live-shorten-cta'),
+    btnRevokeFooter: document.getElementById('btn-revoke-footer'),
+
+    // Revoked slot
+    revokedAt: document.getElementById('revoked-at'),
+    revokedCreated: document.getElementById('revoked-created'),
+
+    // Confetti
+    confettiCanvas: document.getElementById('confetti-canvas'),
+
+    // Revoke confirmation sub-modal (redesigned with cards + type-to-confirm)
     revokeModal: document.getElementById('delete-domain-modal'),
+    revokeTitle: document.getElementById('deleteDomainModalTitle'),
     revokeFqdn: document.getElementById('delete-domain-fqdn'),
     revokeUrlCount: document.getElementById('delete-domain-url-count'),
+    revokeCards: document.querySelectorAll('#delete-domain-modal .cascade-card'),
+    revokeInput: document.getElementById('delete-domain-confirm-input'),
     revokeError: document.getElementById('delete-domain-error'),
     revokeCancel: document.getElementById('btn-cancel-domain-delete'),
     revokeConfirm: document.getElementById('btn-confirm-domain-delete'),
+    revokeConfirmLabel: document.getElementById('btn-confirm-domain-delete-label'),
+
+    // Remove (hard delete) sub-modal — REVOKED docs only
+    removeModal: document.getElementById('remove-domain-modal'),
+    removeFqdn: document.getElementById('remove-domain-fqdn'),
+    removeInput: document.getElementById('remove-domain-confirm-input'),
+    removeError: document.getElementById('remove-domain-error'),
+    removeCancel: document.getElementById('btn-cancel-domain-remove'),
+    removeConfirm: document.getElementById('btn-confirm-domain-remove'),
 };
 
-// State
+// ── State ─────────────────────────────────────────────────────────────────
+
 let currentMode = null;
 let currentDomain = null;
 let domainsCache = [];
+let revokeSelectedCascade = false;   // sync with .cascade-card[aria-pressed]
+let revokeUrlCount = 0;              // captured at modal open
 let pollTimer = null;
-let pollDeadline = 0;
+let pollDomainId = null;
 
-// ── Helpers ───────────────────────────────────────────────────────────────
+// ── Generic helpers ───────────────────────────────────────────────────────
 
 function escapeHtml(s) {
     return String(s ?? '').replace(/[&<>"']/g, c => ({
@@ -81,6 +138,15 @@ function timeAgo(iso) {
     return `${days} day${days === 1 ? '' : 's'} ago`;
 }
 
+function formatAbsolute(iso) {
+    if (!iso) return '—';
+    try {
+        return new Date(iso).toLocaleString();
+    } catch (_) {
+        return '—';
+    }
+}
+
 function setError(node, msg) {
     if (!node) return;
     if (!msg) {
@@ -92,25 +158,121 @@ function setError(node, msg) {
     node.style.display = 'block';
 }
 
-function showSlot(mode) {
+// ── Modal shell control ───────────────────────────────────────────────────
+
+function setMode(mode) {
     document.querySelectorAll('#domainModal .modal-slot').forEach(slot => {
         slot.style.display = slot.dataset.mode === mode ? '' : 'none';
     });
     currentMode = mode;
+
+    // Width + stepper visibility per mode.
+    el.modalContent.dataset.mode = mode;
+    const wide = mode === 'dns' || mode === 'verify';
+    el.modalContent.dataset.size = wide ? 'wide' : (mode === 'live' ? 'medium' : 'narrow');
+    el.modalContent.dataset.showStepper = wide ? 'true' : 'false';
 }
 
-// Footer button visibility per mode. `submit` accepts a label string (shows
-// the button with that label) or false (hides).
-function setFooter({ cancel = false, submit = false, revoke = false, verify = false }) {
-    el.modalCancel.style.display = cancel ? '' : 'none';
+function showModal() {
+    el.modal.style.display = 'flex';
+    el.modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+}
+
+function closeModal({ push = true } = {}) {
+    stopPoll();
+    el.modal.style.display = 'none';
+    el.modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    currentDomain = null;
+    currentMode = null;
+    clearConfetti();
+    if (push) syncUrl({});
+}
+
+function syncUrl(params) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) qs.set(k, v);
+    const url = qs.toString() ? `?${qs.toString()}` : window.location.pathname;
+    history.replaceState(null, '', url);
+}
+
+// ── Footer button orchestration ───────────────────────────────────────────
+
+function setFooter({
+    cancel = false,
+    submit = false,
+    next = false,
+    back = false,
+    remove = false,
+    verify = false,
+    revoke = false,
+    cancelRegistration = false,
+}) {
+    el.btnCancel.style.display = cancel ? '' : 'none';
+    el.btnStepBack.style.display = back ? '' : 'none';
+    el.btnRemove.style.display = remove ? '' : 'none';
+    el.btnVerifyFooter.style.display = verify ? '' : 'none';
+    el.btnRevokeFooter.style.display = revoke ? '' : 'none';
+    el.btnCancelRegistration.style.display = cancelRegistration ? '' : 'none';
+
     if (submit) {
-        el.modalSubmit.style.display = '';
-        el.modalSubmit.textContent = submit;
+        el.btnSubmit.style.display = '';
+        el.btnSubmit.textContent = submit;
     } else {
-        el.modalSubmit.style.display = 'none';
+        el.btnSubmit.style.display = 'none';
     }
-    el.modalRevoke.style.display = revoke ? '' : 'none';
-    el.setupVerify.style.display = verify ? '' : 'none';
+
+    if (next) {
+        el.btnStepNext.style.display = '';
+        el.btnStepNext.querySelector('.btn-label').textContent = next;
+    } else {
+        el.btnStepNext.style.display = 'none';
+    }
+
+    const anyVisible =
+        cancel || submit || next || back || remove || verify || revoke || cancelRegistration;
+    el.modalFooter.style.display = anyVisible ? '' : 'none';
+}
+
+// ── Stepper rendering ─────────────────────────────────────────────────────
+
+// Updates the stepper item states. `step` is the currently-active step
+// (1-4); `completed` is the set of step numbers shown as completed.
+function setStepper(activeStep, { completed = new Set(), failed = null } = {}) {
+    el.stepperItems.forEach(item => {
+        const n = parseInt(item.dataset.step, 10);
+        item.classList.remove('is-active', 'is-completed', 'is-pending', 'is-failed');
+        if (failed && n === failed) {
+            item.classList.add('is-failed');
+        } else if (completed.has(n)) {
+            item.classList.add('is-completed');
+        } else if (n === activeStep) {
+            item.classList.add('is-active');
+        } else {
+            item.classList.add('is-pending');
+        }
+
+        const statusNode = item.querySelector('.stepper-status');
+        if (failed && n === failed) statusNode.textContent = 'Action needed';
+        else if (completed.has(n)) statusNode.textContent = 'Completed';
+        else if (n === activeStep) statusNode.textContent = 'In progress';
+        else statusNode.textContent = 'Pending';
+    });
+}
+
+// Step navigation (user clicking a completed/active step).
+function attemptJumpToStep(step) {
+    if (!currentDomain) return;
+    const status = String(currentDomain.status || '').toUpperCase();
+    // Only allow back-navigation between dns (step 2) and verify (step 3)
+    // while the domain isn't yet active. Live (step 4) ignores stepper clicks.
+    if (status === 'ACTIVE' || status === 'REVOKED') return;
+    if (step === 2) {
+        renderDnsMode(currentDomain);
+    } else if (step === 3) {
+        renderVerifyMode(currentDomain, { triggerImmediate: false });
+    }
 }
 
 // ── List fetch + render ───────────────────────────────────────────────────
@@ -176,16 +338,30 @@ function createRow(domain) {
 
 // ── Modal: open / close / URL sync ────────────────────────────────────────
 
+function setHeader({ title, sub = null }) {
+    el.modalTitle.textContent = title;
+    if (sub) {
+        el.modalSub.textContent = sub;
+        el.modalSub.style.display = '';
+    } else {
+        el.modalSub.style.display = 'none';
+    }
+}
+
 function openAddModal({ push = true } = {}) {
     currentDomain = null;
     el.addInput.value = '';
     setError(el.addError, '');
-    el.modalTitle.textContent = 'Add a domain';
+    setHeader({
+        title: 'Add a domain',
+        sub: "Use a domain you control. We'll guide you through DNS and verification next.",
+    });
     el.modalBadge.style.display = 'none';
 
-    setFooter({ cancel: true, submit: 'Add', revoke: false, verify: false });
+    setStepper(1);
+    setMode('add');
+    setFooter({ submit: 'Add domain' });
 
-    showSlot('add');
     showModal();
     if (push) syncUrl({ new: '1' });
     setTimeout(() => el.addInput.focus(), 60);
@@ -195,9 +371,9 @@ async function openDomainModal(id, { push = true } = {}) {
     if (!id) return;
     currentDomain = null;
 
-    el.modalTitle.textContent = 'Loading…';
+    setHeader({ title: 'Loading…' });
     el.modalBadge.style.display = 'none';
-    setFooter({ cancel: false, submit: false, revoke: false, verify: false });
+    setFooter({});
 
     showModal();
     if (push) syncUrl({ domain: id });
@@ -219,57 +395,35 @@ async function openDomainModal(id, { push = true } = {}) {
     }
 }
 
-function showModal() {
-    el.modal.style.display = 'flex';
-    el.modal.setAttribute('aria-hidden', 'false');
-    document.body.style.overflow = 'hidden';
-}
-
-function closeModal({ push = true } = {}) {
-    stopPoll();
-    el.modal.style.display = 'none';
-    el.modal.setAttribute('aria-hidden', 'true');
-    document.body.style.overflow = '';
-    currentDomain = null;
-    currentMode = null;
-    if (push) syncUrl({});
-}
-
-function syncUrl(params) {
-    const qs = new URLSearchParams();
-    for (const [k, v] of Object.entries(params)) qs.set(k, v);
-    const url = qs.toString() ? `?${qs.toString()}` : window.location.pathname;
-    history.replaceState(null, '', url);
-}
-
 // ── Render by status ──────────────────────────────────────────────────────
 
 function renderForStatus(doc) {
-    el.modalTitle.textContent = doc.fqdn;
+    setHeader({ title: doc.fqdn });
     const status = String(doc.status || '').toUpperCase();
     el.modalBadge.textContent = status;
     el.modalBadge.className = `status-badge modal-status-badge ${statusClass(status)}`;
     el.modalBadge.style.display = '';
 
     if (status === 'PENDING' || status === 'SUSPENDED') {
-        renderSetup(doc, status);
+        renderDnsMode(doc);
     } else if (status === 'ACTIVE') {
-        renderActive(doc);
+        renderLiveMode(doc);
     } else if (status === 'REVOKED') {
-        renderRevoked(doc);
+        renderRevokedMode(doc);
     }
 }
 
-function renderSetup(doc, status) {
-    el.setupBanner.classList.remove('banner-pending', 'banner-suspended');
-    el.setupBanner.classList.add(
-        status === 'SUSPENDED' ? 'banner-suspended' : 'banner-pending'
-    );
-    el.setupBanner.textContent = status === 'SUSPENDED'
-        ? 'Verification lost. Check your DNS records and click Verify.'
-        : 'Add the DNS record(s) below at your DNS provider, then click Verify.';
+function renderDnsMode(doc) {
+    stopPoll();
+    const status = String(doc.status || '').toUpperCase();
+    const isSuspended = status === 'SUSPENDED';
 
-    renderDnsRecords(el.setupRecords, doc.dns_records || []);
+    el.dnsSub.textContent = isSuspended
+        ? "Verification was lost — re-check your DNS records below, then continue to re-verify."
+        : "Publish the record(s) below at your DNS provider, then continue to verify.";
+
+    const records = doc.dns_records || [];
+    renderDnsRecords(el.dnsRecords, records, { withCopy: true });
 
     if (doc.setup_notes && doc.setup_notes.length) {
         el.setupNotes.innerHTML = '';
@@ -283,70 +437,197 @@ function renderSetup(doc, status) {
         el.setupNotes.style.display = 'none';
     }
 
-    setError(el.setupError, doc.last_verification_error || '');
-    el.setupPoll.style.display = 'none';
-    resetVerifyButton();
+    // last_verification_error is verify-step state and must not leak into
+    // the DNS step. SUSPENDED is the one exception — the banner already
+    // tells the user verification was lost, and surfacing the underlying
+    // reason next to the records helps them diagnose what to fix.
+    setError(el.dnsError, isSuspended ? (doc.last_verification_error || '') : '');
 
-    setFooter({ revoke: true, verify: true });
-
-    showSlot('setup');
+    setStepper(2, {
+        completed: new Set([1]),
+        failed: isSuspended ? 2 : null,
+    });
+    setMode('dns');
+    setFooter({
+        next: "I've added the records",
+        cancelRegistration: !isSuspended,  // SUSPENDED uses Revoke from Live view instead
+    });
 }
 
-function renderActive(doc) {
-    el.activeOpenLink.href = `https://${doc.fqdn}`;
-    el.activeOpenLabel.textContent = `Open ${doc.fqdn}`;
+function renderVerifyMode(doc, { triggerImmediate = true } = {}) {
+    stopPoll();
 
-    const verifiedLine = doc.last_verified_at
-        ? `Verified ${timeAgo(doc.last_verified_at)}`
-        : 'Live';
-    el.activeMeta.textContent = verifiedLine;
+    setHeader({ title: doc.fqdn });
 
-    renderDnsRecords(el.activeDnsRecords, doc.dns_records || []);
+    // Reset status rows to pending state
+    setStatusRow(el.statusRowDns, 'pending', friendlyStatusDns(doc));
+    setStatusRow(el.statusRowSsl, 'pending', friendlyStatusSsl(doc));
 
+    setError(el.verifyError, '');
+
+    setStepper(3, { completed: new Set([1, 2]) });
+    setMode('verify');
+    setFooter({ back: true, verify: true, cancelRegistration: true });
+    setVerifyBtnBusy(false);
+
+    if (triggerImmediate) {
+        verifyAndPoll(doc.id, { immediate: true });
+    } else {
+        // Still show whatever the doc already says, plus start the poll.
+        applyVerifyDocState(doc);
+        verifyAndPoll(doc.id, { immediate: false });
+    }
+}
+
+function renderLiveMode(doc) {
+    stopPoll();
+
+    el.liveHeroFqdn.textContent = doc.fqdn;
+    el.liveOpenIconLink.href = `https://${doc.fqdn}`;
+    // Shorten CTA: deep-link to dashboard/links with the domain pre-selected.
+    // Even though links.html doesn't yet honour ?domain= as a default, the
+    // param is harmless; PR4.5 Part B will wire it.
+    el.liveShortenCta.href = `/dashboard/links?domain=${encodeURIComponent(doc.fqdn)}`;
+
+    setStepper(4, { completed: new Set([1, 2, 3]) });
+    setMode('live');
     setFooter({ revoke: true });
 
-    showSlot('active');
+    // Confetti on the *first* time the user lands on Live for this domain.
+    fireConfettiIfFirstLive(doc.id);
 }
 
-function renderRevoked(doc) {
-    setFooter({});
-    showSlot('revoked');
+function renderRevokedMode(doc) {
+    stopPoll();
+
+    el.revokedAt.textContent = doc.updated_at
+        ? `${formatAbsolute(doc.updated_at)} (${timeAgo(doc.updated_at)})`
+        : '—';
+    el.revokedCreated.textContent = doc.created_at
+        ? `${formatAbsolute(doc.created_at)} (${timeAgo(doc.created_at)})`
+        : '—';
+
+    setStepper(4);  // No active step; show as "registration history" only.
+    setMode('revoked');
+    setFooter({ remove: true });
 }
 
-function renderDnsRecords(container, records) {
+function applyVerifyDocState(doc) {
+    const status = String(doc.status || '').toUpperCase();
+    if (status === 'ACTIVE') {
+        setStatusRow(el.statusRowDns, 'success', 'Domain reachable');
+        setStatusRow(el.statusRowSsl, 'success', 'Certificate issued');
+    } else if (doc.last_verification_error) {
+        // Failure shown on whichever row the error implies; default to DNS.
+        const raw = doc.last_verification_error;
+        const friendly = humaniseVerifyError(raw, doc.fqdn);
+        if (/cert|ssl/i.test(raw)) {
+            setStatusRow(el.statusRowDns, 'success', 'Domain reachable');
+            setStatusRow(el.statusRowSsl, 'fail', friendly);
+        } else {
+            setStatusRow(el.statusRowDns, 'fail', friendly);
+            setStatusRow(el.statusRowSsl, 'pending', 'Waiting for domain check');
+        }
+    } else {
+        setStatusRow(el.statusRowDns, 'pending', friendlyStatusDns(doc));
+        setStatusRow(el.statusRowSsl, 'pending', friendlyStatusSsl(doc));
+    }
+}
+
+// Verifier + CF errors are terse / jargon-heavy. Map known codes to copy
+// that tells the user what's wrong and what to do. Unknown codes pass
+// through with the fqdn prefix stripped so they at least read cleaner.
+function humaniseVerifyError(raw, fqdn) {
+    if (!raw) return '';
+    let s = String(raw).trim();
+    // Strip "<fqdn>: " prefix our verifiers emit.
+    if (fqdn) {
+        const prefix = `${fqdn}:`;
+        if (s.toLowerCase().startsWith(prefix.toLowerCase())) {
+            s = s.slice(prefix.length).trim();
+        }
+    }
+    const code = s.toLowerCase();
+
+    if (code === 'nxdomain' || code.includes('nxdomain')) {
+        return "We can't find DNS records for this domain yet. Make sure the CNAME you added has propagated at your DNS provider (this can take a few minutes).";
+    }
+    if (code.includes('timeout') || code.includes('timed out')) {
+        return 'DNS lookup timed out. Your DNS provider is slow or unreachable — usually clears up within a minute.';
+    }
+    if (code.includes('servfail')) {
+        return 'Your DNS provider returned a server error. Check that the records are saved correctly.';
+    }
+    if (code.includes('mismatch') || code.includes('does not match') || code.includes('expected')) {
+        return "The DNS record value doesn't match what we expect. Double-check the value at your DNS provider matches exactly.";
+    }
+    if (code.includes('no answer') || code.includes('noanswer')) {
+        return "We didn't get a DNS answer for this record. Confirm it's published and not behind a proxy (Cloudflare DNS-only / grey cloud).";
+    }
+    if (code.includes('proxied') || code.includes('orange cloud')) {
+        return "This domain is proxied through Cloudflare (orange cloud). Set the record to DNS only (grey cloud) so we can verify it.";
+    }
+    if (code.includes('ssl') || code.includes('certificate')) {
+        return "Certificate hasn't been issued yet. We'll keep checking — this usually completes within a minute or two of the DNS records resolving.";
+    }
+    if (code.includes('hostname not registered') || code.includes('not found')) {
+        return 'This hostname is no longer registered on our edge. Try removing and re-registering the domain.';
+    }
+    // Unknown code — show the cleaned form so we have a starting point for
+    // adding a friendly mapping later.
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// ── DNS records rendering ─────────────────────────────────────────────────
+
+function renderDnsRecords(container, records, { withCopy = true } = {}) {
     container.innerHTML = '';
     if (!records.length) return;
     records.forEach(rec => {
         const node = el.dnsTpl.content.firstElementChild.cloneNode(true);
-        node.querySelector('.rec-type').textContent = rec.type;
+        node.dataset.type = rec.type;
+        node.querySelector('.rec-type-text').textContent = rec.type;
         node.querySelector('.rec-name').textContent = rec.name;
         node.querySelector('.rec-value').textContent = rec.value;
-        const copyBtn = node.querySelector('.rec-copy');
-        copyBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            copyToClipboard(rec.value, copyBtn);
+
+        node.querySelectorAll('.rec-copy-btn').forEach(btn => {
+            if (!withCopy) {
+                btn.style.display = 'none';
+                return;
+            }
+            const field = btn.dataset.field;  // "name" | "value"
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const text = field === 'name' ? rec.name : rec.value;
+                copyToClipboard(text, btn, field);
+            });
         });
+
         container.appendChild(node);
     });
 }
 
-async function copyToClipboard(text, btn) {
+async function copyToClipboard(text, btn, fieldName) {
     try {
         await navigator.clipboard.writeText(text);
         const icon = btn.querySelector('i');
         const original = icon.className;
         icon.className = 'ti ti-check';
         btn.classList.add('copied');
+        // Show what was actually copied so users don't mis-paste Name into a
+        // Value field at their DNS provider.
+        const label = fieldName === 'name' ? 'name' : 'value';
+        showNotification(`Copied DNS ${label} to clipboard`, 'success');
         setTimeout(() => {
             icon.className = original;
             btn.classList.remove('copied');
         }, 1200);
     } catch (_) {
-        showNotification('Copy failed - Select and copy manually.', 'error');
+        showNotification('Copy failed — select and copy manually.', 'error');
     }
 }
 
-// ── Add submit ────────────────────────────────────────────────────────────
+// ── Add (Step 1) submit ───────────────────────────────────────────────────
 
 async function submitAdd() {
     const fqdn = (el.addInput.value || '').trim();
@@ -355,7 +636,7 @@ async function submitAdd() {
         return;
     }
     setError(el.addError, '');
-    el.modalSubmit.disabled = true;
+    el.btnSubmit.disabled = true;
     try {
         const res = await authFetch('/api/v1/custom-domains', {
             method: 'POST',
@@ -364,128 +645,298 @@ async function submitAdd() {
         });
         const body = await res.json().catch(() => ({}));
         if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
-        showNotification(`${body.fqdn} added - Add the DNS record, then verify.`, 'success');
-        // Refresh list in background; morph current modal to setup mode.
-        fetchDomains();
+        showNotification(`${body.fqdn} added — add the DNS records next.`, 'success');
+        fetchDomains();  // background refresh
         currentDomain = body;
         syncUrl({ domain: body.id });
         renderForStatus(body);
     } catch (err) {
         setError(el.addError, err.message);
     } finally {
-        el.modalSubmit.disabled = false;
+        el.btnSubmit.disabled = false;
     }
+}
+
+// ── Step navigation: DNS → Verify, Verify → DNS ───────────────────────────
+
+function stepForwardFromDns() {
+    if (!currentDomain) return;
+    renderVerifyMode(currentDomain, { triggerImmediate: true });
+}
+
+function stepBackFromVerify() {
+    if (!currentDomain) return;
+    stopPoll();
+    renderDnsMode(currentDomain);
 }
 
 // ── Verify + auto-poll ────────────────────────────────────────────────────
+//
+// Loop is silent: every POLL_INTERVAL_MS we hit GET in the background; the
+// status panel updates if state changes, otherwise no UI noise. User can
+// hit "Check now" (footer btn) any time to short-circuit the wait — that
+// fires a POST verify (re-triggers CF probe on the backend) and resets the
+// schedule. Button spinner is the only visible indicator while a check is
+// in flight; idle state is the resting "Check now" label.
 
-async function clickVerify() {
-    if (!currentDomain) return;
-    setError(el.setupError, '');
-    el.setupPoll.style.display = 'none';
-    setVerifyBusy(true);
-    try {
-        const res = await authFetch(
-            `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}/verify`,
-            {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-                body: JSON.stringify({}),
-            }
-        );
-        const body = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
-
-        currentDomain = body;
-        const status = String(body.status || '').toUpperCase();
-        if (status === 'ACTIVE') {
-            showNotification('Domain verified — it\'s now live.', 'success');
-            renderForStatus(body);
-            fetchDomains();
-            return;
-        }
-        if (body.last_verification_error) {
-            setError(el.setupError, body.last_verification_error);
-            setVerifyBusy(false);
-            return;
-        }
-        // Still PENDING with no explicit error — CF may still be validating.
-        el.setupPoll.style.display = 'block';
-        startPoll(currentDomain.id);
-    } catch (err) {
-        setError(el.setupError, err.message);
-        setVerifyBusy(false);
+async function verifyAndPoll(id, { immediate = true } = {}) {
+    pollDomainId = id;
+    setError(el.verifyError, '');
+    if (immediate) {
+        await pollTick({ method: 'POST' });
+    } else {
+        scheduleNextPoll();
     }
 }
 
-function startPoll(id) {
+function scheduleNextPoll() {
     stopPoll();
-    pollDeadline = Date.now() + POLL_MAX_DURATION_MS;
-    pollTimer = setInterval(async () => {
-        if (Date.now() > pollDeadline) {
+    if (!pollDomainId) return;
+    pollTimer = setTimeout(() => pollTick({ method: 'GET' }), POLL_INTERVAL_MS);
+}
+
+async function pollTick({ method }) {
+    if (!pollDomainId) return;
+    setVerifyBtnBusy(true);
+    try {
+        const url = method === 'POST'
+            ? `/api/v1/custom-domains/${encodeURIComponent(pollDomainId)}/verify`
+            : `/api/v1/custom-domains/${encodeURIComponent(pollDomainId)}`;
+        const init = method === 'POST'
+            ? {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                body: JSON.stringify({}),
+              }
+            : { headers: { 'Accept': 'application/json' } };
+
+        const res = await authFetch(url, init);
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
+
+        // Modal may have been closed / changed while we were in flight.
+        if (!currentDomain || currentDomain.id !== body.id || currentMode !== 'verify') {
             stopPoll();
-            setVerifyBusy(false);
-            el.setupPoll.style.display = 'none';
-            setError(el.setupError,
-                'Still waiting on DNS. Try again in a few minutes.');
             return;
         }
-        try {
-            const res = await authFetch(
-                `/api/v1/custom-domains/${encodeURIComponent(id)}`,
-                { headers: { 'Accept': 'application/json' } }
-            );
-            if (!res.ok) return;
-            const doc = await res.json();
-            if (!currentDomain || currentDomain.id !== doc.id) {
-                stopPoll();
-                return;
-            }
-            currentDomain = doc;
-            const status = String(doc.status || '').toUpperCase();
-            if (status === 'ACTIVE') {
-                stopPoll();
-                showNotification("Domain verified - It's now live.", 'success');
-                renderForStatus(doc);
-                fetchDomains();
-            }
-        } catch (_) {
-            // Network blip — keep polling; next tick will retry.
+
+        currentDomain = body;
+        applyVerifyDocState(body);
+
+        const status = String(body.status || '').toUpperCase();
+        if (status === 'ACTIVE') {
+            stopPoll();
+            showNotification("Domain verified — it's now live.", 'success');
+            renderLiveMode(body);
+            fetchDomains();
+            return;
         }
-    }, POLL_INTERVAL_MS);
+
+        // Domain-side failures (NXDOMAIN, etc.) live on the status row only.
+        setError(el.verifyError, '');
+    } catch (err) {
+        setError(el.verifyError, `Couldn't reach the server: ${err.message}`);
+    } finally {
+        setVerifyBtnBusy(false);
+        if (currentMode === 'verify' && currentDomain && currentDomain.id === pollDomainId) {
+            scheduleNextPoll();
+        }
+    }
 }
 
 function stopPoll() {
     if (pollTimer) {
-        clearInterval(pollTimer);
+        clearTimeout(pollTimer);
         pollTimer = null;
     }
 }
 
-function setVerifyBusy(busy) {
-    el.setupVerify.disabled = busy;
-    el.setupVerify.querySelector('.btn-label').textContent =
-        busy ? 'Verifying…' : 'Verify';
-    el.setupVerify.querySelector('.btn-spinner').style.display =
-        busy ? '' : 'none';
+function setVerifyBtnBusy(busy) {
+    if (!el.btnVerifyFooter) return;
+    el.btnVerifyFooter.disabled = busy;
+    const icon = el.btnVerifyFooter.querySelector('.btn-verify-icon');
+    const label = el.btnVerifyFooter.querySelector('.btn-label');
+    if (icon) icon.classList.toggle('spinning', busy);
+    if (label) label.textContent = busy ? 'Checking…' : 'Check now';
 }
 
-function resetVerifyButton() {
-    setVerifyBusy(false);
+// ── Status panel helpers ──────────────────────────────────────────────────
+
+function setStatusRow(row, state /* 'pending'|'success'|'fail' */, message) {
+    row.dataset.state = state;
+    const msgNode = row.querySelector('.status-message');
+    if (msgNode) msgNode.textContent = message;
 }
 
-// ── Revoke sub-modal ──────────────────────────────────────────────────────
+// CF state → friendly copy. Centralised so we can extend as we observe new
+// CF statuses in the wild.
+function friendlyStatusDns(doc) {
+    const s = (doc.cf_status || '').toLowerCase();
+    if (s === 'active') return 'Domain reachable';
+    if (s === 'pending') return 'Waiting for DNS to propagate';
+    if (s === 'pending_deployment') return 'Deploying to edge';
+    if (s === 'moved') return 'Domain reachable';
+    if (s === 'deleted') return 'Domain no longer registered with Cloudflare';
+    return 'Checking DNS propagation';
+}
+
+function friendlyStatusSsl(doc) {
+    const s = (doc.cf_ssl_status || '').toLowerCase();
+    if (s === 'active') return 'Certificate issued';
+    if (s === 'pending_validation') return 'Waiting for certificate issuance';
+    if (s === 'pending_issuance') return 'Issuing certificate';
+    if (s === 'pending_deployment') return 'Deploying certificate to edge';
+    if (s === 'pending_deletion') return 'Removing certificate';
+    if (s === 'deleted') return 'Certificate revoked';
+    return 'Waiting for certificate';
+}
+
+function humaniseCfStatus(s) {
+    if (!s) return '';
+    return friendlyStatusDns({ cf_status: s });
+}
+
+function humaniseCfSslStatus(s) {
+    if (!s) return '';
+    return friendlyStatusSsl({ cf_ssl_status: s });
+}
+
+// ── Confetti (canvas-based one-shot burst) ────────────────────────────────
+
+let confettiAnimating = false;
+
+function fireConfettiIfFirstLive(domainId) {
+    const key = FIRST_LIVE_FLAG_KEY + domainId;
+    if (localStorage.getItem(key)) return;
+    try { localStorage.setItem(key, '1'); } catch (_) { /* private mode → still fire once */ }
+    fireConfetti();
+}
+
+function fireConfetti() {
+    const canvas = el.confettiCanvas;
+    if (!canvas || confettiAnimating) return;
+
+    const ctx = canvas.getContext('2d');
+    const dpr = window.devicePixelRatio || 1;
+    const rect = el.modalContent.getBoundingClientRect();
+    canvas.style.left = `${rect.left}px`;
+    canvas.style.top = `${rect.top}px`;
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.scale(dpr, dpr);
+
+    const w = rect.width;
+    const h = rect.height;
+    const colors = ['#a855f7', '#22d3ee', '#34d399', '#fbbf24', '#f472b6', '#60a5fa'];
+    const particles = Array.from({ length: 120 }, () => ({
+        x: w / 2,
+        y: h * 0.35,
+        vx: (Math.random() - 0.5) * 8,
+        vy: (Math.random() - 1) * 8 - 2,
+        size: Math.random() * 6 + 4,
+        rot: Math.random() * Math.PI,
+        vRot: (Math.random() - 0.5) * 0.3,
+        color: colors[Math.floor(Math.random() * colors.length)],
+        life: 1,
+    }));
+
+    confettiAnimating = true;
+    canvas.style.display = 'block';
+
+    let frame = 0;
+    const maxFrames = 140;
+    function tick() {
+        ctx.clearRect(0, 0, w, h);
+        particles.forEach(p => {
+            p.vy += 0.18;             // gravity
+            p.vx *= 0.995;            // air drag
+            p.x += p.vx;
+            p.y += p.vy;
+            p.rot += p.vRot;
+            p.life -= 1 / maxFrames;
+            ctx.save();
+            ctx.globalAlpha = Math.max(0, p.life);
+            ctx.translate(p.x, p.y);
+            ctx.rotate(p.rot);
+            ctx.fillStyle = p.color;
+            ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.4);
+            ctx.restore();
+        });
+        frame++;
+        if (frame < maxFrames) {
+            requestAnimationFrame(tick);
+        } else {
+            ctx.clearRect(0, 0, w, h);
+            canvas.style.display = 'none';
+            confettiAnimating = false;
+        }
+    }
+    requestAnimationFrame(tick);
+}
+
+function clearConfetti() {
+    if (!el.confettiCanvas) return;
+    const ctx = el.confettiCanvas.getContext('2d');
+    if (ctx) ctx.clearRect(0, 0, el.confettiCanvas.width, el.confettiCanvas.height);
+    el.confettiCanvas.style.display = 'none';
+    confettiAnimating = false;
+}
+
+// ── Cancel-registration (PENDING / VERIFYING docs) ────────────────────────
+// Tiny confirm flow: the doc has no URLs yet, so we don't need the cards-as-
+// target sub-modal. Native confirm() keeps the cancel path one click away.
+
+async function cancelRegistration() {
+    if (!currentDomain) return;
+    const fqdn = currentDomain.fqdn;
+    if (!window.confirm(
+        `Cancel registration of ${fqdn}?\n\n` +
+        `The domain will be revoked. You can re-add it later.`
+    )) return;
+
+    el.btnCancelRegistration.disabled = true;
+    stopPoll();
+    try {
+        const url = `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}?cascade=false`;
+        const res = await authFetch(url, { method: 'DELETE' });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
+        showNotification(`${fqdn} registration cancelled`, 'success');
+        closeModal();
+        fetchDomains();
+    } catch (err) {
+        showNotification(`Couldn't cancel: ${err.message}`, 'error');
+    } finally {
+        el.btnCancelRegistration.disabled = false;
+    }
+}
+
+// ── Revoke sub-modal (cards + type-to-confirm) ────────────────────────────
 
 async function openRevokeModal() {
     if (!currentDomain) return;
+
+    revokeSelectedCascade = false;
+    el.revokeCards.forEach(c => {
+        const isOrphan = c.dataset.cascade === 'false';
+        c.setAttribute('aria-pressed', isOrphan ? 'true' : 'false');
+        c.classList.toggle('is-selected', isOrphan);
+    });
+
+    el.revokeTitle.textContent = `Revoke ${currentDomain.fqdn}?`;
     el.revokeFqdn.textContent = currentDomain.fqdn;
     el.revokeUrlCount.textContent = '…';
+    el.revokeInput.value = '';
+    el.revokeInput.placeholder = currentDomain.fqdn;
     setError(el.revokeError, '');
-    const orphan = el.revokeModal.querySelector('input[name="cascade"][value="false"]');
-    if (orphan) orphan.checked = true;
+    syncRevokeConfirmState();
 
     el.revokeModal.classList.add('active');
     el.revokeModal.setAttribute('aria-hidden', 'false');
+
+    setTimeout(() => el.revokeInput.focus(), 0);
 
     try {
         const res = await authFetch(
@@ -494,13 +945,17 @@ async function openRevokeModal() {
         );
         if (res.ok) {
             const body = await res.json();
-            el.revokeUrlCount.textContent = String(body.total || 0);
+            revokeUrlCount = body.total || 0;
+            el.revokeUrlCount.textContent = String(revokeUrlCount);
         } else {
+            revokeUrlCount = 0;
             el.revokeUrlCount.textContent = '?';
         }
     } catch (_) {
+        revokeUrlCount = 0;
         el.revokeUrlCount.textContent = '?';
     }
+    syncRevokeConfirmState();  // update button label after count loads
 }
 
 function closeRevokeModal() {
@@ -508,14 +963,42 @@ function closeRevokeModal() {
     el.revokeModal.setAttribute('aria-hidden', 'true');
 }
 
+function pickCascadeCard(card) {
+    revokeSelectedCascade = card.dataset.cascade === 'true';
+    el.revokeCards.forEach(c => {
+        const isThis = c === card;
+        c.setAttribute('aria-pressed', isThis ? 'true' : 'false');
+        c.classList.toggle('is-selected', isThis);
+    });
+    syncRevokeConfirmState();
+}
+
+function syncRevokeConfirmState() {
+    const typed = el.revokeInput.value.trim();
+    const fqdnMatches = currentDomain && typed === currentDomain.fqdn;
+    el.revokeConfirm.disabled = !fqdnMatches;
+
+    // Dynamic button copy.
+    if (revokeSelectedCascade) {
+        el.revokeConfirmLabel.textContent =
+            revokeUrlCount > 0
+                ? `Revoke and delete ${revokeUrlCount} URL${revokeUrlCount === 1 ? '' : 's'}`
+                : 'Revoke and delete URLs';
+        el.revokeConfirm.classList.add('btn-destructive-strong');
+    } else {
+        el.revokeConfirmLabel.textContent = 'Revoke domain';
+        el.revokeConfirm.classList.remove('btn-destructive-strong');
+    }
+}
+
 async function confirmRevoke() {
     if (!currentDomain) return;
-    const selected = el.revokeModal.querySelector('input[name="cascade"]:checked');
-    const cascade = selected && selected.value === 'true';
+    if (el.revokeInput.value.trim() !== currentDomain.fqdn) return;
 
     setError(el.revokeError, '');
     el.revokeConfirm.disabled = true;
     try {
+        const cascade = revokeSelectedCascade;
         const url = `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}?cascade=${cascade}`;
         const res = await authFetch(url, { method: 'DELETE' });
         const body = await res.json().catch(() => ({}));
@@ -529,8 +1012,59 @@ async function confirmRevoke() {
         fetchDomains();
     } catch (err) {
         setError(el.revokeError, err.message);
-    } finally {
-        el.revokeConfirm.disabled = false;
+        syncRevokeConfirmState();
+    }
+}
+
+// ── Remove sub-modal (REVOKED → hard delete) ──────────────────────────────
+
+function openRemoveModal() {
+    if (!currentDomain) return;
+    el.removeFqdn.textContent = currentDomain.fqdn;
+    el.removeInput.value = '';
+    el.removeInput.placeholder = currentDomain.fqdn;
+    el.removeConfirm.disabled = true;
+    setError(el.removeError, '');
+
+    el.removeModal.classList.add('active');
+    el.removeModal.setAttribute('aria-hidden', 'false');
+
+    setTimeout(() => el.removeInput.focus(), 0);
+}
+
+function closeRemoveModal() {
+    el.removeModal.classList.remove('active');
+    el.removeModal.setAttribute('aria-hidden', 'true');
+}
+
+function syncRemoveConfirmState() {
+    if (!currentDomain) {
+        el.removeConfirm.disabled = true;
+        return;
+    }
+    el.removeConfirm.disabled = el.removeInput.value.trim() !== currentDomain.fqdn;
+}
+
+async function confirmRemove() {
+    if (!currentDomain) return;
+    if (el.removeInput.value.trim() !== currentDomain.fqdn) return;
+
+    setError(el.removeError, '');
+    el.removeConfirm.disabled = true;
+    try {
+        const url = `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}/permanent`;
+        const res = await authFetch(url, { method: 'DELETE' });
+        if (res.status !== 204) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body.error || `Request failed (${res.status})`);
+        }
+        showNotification(`${currentDomain.fqdn} removed`, 'success');
+        closeRemoveModal();
+        closeModal();
+        fetchDomains();
+    } catch (err) {
+        setError(el.removeError, err.message);
+        syncRemoveConfirmState();
     }
 }
 
@@ -539,7 +1073,6 @@ async function confirmRevoke() {
 document.addEventListener('DOMContentLoaded', () => {
     fetchDomains();
 
-    // Initial URL inspection — open the right modal if QS specifies one.
     const params = new URLSearchParams(window.location.search);
     if (params.get('new')) {
         openAddModal({ push: false });
@@ -550,21 +1083,58 @@ document.addEventListener('DOMContentLoaded', () => {
     el.newBtn.addEventListener('click', () => openAddModal());
 
     el.modalClose.addEventListener('click', () => closeModal());
-    el.modalCancel.addEventListener('click', () => closeModal());
+    el.btnCancel.addEventListener('click', () => closeModal());
     el.modal.addEventListener('click', (e) => {
         if (e.target === el.modal || e.target.classList.contains('modal-overlay')) {
             closeModal();
         }
     });
 
-    el.modalSubmit.addEventListener('click', submitAdd);
+    el.btnSubmit.addEventListener('click', submitAdd);
     el.addInput.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') submitAdd();
     });
 
-    el.setupVerify.addEventListener('click', clickVerify);
+    el.btnStepNext.addEventListener('click', () => {
+        if (currentMode === 'dns') stepForwardFromDns();
+    });
+    el.btnStepBack.addEventListener('click', () => {
+        if (currentMode === 'verify') stepBackFromVerify();
+    });
 
-    el.modalRevoke.addEventListener('click', openRevokeModal);
+    el.btnVerifyFooter.addEventListener('click', () => {
+        if (!pollDomainId || el.btnVerifyFooter.disabled) return;
+        stopPoll();
+        pollTick({ method: 'POST' });
+    });
+
+    el.btnCancelRegistration.addEventListener('click', cancelRegistration);
+
+    // Stepper navigation
+    el.stepperItems.forEach(item => {
+        item.addEventListener('click', () => {
+            const n = parseInt(item.dataset.step, 10);
+            attemptJumpToStep(n);
+        });
+    });
+
+    // Live mode revoke action (footer)
+    el.btnRevokeFooter.addEventListener('click', openRevokeModal);
+
+    // Revoke sub-modal
+    el.revokeCards.forEach(card => {
+        card.addEventListener('click', () => pickCascadeCard(card));
+        card.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                pickCascadeCard(card);
+            }
+        });
+    });
+    el.revokeInput.addEventListener('input', syncRevokeConfirmState);
+    el.revokeInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !el.revokeConfirm.disabled) confirmRevoke();
+    });
     el.revokeCancel.addEventListener('click', closeRevokeModal);
     el.revokeConfirm.addEventListener('click', confirmRevoke);
     el.revokeModal.addEventListener('click', (e) => {
@@ -576,9 +1146,28 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // Remove sub-modal (REVOKED)
+    el.btnRemove.addEventListener('click', openRemoveModal);
+    el.removeCancel.addEventListener('click', closeRemoveModal);
+    el.removeConfirm.addEventListener('click', confirmRemove);
+    el.removeInput.addEventListener('input', syncRemoveConfirmState);
+    el.removeInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !el.removeConfirm.disabled) confirmRemove();
+    });
+    el.removeModal.addEventListener('click', (e) => {
+        if (
+            e.target.classList.contains('modal-container') ||
+            e.target.classList.contains('modal-backdrop')
+        ) {
+            closeRemoveModal();
+        }
+    });
+
     document.addEventListener('keydown', (e) => {
         if (e.key !== 'Escape') return;
-        if (el.revokeModal.classList.contains('active')) {
+        if (el.removeModal.classList.contains('active')) {
+            closeRemoveModal();
+        } else if (el.revokeModal.classList.contains('active')) {
             closeRevokeModal();
         } else if (el.modal.style.display === 'flex') {
             closeModal();
@@ -586,14 +1175,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     window.addEventListener('popstate', () => {
-        // Browser back/forward — sync modal to new URL.
         const p = new URLSearchParams(window.location.search);
         if (p.get('new')) {
             openAddModal({ push: false });
         } else if (p.get('domain')) {
             openDomainModal(p.get('domain'), { push: false });
         } else {
-            // Closed
             stopPoll();
             el.modal.style.display = 'none';
             el.modal.setAttribute('aria-hidden', 'true');

--- a/static/js/dashboard/domains.js
+++ b/static/js/dashboard/domains.js
@@ -258,6 +258,12 @@ function setStepper(activeStep, { completed = new Set(), failed = null } = {}) {
         else if (completed.has(n)) statusNode.textContent = 'Completed';
         else if (n === activeStep) statusNode.textContent = 'In progress';
         else statusNode.textContent = 'Pending';
+
+        // Keyboard focusability mirrors interactivity (completed or active
+        // steps are reachable; pending/failed are not).
+        const interactive = completed.has(n) || n === activeStep;
+        item.tabIndex = interactive ? 0 : -1;
+        item.setAttribute('aria-disabled', interactive ? 'false' : 'true');
     });
 }
 
@@ -710,9 +716,18 @@ async function pollTick({ method }) {
               }
             : { headers: { 'Accept': 'application/json' } };
 
-        const res = await authFetch(url, init);
+        let res;
+        try {
+            res = await authFetch(url, init);
+        } catch (netErr) {
+            setError(el.verifyError, `Couldn't reach the server: ${netErr.message}`);
+            return;
+        }
         const body = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
+        if (!res.ok) {
+            setError(el.verifyError, body.error || `Server returned ${res.status}.`);
+            return;
+        }
 
         // Modal may have been closed / changed while we were in flight.
         if (!currentDomain || currentDomain.id !== body.id || currentMode !== 'verify') {
@@ -734,8 +749,6 @@ async function pollTick({ method }) {
 
         // Domain-side failures (NXDOMAIN, etc.) live on the status row only.
         setError(el.verifyError, '');
-    } catch (err) {
-        setError(el.verifyError, `Couldn't reach the server: ${err.message}`);
     } finally {
         setVerifyBtnBusy(false);
         if (currentMode === 'verify' && currentDomain && currentDomain.id === pollDomainId) {
@@ -891,18 +904,28 @@ function clearConfetti() {
 async function cancelRegistration() {
     if (!currentDomain) return;
     const fqdn = currentDomain.fqdn;
+    const id = currentDomain.id;
     if (!window.confirm(
         `Cancel registration of ${fqdn}?\n\n` +
-        `The domain will be revoked. You can re-add it later.`
+        `The domain will be removed from your account. You can re-add it later.`
     )) return;
 
     el.btnCancelRegistration.disabled = true;
     stopPoll();
     try {
-        const url = `/api/v1/custom-domains/${encodeURIComponent(currentDomain.id)}?cascade=false`;
-        const res = await authFetch(url, { method: 'DELETE' });
-        const body = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(body.error || `Request failed (${res.status})`);
+        // Revoke then hard-delete so the slot frees immediately.
+        const revokeUrl = `/api/v1/custom-domains/${encodeURIComponent(id)}?cascade=false`;
+        const revokeRes = await authFetch(revokeUrl, { method: 'DELETE' });
+        if (!revokeRes.ok) {
+            const body = await revokeRes.json().catch(() => ({}));
+            throw new Error(body.error || `Revoke failed (${revokeRes.status})`);
+        }
+        const removeUrl = `/api/v1/custom-domains/${encodeURIComponent(id)}/permanent`;
+        const removeRes = await authFetch(removeUrl, { method: 'DELETE' });
+        if (removeRes.status !== 204) {
+            const body = await removeRes.json().catch(() => ({}));
+            throw new Error(body.error || `Remove failed (${removeRes.status})`);
+        }
         showNotification(`${fqdn} registration cancelled`, 'success');
         closeModal();
         fetchDomains();
@@ -921,7 +944,8 @@ async function openRevokeModal() {
     revokeSelectedCascade = false;
     el.revokeCards.forEach(c => {
         const isOrphan = c.dataset.cascade === 'false';
-        c.setAttribute('aria-pressed', isOrphan ? 'true' : 'false');
+        c.setAttribute('aria-checked', isOrphan ? 'true' : 'false');
+        c.tabIndex = isOrphan ? 0 : -1;
         c.classList.toggle('is-selected', isOrphan);
     });
 
@@ -967,9 +991,11 @@ function pickCascadeCard(card) {
     revokeSelectedCascade = card.dataset.cascade === 'true';
     el.revokeCards.forEach(c => {
         const isThis = c === card;
-        c.setAttribute('aria-pressed', isThis ? 'true' : 'false');
+        c.setAttribute('aria-checked', isThis ? 'true' : 'false');
+        c.tabIndex = isThis ? 0 : -1;
         c.classList.toggle('is-selected', isThis);
     });
+    card.focus();
     syncRevokeConfirmState();
 }
 
@@ -1110,11 +1136,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     el.btnCancelRegistration.addEventListener('click', cancelRegistration);
 
-    // Stepper navigation
+    // Stepper navigation (mouse + keyboard)
     el.stepperItems.forEach(item => {
-        item.addEventListener('click', () => {
+        const fire = () => {
             const n = parseInt(item.dataset.step, 10);
             attemptJumpToStep(n);
+        };
+        item.addEventListener('click', fire);
+        item.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                fire();
+            }
         });
     });
 
@@ -1122,12 +1155,22 @@ document.addEventListener('DOMContentLoaded', () => {
     el.btnRevokeFooter.addEventListener('click', openRevokeModal);
 
     // Revoke sub-modal
-    el.revokeCards.forEach(card => {
+    el.revokeCards.forEach((card, idx) => {
         card.addEventListener('click', () => pickCascadeCard(card));
         card.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 pickCascadeCard(card);
+            } else if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                const next = el.revokeCards[(idx + 1) % el.revokeCards.length];
+                pickCascadeCard(next);
+            } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                e.preventDefault();
+                const prev = el.revokeCards[
+                    (idx - 1 + el.revokeCards.length) % el.revokeCards.length
+                ];
+                pickCascadeCard(prev);
             }
         });
     });

--- a/templates/dashboard/domains.html
+++ b/templates/dashboard/domains.html
@@ -81,7 +81,7 @@
             <!-- Stepper rail — visibility controlled per-mode via [data-show-stepper] on .modal-content -->
             <aside class="stepper-rail" id="stepper-rail" aria-label="Setup progress">
                 <ol class="stepper" id="stepper">
-                    <li class="stepper-item" data-step="1">
+                    <li class="stepper-item" data-step="1" role="button" tabindex="-1" aria-label="Step 1: Domain">
                         <div class="stepper-rail-line"></div>
                         <div class="stepper-dot">
                             <span class="stepper-num">1</span>
@@ -93,7 +93,7 @@
                             <div class="stepper-status"></div>
                         </div>
                     </li>
-                    <li class="stepper-item" data-step="2">
+                    <li class="stepper-item" data-step="2" role="button" tabindex="-1" aria-label="Step 2: DNS records">
                         <div class="stepper-rail-line"></div>
                         <div class="stepper-dot">
                             <span class="stepper-num">2</span>
@@ -105,7 +105,7 @@
                             <div class="stepper-status"></div>
                         </div>
                     </li>
-                    <li class="stepper-item" data-step="3">
+                    <li class="stepper-item" data-step="3" role="button" tabindex="-1" aria-label="Step 3: Verification">
                         <div class="stepper-rail-line"></div>
                         <div class="stepper-dot">
                             <span class="stepper-num">3</span>
@@ -117,7 +117,7 @@
                             <div class="stepper-status"></div>
                         </div>
                     </li>
-                    <li class="stepper-item" data-step="4">
+                    <li class="stepper-item" data-step="4" role="button" tabindex="-1" aria-label="Step 4: Live">
                         <div class="stepper-rail-line"></div>
                         <div class="stepper-dot">
                             <span class="stepper-num">4</span>
@@ -356,7 +356,7 @@
                     Pick what should happen to them.
                 </p>
                 <div class="cascade-choice" role="radiogroup" aria-label="URL handling">
-                    <button type="button" class="cascade-card" data-cascade="false" aria-pressed="true">
+                    <div class="cascade-card" data-cascade="false" role="radio" aria-checked="true" tabindex="0">
                         <i class="ti ti-archive cascade-icon"></i>
                         <div class="cascade-text">
                             <span class="cascade-card-title">Keep URLs (orphan)</span>
@@ -365,8 +365,8 @@
                                 the same domain later, they resume.
                             </span>
                         </div>
-                    </button>
-                    <button type="button" class="cascade-card cascade-card-destructive" data-cascade="true" aria-pressed="false">
+                    </div>
+                    <div class="cascade-card cascade-card-destructive" data-cascade="true" role="radio" aria-checked="false" tabindex="-1">
                         <i class="ti ti-trash cascade-icon"></i>
                         <div class="cascade-text">
                             <span class="cascade-card-title">Delete URLs permanently</span>
@@ -374,7 +374,7 @@
                                 Every short link on this domain is permanently deleted - destinations, click stats, and short codes all gone. Cannot be undone.
                             </span>
                         </div>
-                    </button>
+                    </div>
                 </div>
 
                 <div class="field type-to-confirm-field">
@@ -478,7 +478,7 @@
             <span class="rec-cell-label">Host-Name</span>
             <div class="rec-cell-box">
                 <code class="rec-name"></code>
-                <button type="button" class="rec-copy-btn" data-field="name" title="Copy name">
+                <button type="button" class="rec-copy-btn" data-field="name" title="Copy host name" aria-label="Copy host name">
                     <i class="ti ti-copy"></i>
                 </button>
             </div>
@@ -487,7 +487,7 @@
             <span class="rec-cell-label">Value</span>
             <div class="rec-cell-box">
                 <code class="rec-value"></code>
-                <button type="button" class="rec-copy-btn" data-field="value" title="Copy value">
+                <button type="button" class="rec-copy-btn" data-field="value" title="Copy value" aria-label="Copy record value">
                     <i class="ti ti-copy"></i>
                 </button>
             </div>
@@ -498,5 +498,5 @@
 
 {% block scripts %}
 <script src="{{ url_for('static', path='js/verification-check.js') }}?v=1"></script>
-<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=18"></script>
+<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=19"></script>
 {% endblock %}

--- a/templates/dashboard/domains.html
+++ b/templates/dashboard/domains.html
@@ -4,7 +4,7 @@
 
 {% block head_css %}
 <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/keys.css') }}?v=7">
-<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=4">
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard/domains.css') }}?v=21">
 <meta name="robots" content="noindex">
 {% endblock %}
 
@@ -54,95 +54,287 @@
     </div>
 </div>
 
-<!-- One large modal, four content slots — JS swaps which slot is visible -->
-<div id="domainModal" class="modal modal-large" aria-hidden="true" style="display:none">
+<!--
+    Domain modal. Single shell, mode-driven width + stepper visibility.
+    Modes: add | dns | verify | live | revoked
+        add / revoked → narrow (no stepper)
+        dns / verify  → wide   (vertical stepper rail)
+        live          → medium (no stepper, management view)
+-->
+<div id="domainModal" class="modal domain-modal" aria-hidden="true" style="display:none">
     <div class="modal-overlay"></div>
     <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="domainModalTitle">
         <div class="modal-header">
             <div class="modal-header-left">
-                <h2 id="domainModalTitle">Add a domain</h2>
-                <span class="status-badge modal-status-badge" id="modalStatusBadge" style="display:none"></span>
+                <div class="modal-header-titlerow">
+                    <h2 id="domainModalTitle">Add a domain</h2>
+                    <span class="status-badge modal-status-badge" id="modalStatusBadge" style="display:none"></span>
+                </div>
+                <p id="domainModalSub" class="modal-header-sub" style="display:none"></p>
             </div>
             <button class="modal-close" id="btn-close-domain-modal" aria-label="Close">
                 <i class="ti ti-x"></i>
             </button>
         </div>
 
-        <div class="modal-body">
-            <!-- Add mode -->
-            <div class="modal-slot" data-mode="add">
-                <div class="form-grid">
-                    <div class="field">
-                        <label for="domain-fqdn">Your domain</label>
-                        <input id="domain-fqdn" type="text" placeholder="links.yoursite.com" autocomplete="off" />
-                        <small class="field-hint">
-                            Subdomains like <code>links.yoursite.com</code> work best.
-                            Root domains need DNS that supports CNAME flattening (Cloudflare, Route 53, DNSimple).
-                        </small>
+        <div class="modal-shell">
+            <!-- Stepper rail — visibility controlled per-mode via [data-show-stepper] on .modal-content -->
+            <aside class="stepper-rail" id="stepper-rail" aria-label="Setup progress">
+                <ol class="stepper" id="stepper">
+                    <li class="stepper-item" data-step="1">
+                        <div class="stepper-rail-line"></div>
+                        <div class="stepper-dot">
+                            <span class="stepper-num">1</span>
+                            <i class="ti ti-check stepper-check"></i>
+                        </div>
+                        <div class="stepper-meta">
+                            <div class="stepper-tag">Step 1</div>
+                            <div class="stepper-label">Domain</div>
+                            <div class="stepper-status"></div>
+                        </div>
+                    </li>
+                    <li class="stepper-item" data-step="2">
+                        <div class="stepper-rail-line"></div>
+                        <div class="stepper-dot">
+                            <span class="stepper-num">2</span>
+                            <i class="ti ti-check stepper-check"></i>
+                        </div>
+                        <div class="stepper-meta">
+                            <div class="stepper-tag">Step 2</div>
+                            <div class="stepper-label">DNS records</div>
+                            <div class="stepper-status"></div>
+                        </div>
+                    </li>
+                    <li class="stepper-item" data-step="3">
+                        <div class="stepper-rail-line"></div>
+                        <div class="stepper-dot">
+                            <span class="stepper-num">3</span>
+                            <i class="ti ti-check stepper-check"></i>
+                        </div>
+                        <div class="stepper-meta">
+                            <div class="stepper-tag">Step 3</div>
+                            <div class="stepper-label">Verification</div>
+                            <div class="stepper-status"></div>
+                        </div>
+                    </li>
+                    <li class="stepper-item" data-step="4">
+                        <div class="stepper-rail-line"></div>
+                        <div class="stepper-dot">
+                            <span class="stepper-num">4</span>
+                            <i class="ti ti-check stepper-check"></i>
+                        </div>
+                        <div class="stepper-meta">
+                            <div class="stepper-tag">Step 4</div>
+                            <div class="stepper-label">Live</div>
+                            <div class="stepper-status"></div>
+                        </div>
+                    </li>
+                </ol>
+            </aside>
+
+            <div class="modal-body">
+                <!-- ==================== Add slot (Step 1) ==================== -->
+                <div class="modal-slot" data-mode="add">
+                    <div class="form-grid">
+                        <div class="field">
+                            <label for="domain-fqdn">Your domain</label>
+                            <input id="domain-fqdn" type="text" placeholder="links.yoursite.com" autocomplete="off" />
+                            <small class="field-hint">
+                                Works with subdomains like <code>links.yoursite.com</code> or root
+                                domains like <code>yoursite.com</code>. You'll need access to your
+                                DNS provider to add a record in the next step.
+                            </small>
+                        </div>
+                        <div id="add-domain-error" class="inline-error" style="display:none"></div>
                     </div>
-                    <div id="add-domain-error" class="inline-error" style="display:none"></div>
-                </div>
-            </div>
-
-            <!-- Setup mode (PENDING / SUSPENDED) -->
-            <div class="modal-slot" data-mode="setup" style="display:none">
-                <div class="banner banner-pending" id="setup-banner">
-                    Add the DNS record(s) below at your DNS provider, then click Verify.
                 </div>
 
-                <h3 class="section-title">DNS record</h3>
-                <div class="dns-records" id="dns-records"></div>
-                <div class="setup-notes" id="setup-notes" style="display:none"></div>
+                <!-- ==================== DNS slot (Step 2) ==================== -->
+                <div class="modal-slot" data-mode="dns" style="display:none">
+                    <div class="slot-intro">
+                        <h3 class="slot-heading">Add the DNS records</h3>
+                        <p class="slot-sub" id="dns-sub">
+                            Publish the record(s) below at your DNS provider. We'll verify once they propagate.
+                        </p>
+                    </div>
 
-                <div id="setup-error" class="inline-error" style="display:none"></div>
-                <div id="setup-poll-status" class="inline-info" style="display:none">
-                    Checking DNS… we'll keep watching for a minute.
+                    <div class="dns-records-section">
+                        <div class="dns-records-list" id="dns-records"></div>
+                        <div class="setup-notes" id="setup-notes" style="display:none"></div>
+                    </div>
+
+                    <p class="setup-help">
+                        Not sure where to add these?
+                        <a href="https://docs.spoo.me/custom-domains/dns-setup"
+                           target="_blank" rel="noopener noreferrer" class="setup-help-link">
+                            View the DNS setup guide
+                            <i class="ti ti-external-link"></i>
+                        </a>
+                    </p>
+
+                    <div id="dns-error" class="inline-error" style="display:none"></div>
                 </div>
-            </div>
 
-            <!-- Active mode -->
-            <div class="modal-slot" data-mode="active" style="display:none">
-                <div class="banner banner-active">
-                    <i class="ti ti-check"></i>
-                    Live. Short links work on this domain.
+                <!-- ==================== Verify slot (Step 3) ==================== -->
+                <div class="modal-slot" data-mode="verify" style="display:none">
+                    <div class="slot-intro">
+                        <h3 class="slot-heading">Verifying your domain</h3>
+                        <p class="slot-sub">
+                            We're checking that the DNS records resolve and that the certificate is issued.
+                            This can take from a few minutes to a few hours, depending on your DNS provider.
+                        </p>
+                    </div>
+
+                    <div class="status-panel" id="verify-status-panel">
+                        <div class="status-row" data-step="dns" id="status-row-dns">
+                            <div class="status-icon">
+                                <i class="ti ti-loader-2 spinning status-spinner"></i>
+                                <i class="ti ti-check status-success"></i>
+                                <i class="ti ti-x status-fail"></i>
+                            </div>
+                            <div class="status-content">
+                                <div class="status-label">Domain connection</div>
+                                <div class="status-message" id="status-dns-message">Waiting for DNS to propagate</div>
+                            </div>
+                        </div>
+                        <div class="status-row" data-step="ssl" id="status-row-ssl">
+                            <div class="status-icon">
+                                <i class="ti ti-loader-2 spinning status-spinner"></i>
+                                <i class="ti ti-check status-success"></i>
+                                <i class="ti ti-x status-fail"></i>
+                            </div>
+                            <div class="status-content">
+                                <div class="status-label">SSL certificate</div>
+                                <div class="status-message" id="status-ssl-message">Waiting for certificate to be issued</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="verify-error" class="inline-error" style="display:none"></div>
                 </div>
 
-                <a id="active-open-link" class="btn btn-secondary btn-block" target="_blank" rel="noopener noreferrer">
-                    <i class="ti ti-external-link"></i>
-                    <span id="active-open-label">Open your domain</span>
-                </a>
+                <!-- ==================== Live slot (Step 4) — Management view ==================== -->
+                <div class="modal-slot" data-mode="live" style="display:none">
+                    <div class="live-hero">
+                        <div class="live-hero-text">
+                            <h3 class="slot-heading">
+                                <i class="ti ti-circle-check live-hero-check"></i>
+                                Your domain is live
+                            </h3>
+                            <p class="slot-sub">Short links resolve from
+                                <code id="live-hero-fqdn"></code>.
+                            </p>
+                        </div>
+                        <a class="btn btn-ghost btn-icon-text" id="live-open-icon-link"
+                           target="_blank" rel="noopener noreferrer" title="Open in new tab">
+                            <i class="ti ti-external-link"></i>
+                            <span>Open</span>
+                        </a>
+                    </div>
 
-                <p class="active-meta" id="active-meta"></p>
+                    <div class="live-actions">
+                        <a class="action-card" id="live-shorten-cta" href="/dashboard/links?domain=">
+                            <div class="action-icon"><i class="ti ti-link"></i></div>
+                            <div class="action-text">
+                                <div class="action-title">Shorten a link on this domain</div>
+                                <div class="action-desc">Create a branded short link →</div>
+                            </div>
+                        </a>
+                    </div>
 
-                <details class="collapsible">
-                    <summary>DNS record (for reference)</summary>
-                    <div class="dns-records" id="active-dns-records"></div>
-                </details>
-            </div>
+                    <section class="settings-section settings-disabled" aria-labelledby="settings-routing-heading">
+                        <header class="settings-header">
+                            <div>
+                                <h3 id="settings-routing-heading">Routing settings</h3>
+                                <p class="settings-hint">Control root and unknown-path behaviour, robots.txt, and indexing.</p>
+                            </div>
+                        </header>
+                        <div class="settings-grid" aria-hidden="true">
+                            <div class="setting-field">
+                                <label>Root redirect (<code>/</code>)</label>
+                                <input type="text" disabled placeholder="https://yoursite.com" />
+                            </div>
+                            <div class="setting-field">
+                                <label>Unknown path redirect</label>
+                                <input type="text" disabled placeholder="https://yoursite.com/404" />
+                            </div>
+                            <div class="setting-field setting-full">
+                                <label>Custom robots.txt</label>
+                                <textarea disabled rows="3" placeholder="User-agent: *&#10;Disallow: /"></textarea>
+                            </div>
+                            <div class="setting-field setting-full">
+                                <label class="toggle-label">
+                                    <input type="checkbox" disabled />
+                                    <span>Allow search engines to index links on this domain</span>
+                                </label>
+                            </div>
+                        </div>
+                    </section>
 
-            <!-- Revoked mode -->
-            <div class="modal-slot" data-mode="revoked" style="display:none">
-                <div class="banner banner-revoked">
-                    This domain was revoked. Re-registration available 30 days after revocation.
+                </div>
+
+                <!-- ==================== Revoked slot ==================== -->
+                <div class="modal-slot" data-mode="revoked" style="display:none">
+                    <div class="banner banner-revoked">
+                        <i class="ti ti-ban banner-icon"></i>
+                        <div>
+                            <strong>This domain has been revoked.</strong>
+                            <p>Short links on it no longer resolve. The domain still occupies a
+                                slot on your account — Remove it to free the slot, or leave it for
+                                the audit record.</p>
+                        </div>
+                    </div>
+                    <dl class="diag-list revoked-meta">
+                        <dt>Revoked</dt><dd id="revoked-at">—</dd>
+                        <dt>Originally registered</dt><dd id="revoked-created">—</dd>
+                    </dl>
                 </div>
             </div>
         </div>
 
         <div class="modal-footer" id="domain-modal-footer">
-            <button type="button" class="btn btn-danger-ghost" id="btn-domain-revoke" style="display:none">Revoke</button>
-            <button type="button" class="btn btn-ghost" id="btn-domain-modal-cancel" style="display:none">Cancel</button>
-            <button type="button" class="btn btn-primary" id="btn-domain-modal-submit" style="display:none">Add</button>
-            <button type="button" class="btn btn-primary" id="btn-verify" style="display:none">
-                <span class="btn-label">Verify</span>
-                <span class="btn-spinner" style="display:none">
-                    <i class="ti ti-loader-2"></i>
-                </span>
-            </button>
+            <!-- Left-aligned secondary actions -->
+            <div class="modal-footer-left">
+                <button type="button" class="btn btn-ghost" id="btn-step-back" style="display:none">
+                    <i class="ti ti-arrow-left"></i>
+                    <span>Back</span>
+                </button>
+                <button type="button" class="btn btn-link-danger" id="btn-cancel-registration" style="display:none">
+                    Cancel registration
+                </button>
+            </div>
+
+            <!-- Right-aligned primary actions -->
+            <div class="modal-footer-right">
+                <button type="button" class="btn btn-ghost" id="btn-domain-modal-cancel" style="display:none">Cancel</button>
+                <button type="button" class="btn btn-primary" id="btn-domain-modal-submit" style="display:none">Add domain</button>
+                <button type="button" class="btn btn-primary" id="btn-step-next" style="display:none">
+                    <span class="btn-label">I've added the records</span>
+                    <i class="ti ti-arrow-right"></i>
+                </button>
+                <button type="button" class="btn btn-primary" id="btn-verify-footer" style="display:none">
+                    <i class="ti ti-refresh btn-verify-icon"></i>
+                    <span class="btn-label">Check now</span>
+                </button>
+                <button type="button" class="btn btn-danger" id="btn-revoke-footer" style="display:none">
+                    <i class="ti ti-trash"></i>
+                    <span>Revoke domain</span>
+                </button>
+                <button type="button" class="btn btn-danger" id="btn-domain-remove" style="display:none">
+                    <i class="ti ti-trash"></i>
+                    <span>Remove permanently</span>
+                </button>
+            </div>
         </div>
     </div>
+
+    <!-- Confetti canvas (overlays the entire modal viewport on Live transition) -->
+    <canvas id="confetti-canvas" class="confetti-canvas" aria-hidden="true"></canvas>
 </div>
 
-<!-- Revoke confirmation sub-modal — same pattern as #delete-key-modal -->
+<!-- ===================================================================== -->
+<!-- Revoke confirmation sub-modal — card-as-target + type-to-confirm -->
+<!-- ===================================================================== -->
 <div id="delete-domain-modal" aria-hidden="true">
     <div class="modal-backdrop"></div>
     <div class="modal-container">
@@ -161,24 +353,41 @@
                 <p id="deleteDomainModalDesc">
                     <strong id="delete-domain-fqdn"></strong> has
                     <strong id="delete-domain-url-count">…</strong> URL(s) on it.
-                    What should happen to them?
+                    Pick what should happen to them.
                 </p>
-                <div class="cascade-choice">
-                    <label class="cascade-option">
-                        <input type="radio" name="cascade" value="false" checked>
-                        <span class="cascade-option-label">Keep the URLs (orphan)</span>
-                        <div class="cascade-option-desc">
-                            URLs become unreachable. If you re-register this domain later, they resume working.
+                <div class="cascade-choice" role="radiogroup" aria-label="URL handling">
+                    <button type="button" class="cascade-card" data-cascade="false" aria-pressed="true">
+                        <i class="ti ti-archive cascade-icon"></i>
+                        <div class="cascade-text">
+                            <span class="cascade-card-title">Keep URLs (orphan)</span>
+                            <span class="cascade-card-desc">
+                                URLs stop resolving while the domain is revoked. If you re-register
+                                the same domain later, they resume.
+                            </span>
                         </div>
-                    </label>
-                    <label class="cascade-option">
-                        <input type="radio" name="cascade" value="true">
-                        <span class="cascade-option-label">Delete all URLs permanently</span>
-                        <div class="cascade-option-desc warning">
-                            Destination data is lost. Aliases free up for reuse. Cannot be undone.
+                    </button>
+                    <button type="button" class="cascade-card cascade-card-destructive" data-cascade="true" aria-pressed="false">
+                        <i class="ti ti-trash cascade-icon"></i>
+                        <div class="cascade-text">
+                            <span class="cascade-card-title">Delete URLs permanently</span>
+                            <span class="cascade-card-desc">
+                                Every short link on this domain is permanently deleted - destinations, click stats, and short codes all gone. Cannot be undone.
+                            </span>
                         </div>
-                    </label>
+                    </button>
                 </div>
+
+                <div class="field type-to-confirm-field">
+                    <label for="delete-domain-confirm-input">
+                        Type the domain name to confirm
+                    </label>
+                    <input
+                        type="text"
+                        id="delete-domain-confirm-input"
+                        autocomplete="off"
+                        spellcheck="false" />
+                </div>
+
                 <div id="delete-domain-error" class="inline-error" style="display:none"></div>
             </div>
 
@@ -186,9 +395,60 @@
                 <button type="button" class="btn btn-cancel" id="btn-cancel-domain-delete">
                     <span>Cancel</span>
                 </button>
-                <button type="button" class="btn btn-delete" id="btn-confirm-domain-delete">
+                <button type="button" class="btn btn-delete" id="btn-confirm-domain-delete" disabled>
                     <i class="ti ti-trash"></i>
-                    <span>Revoke domain</span>
+                    <span id="btn-confirm-domain-delete-label">Revoke domain</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ===================================================================== -->
+<!-- Remove (hard delete) confirmation sub-modal — REVOKED docs only -->
+<!-- ===================================================================== -->
+<div id="remove-domain-modal" aria-hidden="true">
+    <div class="modal-backdrop"></div>
+    <div class="modal-container">
+        <div class="modal-content" role="dialog" aria-modal="true"
+            aria-labelledby="removeDomainModalTitle" aria-describedby="removeDomainModalDesc">
+            <div class="modal-header">
+                <div class="modal-title-section-delete">
+                    <div class="modal-icon">
+                        <i class="ti ti-alert-triangle"></i>
+                    </div>
+                    <h2 class="modal-title" id="removeDomainModalTitle">Remove revoked domain?</h2>
+                </div>
+            </div>
+
+            <div class="modal-body">
+                <p id="removeDomainModalDesc">
+                    Permanently deletes <strong id="remove-domain-fqdn"></strong> from
+                    your account. The audit record is preserved, but the domain stops
+                    counting toward your slot and the row is gone from the dashboard.
+                    This cannot be undone.
+                </p>
+                <div class="field type-to-confirm-field">
+                    <label for="remove-domain-confirm-input">
+                        Type the domain name to confirm
+                    </label>
+                    <input
+                        type="text"
+                        id="remove-domain-confirm-input"
+                        autocomplete="off"
+                        spellcheck="false"
+                        placeholder="" />
+                </div>
+                <div id="remove-domain-error" class="inline-error" style="display:none"></div>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-cancel" id="btn-cancel-domain-remove">
+                    <span>Cancel</span>
+                </button>
+                <button type="button" class="btn btn-delete" id="btn-confirm-domain-remove" disabled>
+                    <i class="ti ti-trash"></i>
+                    <span>Remove permanently</span>
                 </button>
             </div>
         </div>
@@ -208,25 +468,35 @@
 
 <template id="tpl-dns-record">
     <div class="dns-record">
-        <span class="rec-type"></span>
-        <div class="rec-fields">
-            <div class="rec-field">
-                <span class="rec-label">Name</span>
-                <code class="rec-name"></code>
-            </div>
-            <div class="rec-field">
-                <span class="rec-label">Value</span>
-                <code class="rec-value"></code>
+        <div class="rec-cell rec-cell-type">
+            <span class="rec-cell-label">Type</span>
+            <div class="rec-cell-box rec-cell-box-static">
+                <span class="rec-type-text"></span>
             </div>
         </div>
-        <button type="button" class="rec-copy" title="Copy value">
-            <i class="ti ti-copy"></i>
-        </button>
+        <div class="rec-cell rec-cell-name">
+            <span class="rec-cell-label">Host-Name</span>
+            <div class="rec-cell-box">
+                <code class="rec-name"></code>
+                <button type="button" class="rec-copy-btn" data-field="name" title="Copy name">
+                    <i class="ti ti-copy"></i>
+                </button>
+            </div>
+        </div>
+        <div class="rec-cell rec-cell-value">
+            <span class="rec-cell-label">Value</span>
+            <div class="rec-cell-box">
+                <code class="rec-value"></code>
+                <button type="button" class="rec-copy-btn" data-field="value" title="Copy value">
+                    <i class="ti ti-copy"></i>
+                </button>
+            </div>
+        </div>
     </div>
 </template>
 {% endblock %}
 
 {% block scripts %}
 <script src="{{ url_for('static', path='js/verification-check.js') }}?v=1"></script>
-<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=4"></script>
+<script src="{{ url_for('static', path='js/dashboard/domains.js') }}?v=18"></script>
 {% endblock %}

--- a/templates/dashboard/partials/sidebar.html
+++ b/templates/dashboard/partials/sidebar.html
@@ -26,6 +26,13 @@
             <span class="nav-text">API Keys</span>
         </a>
 
+        <a href="/dashboard/statistics"
+            class="nav-item {% if request.path == '/dashboard/statistics' %}active{% endif %}"
+            data-tooltip="Statistics">
+            <i class="ti ti-chart-bar"></i>
+            <span class="nav-text">Statistics</span>
+        </a>
+
         {% if show_custom_domains %}
         <a href="/dashboard/domains" class="nav-item {% if request.path == '/dashboard/domains' %}active{% endif %}"
             data-tooltip="Custom Domains">
@@ -33,13 +40,6 @@
             <span class="nav-text">Domains</span>
         </a>
         {% endif %}
-
-        <a href="/dashboard/statistics"
-            class="nav-item {% if request.path == '/dashboard/statistics' %}active{% endif %}"
-            data-tooltip="Statistics">
-            <i class="ti ti-chart-bar"></i>
-            <span class="nav-text">Statistics</span>
-        </a>
 
         {% if show_apps %}
         <a href="/dashboard/apps" class="nav-item {% if request.path == '/dashboard/apps' %}active{% endif %}"

--- a/tests/integration/test_custom_domain_routes.py
+++ b/tests/integration/test_custom_domain_routes.py
@@ -27,6 +27,7 @@ from dependencies import (
 from errors import (
     DomainAlreadyRegisteredError,
     ForbiddenError,
+    InvalidDomainTransitionError,
     NotFoundError,
 )
 from routes.api_v1 import router as api_v1_router
@@ -298,3 +299,45 @@ class TestDeleteCustomDomain:
         client = TestClient(_make_app(svc), raise_server_exceptions=False)
         resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}")
         assert resp.status_code == 403
+
+
+class TestRemoveCustomDomain:
+    def test_happy_path_returns_204(self):
+        svc = AsyncMock()
+        svc.remove_revoked = AsyncMock(return_value=_doc(status=DomainStatus.REVOKED))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}/permanent")
+        assert resp.status_code == 204
+        svc.remove_revoked.assert_awaited_once()
+
+    def test_not_revoked_returns_422(self):
+        svc = AsyncMock()
+        svc.remove_revoked = AsyncMock(
+            side_effect=InvalidDomainTransitionError(
+                "Only revoked domains can be removed. Revoke this domain first."
+            )
+        )
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}/permanent")
+        assert resp.status_code == 422
+
+    def test_not_found_returns_404(self):
+        svc = AsyncMock()
+        svc.remove_revoked = AsyncMock(side_effect=NotFoundError("domain not found"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}/permanent")
+        assert resp.status_code == 404
+
+    def test_not_owner_returns_403(self):
+        svc = AsyncMock()
+        svc.remove_revoked = AsyncMock(side_effect=ForbiddenError("not yours"))
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete(f"/api/v1/custom-domains/{_DOMAIN_ID}/permanent")
+        assert resp.status_code == 403
+
+    def test_invalid_id_returns_404(self):
+        svc = AsyncMock()
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.delete("/api/v1/custom-domains/not-an-objectid/permanent")
+        assert resp.status_code == 404
+        svc.remove_revoked.assert_not_called()

--- a/tests/unit/repositories/test_custom_domain_repository.py
+++ b/tests/unit/repositories/test_custom_domain_repository.py
@@ -77,6 +77,36 @@ class TestCustomDomainRepository:
         )
 
     @pytest.mark.asyncio
+    async def test_find_blocking_by_fqdn_excludes_revoked(self):
+        # Uniqueness gate must not consider REVOKED docs — they're terminal
+        # records of past registrations and don't reserve the fqdn for
+        # future use. New registrations of the same fqdn are gated by DCV,
+        # not by a database cooldown.
+        col = AsyncMock()
+        col.find_one = AsyncMock(return_value=None)
+        col.name = "custom_domains"
+        repo = CustomDomainRepository(col)
+
+        await repo.find_blocking_by_fqdn("links.example.com")
+        col.find_one.assert_awaited_once_with(
+            {
+                "fqdn": "links.example.com",
+                "status": {"$ne": DomainStatus.REVOKED},
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_find_blocking_by_fqdn_normalises_lookup_input(self):
+        col = AsyncMock()
+        col.find_one = AsyncMock(return_value=None)
+        col.name = "custom_domains"
+        repo = CustomDomainRepository(col)
+
+        await repo.find_blocking_by_fqdn("LINKS.Example.COM.")
+        args = col.find_one.call_args.args[0]
+        assert args["fqdn"] == "links.example.com"
+
+    @pytest.mark.asyncio
     async def test_count_by_owner_runs_on_owner_id(self):
         col = AsyncMock()
         col.count_documents = AsyncMock(return_value=2)

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -71,7 +71,14 @@ class TestEnsureIndexes:
         )
         app_grants_col.create_index.assert_any_await([("app_id", 1), ("revoked_at", 1)])
         feature_flags_col.create_index.assert_any_await([("name", 1)], unique=True)
-        custom_domains_col.create_index.assert_any_await([("fqdn", 1)], unique=True)
+        custom_domains_col.create_index.assert_any_await(
+            [("fqdn", 1)],
+            unique=True,
+            partialFilterExpression={
+                "status": {"$in": ["pending", "verifying", "active", "suspended"]}
+            },
+            name="fqdn_unique_non_revoked",
+        )
         custom_domains_col.create_index.assert_any_await(
             [("owner_id", 1), ("created_at", -1)]
         )

--- a/tests/unit/services/test_custom_domain_service.py
+++ b/tests/unit/services/test_custom_domain_service.py
@@ -234,7 +234,10 @@ class TestCreate:
         svc, repo, _, _, _ = _build_service()
         repo.find_blocking_by_fqdn = AsyncMock(return_value=_doc())
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
-        with pytest.raises(DomainAlreadyRegisteredError):
+        with pytest.raises(
+            DomainAlreadyRegisteredError,
+            match="registered to another account",
+        ):
             await svc.create(req, _user())
 
     @pytest.mark.asyncio
@@ -617,6 +620,23 @@ class TestRemoveRevoked:
         repo.find_by_id = AsyncMock(return_value=None)
         with pytest.raises(NotFoundError):
             await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_hard_delete_noops(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.REVOKED))
+        repo.delete_by_id = AsyncMock(return_value=False)
+        with pytest.raises(NotFoundError):
+            await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_awaited_once_with(DOMAIN_OID)
+
+    @pytest.mark.asyncio
+    async def test_respects_feature_flag(self):
+        svc, repo, _, _, _ = _build_service(enabled=False)
+        with pytest.raises(DomainQuotaExceededError):
+            await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.find_by_id.assert_not_called()
         repo.delete_by_id.assert_not_called()
 
 

--- a/tests/unit/services/test_custom_domain_service.py
+++ b/tests/unit/services/test_custom_domain_service.py
@@ -84,6 +84,7 @@ def _build_service(
     repo.update_edge_metadata = AsyncMock(return_value=True)
     repo.count_by_owner = AsyncMock(return_value=0)
     repo.find_by_fqdn = AsyncMock(return_value=None)
+    repo.find_blocking_by_fqdn = AsyncMock(return_value=None)
     repo.find_by_id = AsyncMock(return_value=None)
     repo.update_status = AsyncMock(return_value=True)
     repo.set_eviction_pending = AsyncMock(return_value=True)
@@ -231,10 +232,26 @@ class TestCreate:
     @pytest.mark.asyncio
     async def test_uniqueness_conflict_raises(self):
         svc, repo, _, _, _ = _build_service()
-        repo.find_by_fqdn = AsyncMock(return_value=_doc())
+        repo.find_blocking_by_fqdn = AsyncMock(return_value=_doc())
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
         with pytest.raises(DomainAlreadyRegisteredError):
             await svc.create(req, _user())
+
+    @pytest.mark.asyncio
+    async def test_uniqueness_ignores_revoked_docs(self):
+        # REVOKED doc does NOT block re-registration of the same fqdn —
+        # different owner can claim it (DCV gates takeover), or the same
+        # owner can re-register after Remove. find_blocking_by_fqdn must
+        # return None when the only matching doc is REVOKED.
+        svc, repo, _, _, _ = _build_service()
+        # Repo's find_blocking_by_fqdn is the gate; default mock returns
+        # None to simulate "no blocking doc found" (REVOKED docs would be
+        # filtered out at the query level).
+        repo.find_blocking_by_fqdn = AsyncMock(return_value=None)
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
+        req = CreateCustomDomainRequest(fqdn="links.acme.com")
+        await svc.create(req, _user())  # must not raise
+        repo.insert.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_per_user_quota_enforced(self):
@@ -265,16 +282,6 @@ class TestCreate:
         req = CreateCustomDomainRequest(fqdn="anything.example.com")
         # Must not raise — just skip the check.
         await svc.create(req, _user())
-
-    @pytest.mark.asyncio
-    async def test_create_attempts_quota_via_redis(self):
-        redis = AsyncMock()
-        redis.incr = AsyncMock(return_value=99)  # way over cap of 3
-        redis.expire = AsyncMock()
-        svc, _, _, _, _ = _build_service(redis=redis)
-        req = CreateCustomDomainRequest(fqdn="links.acme.com")
-        with pytest.raises(DomainQuotaExceededError):
-            await svc.create(req, _user())
 
     @pytest.mark.asyncio
     async def test_duplicate_key_during_race_translates_to_friendly_error(self):
@@ -567,6 +574,50 @@ class TestSuspendNotFound:
 
         repo.update_status.assert_not_called()
         edge.announce_revoked.assert_not_called()
+
+
+class TestRemoveRevoked:
+    @pytest.mark.asyncio
+    async def test_hard_deletes_revoked_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.REVOKED))
+        await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_awaited_once_with(DOMAIN_OID)
+
+    @pytest.mark.asyncio
+    async def test_refuses_active_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.ACTIVE))
+        with pytest.raises(InvalidDomainTransitionError):
+            await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refuses_pending_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
+        with pytest.raises(InvalidDomainTransitionError):
+            await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refuses_non_owner(self):
+        # _load_owned raises ForbiddenError before status check fires.
+        svc, repo, _, _, _ = _build_service()
+        other = _doc(status=DomainStatus.REVOKED)
+        other.owner_id = ObjectId()  # different from _user()'s id
+        repo.find_by_id = AsyncMock(return_value=other)
+        with pytest.raises(ForbiddenError):
+            await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refuses_missing_doc(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=None)
+        with pytest.raises(NotFoundError):
+            await svc.remove_revoked(DOMAIN_OID, _user())
+        repo.delete_by_id.assert_not_called()
 
 
 class TestVerifyAttemptsQuota:


### PR DESCRIPTION
Lifecycle / quota:
- Drop the daily create counter. Lifetime cap + slowapi route limit are sufficient; the counter only burned user quota on transient CF failures without adding real abuse defence.
- Status-aware uniqueness check. New find_blocking_by_fqdn excludes REVOKED docs so re-registering a previously revoked domain works — same posture as Vercel/Netlify/CF SaaS, with DCV at register-time as the security gate.
- New "Remove" action for revoked domains. DELETE /api/v1/custom-domains/{id}/permanent hard-deletes a REVOKED doc to free the user's slot. 422 on non-REVOKED status. Emits audit.domain.removed.
- Friendlier error copy on quota + uniqueness paths.
- Drop the unused re_register_cooldown_days config field.

Add / manage flow UX:
- Replace the single-modal-many-slots dashboard with a 4-step flow (Domain -> DNS records -> Verify -> Live), vertical stepper rail on the setup steps, mode-driven modal width.
- DNS records: 3-column layout (Type / Host-Name / Value) with per-field copy buttons that toast which field was copied. Coloured type pill per record type. Setup-guide link under the records.
- Verify step: two-row status panel (Domain connection + SSL certificate) with friendly copy mapping for the common CF and DNS states (NXDOMAIN, pending_validation, timeout, mismatch, etc.). Auto-poll every 10s; manual "Check now" footer button shows in-flight spinner.
- Live management view: hero confirmation, "Shorten a link on this domain" CTA, routing-settings placeholder, single Revoke footer button. One-shot confetti on first ever ACTIVE transition per domain, deduped via localStorage.
- Revoked state: improved banner copy, "Remove permanently" footer button with type-to-confirm fqdn.
- Revoke confirmation modal: cards-as-target (orphan vs delete-URLs) instead of radio buttons. Amber highlight on the safe option, red on the destructive one. Type-to-confirm fqdn gate. Button label updates to "Revoke and delete N URLs" on the destructive variant.
- "Cancel registration" link in the footer of the DNS / Verify steps for PENDING domains (deletes the doc, no URLs involved).
- Step navigation: clicking any completed step navigates back. No skip-ahead.
- Sidebar nav: Domains moved below Statistics.

Tests: 1570 passing. New unit coverage for remove_revoked happy/sad paths and find_blocking_by_fqdn. New integration tests for the DELETE /permanent endpoint.

## Summary by Sourcery

Redesign the custom domains dashboard flow into a guided multi-step experience, relax and clarify domain lifecycle constraints, and add support for permanently removing revoked domains while updating related tests and documentation.

New Features:
- Introduce a 4-step domain setup and management modal with a vertical stepper, DNS records view, verification status panel, and live management view including confetti and CTA.
- Add a permanent removal flow for revoked custom domains, including a dedicated confirmation modal and API endpoint to hard-delete revoked domains and free account slots.
- Allow re-registration of previously revoked domains by ignoring REVOKED records in uniqueness checks and adding friendlier error messages for quota and uniqueness failures.

Bug Fixes:
- Prevent revoked domains from permanently blocking subsequent registrations of the same hostname by excluding REVOKED records from uniqueness enforcement.
- Make verify and cancel flows more robust by tightening state handling around polling, navigation, and modal closure.

Enhancements:
- Refine domain quota enforcement copy to guide users toward revoking or removing domains to free slots.
- Improve DNS records UI with a three-column layout, per-field copy actions, and contextual setup guidance.
- Revamp the revoke confirmation UX with card-based choices, type-to-confirm safeguards, and dynamic destructive button labelling.
- Adjust mobile modal behavior and layout for better readability and interaction in the domains flow.
- Log an explicit audit.domain.removed event when a revoked domain is permanently deleted.

Documentation:
- Update API route documentation and inline comments to describe the new permanent removal endpoint and domain lifecycle behavior.

Tests:
- Add unit coverage for the new remove_revoked service method, including owner, status, and not-found edge cases.
- Add unit tests for the repository-level find_blocking_by_fqdn helper to ensure REVOKED domains are excluded and lookups are normalized.
- Add integration tests for the new DELETE /api/v1/custom-domains/{id}/permanent endpoint covering success and error conditions.
- Remove obsolete tests related to per-day domain creation quotas as that mechanism is dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permanently delete revoked custom domains
  * Redesigned domain management dashboard with improved workflows
  * Copy-to-clipboard buttons for DNS records
  * Enhanced revoke confirmation with typed domain verification

* **Bug Fixes**
  * Revoked domains no longer prevent new domain registrations

* **UI/Navigation**
  * Reorganized dashboard sidebar navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spoo-me/spoo/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->