### PR TITLE
fix(tests): restore CI compat with pyjwt 2.13 and fastapi 0.137

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,9 @@ os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 # .env) does not set JWT_SECRET, leaving it "" — and pyjwt >= 2.13 rejects empty
 # HMAC keys ("HMAC key must not be empty."). Provide a non-prod test secret here,
 # before any test module constructs AppSettings(), so signing/verification match.
-os.environ.setdefault("JWT_SECRET", "test-jwt-secret-not-for-production")
+# Set when missing *or* empty (setdefault would keep an explicit JWT_SECRET="").
+if not os.environ.get("JWT_SECRET"):
+    os.environ["JWT_SECRET"] = "test-jwt-secret-not-for-production"
 
 from config import AppSettings
 from middleware.error_handler import register_error_handlers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
+# Tests sign/verify JWTs with the HS256 symmetric secret. CI (and a typical local
+# .env) does not set JWT_SECRET, leaving it "" — and pyjwt >= 2.13 rejects empty
+# HMAC keys ("HMAC key must not be empty."). Provide a non-prod test secret here,
+# before any test module constructs AppSettings(), so signing/verification match.
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret-not-for-production")
 
 from config import AppSettings
 from middleware.error_handler import register_error_handlers

--- a/tests/smoke/test_routes_registered.py
+++ b/tests/smoke/test_routes_registered.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import NamedTuple
 
 os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 
@@ -10,9 +11,40 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
 
-def _get_api_routes(app: FastAPI) -> list[APIRoute]:
-    """Extract all APIRoute objects from the app (excluding mount/static)."""
-    return [r for r in app.routes if isinstance(r, APIRoute)]
+class _ResolvedRoute(NamedTuple):
+    """A flattened API route with its fully-qualified path and HTTP methods."""
+
+    path: str
+    methods: set[str]
+
+
+def _get_api_routes(app: FastAPI) -> list[_ResolvedRoute]:
+    """Return every API route as ``(full_path, methods)`` in registration order.
+
+    FastAPI >= 0.137 no longer flattens ``include_router()`` routes into
+    ``app.routes``; included routers appear as ``_IncludedRouter`` wrapper nodes
+    whose real routes live under ``.original_router.routes`` and whose mount
+    prefix lives on ``.include_context.prefix``. Walk that tree accumulating
+    prefixes so full paths (e.g. ``/api/v1/shorten``) and methods (incl. the
+    auto-added ``HEAD``) are reconstructed. Falls back to flat ``APIRoute``
+    objects on older FastAPI, where they appear directly in ``app.routes``.
+    """
+
+    def _collect(routes, prefix: str = "") -> list[_ResolvedRoute]:
+        found: list[_ResolvedRoute] = []
+        for route in routes:
+            if isinstance(route, APIRoute):
+                found.append(_ResolvedRoute(prefix + route.path, set(route.methods)))
+            elif hasattr(route, "original_router"):
+                child_prefix = (
+                    getattr(getattr(route, "include_context", None), "prefix", "") or ""
+                )
+                found.extend(
+                    _collect(route.original_router.routes, prefix + child_prefix)
+                )
+        return found
+
+    return _collect(app.routes)
 
 
 def _get_path_method_pairs(app: FastAPI) -> set[tuple[str, str]]:

--- a/tests/smoke/test_routes_registered.py
+++ b/tests/smoke/test_routes_registered.py
@@ -15,7 +15,7 @@ class _ResolvedRoute(NamedTuple):
     """A flattened API route with its fully-qualified path and HTTP methods."""
 
     path: str
-    methods: set[str]
+    methods: frozenset[str]
 
 
 def _get_api_routes(app: FastAPI) -> list[_ResolvedRoute]:
@@ -34,7 +34,9 @@ def _get_api_routes(app: FastAPI) -> list[_ResolvedRoute]:
         found: list[_ResolvedRoute] = []
         for route in routes:
             if isinstance(route, APIRoute):
-                found.append(_ResolvedRoute(prefix + route.path, set(route.methods)))
+                found.append(
+                    _ResolvedRoute(prefix + route.path, frozenset(route.methods))
+                )
             elif hasattr(route, "original_router"):
                 child_prefix = (
                     getattr(getattr(route, "include_context", None), "prefix", "") or ""


### PR DESCRIPTION
## Why

The dependency upgrade in #204 turned `main` CI red — 7 tests fail in the **Tests & Coverage** job. This is **test-only**; production is unaffected (routing verified working, **Deploy to Production passed** on the same commit, and all 1647 non-affected tests stayed green). The `fail-fast` matrix made it look like a flaky single-version failure — really *every* Python version fails identically; the first to trip cancels the rest.

## Root causes (both from #204 bumps)

1. **`pyjwt` 2.12.1 → 2.13.0** now raises `InvalidKeyError: HMAC key must not be empty.` The 4 JWT tests in `tests/integration/test_security.py` sign with `jwt_secret`, which is `""` in CI (no `JWT_SECRET` env var, and `.env` is gitignored). 2.12.1 silently tolerated the empty key.
2. **`fastapi` 0.136.1 → 0.137.0** no longer flattens `include_router()` routes into `app.routes`; they now appear as `_IncludedRouter` wrapper nodes. The 3 route smoke tests in `tests/smoke/test_routes_registered.py` filter `app.routes` for `APIRoute` and found **zero**.

## Fix (test-only, ~40 lines, 2 files)

- `tests/conftest.py`: `os.environ.setdefault("JWT_SECRET", ...)` before any test builds `AppSettings()`, so token signing/verification have a non-empty key everywhere.
- `tests/smoke/test_routes_registered.py`: walk the `_IncludedRouter` tree (accumulating `.include_context.prefix`) to reconstruct full paths + methods (incl. auto-`HEAD`), with a clean fallback to flat `APIRoute`s on older FastAPI.

## Verification

```
1654 passed in 16.02s   (was 1647 passed, 7 failed)
```
The 7 previously-failing tests now pass; no other test changed. No production code touched.

## Summary by Sourcery

Restore CI test compatibility with updated pyjwt and FastAPI dependencies by adjusting JWT test configuration and route discovery logic.

Bug Fixes:
- Ensure tests use a non-empty JWT secret so pyjwt 2.13 token signing and verification succeed in CI.
- Update route discovery in smoke tests to correctly traverse included routers under FastAPI 0.137 while remaining compatible with older versions.

Tests:
- Refine helper for collecting API routes in smoke tests to handle nested included routers and reconstructed method sets across FastAPI versions.
- Set a default JWT_SECRET in test configuration to stabilize JWT-related integration tests across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the test configuration to ensure JWT signing uses a stable, non-empty secret in the test environment.
  * Improved route-registration checks to correctly validate registered API paths and HTTP methods across different FastAPI routing layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->