### PR TITLE
Fix edge deploy job toolchain

### DIFF
--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -76,6 +76,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: edge/spoo-edge-cache/package-lock.json
+
+      # wrangler-action runs the wrangler from node_modules — without
+      # this install the runner falls back to a stray global wrangler
+      # in the wrong directory.
+      - name: Install
+        run: npm ci
+        working-directory: edge/spoo-edge-cache
+
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
The deploy job invoked wrangler-action without npm ci — no wrangler in node_modules, npx fell back to a stray global wrangler in the wrong directory ("missing entry-point"). Adds the same Node setup + install the check job already has.

## Summary by Sourcery

Ensure edge deployment job uses a consistent Node toolchain and local wrangler installation before running the Cloudflare deploy action.

Build:
- Add Node setup with npm caching and lockfile path in the edge deploy workflow to align tooling with the check job.

CI:
- Install wrangler via npm ci in the edge/spoo-edge-cache directory so the deploy job uses the intended local wrangler instead of a global installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the edge deployment workflow so it installs the correct project dependencies before running the deployment step, helping avoid unexpected deployment failures.
  * Added clearer guidance in the workflow to ensure the deployment tool uses the intended local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->