### PR TITLE
feat(apps): mark spoo-cli live with loopback redirect URI

### DIFF
--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -120,5 +120,7 @@ apps:
     icon: spoo-cli.svg
     description: Shorten links from your terminal
     verified: true
-    status: coming_soon
+    status: live
     type: device_auth
+    redirect_uris:
+      - http://127.0.0.1:53682/callback

--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -124,3 +124,10 @@ apps:
     type: device_auth
     redirect_uris:
       - http://127.0.0.1:53682/callback
+    links:
+      github: https://github.com/spoo-me/spoo-cli
+    permissions:
+      - Access your spoo.me account
+      - Create and manage your short URLs
+      - View your analytics
+      - Manage your API keys


### PR DESCRIPTION
Flips the `spoo-cli` connected app from `coming_soon` to `live` and adds the loopback redirect URI (`http://127.0.0.1:53682/callback`) used by the device-auth flow.

Split out from `feat/spoo-cli-live` so this PR contains **only** the `config/apps.yaml` change — the onboarding commits on that branch are unrelated and not included here.

## Summary by Sourcery

Promote the spoo-cli connected app to live status and configure its device-auth loopback redirect URI.

New Features:
- Enable the spoo-cli connected app for live use with device authentication.

Enhancements:
- Add a loopback redirect URI for the spoo-cli device-auth flow in the apps configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The spoo-cli application is now live and available for use.
  * Added support for a new callback redirect URI (`http://127.0.0.1:53682/callback`).
  * Updated the app’s configuration with a GitHub link and expanded declared permissions, including “Manage your API keys”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->