### PR TITLE
Pin production KV namespace id

### DIFF
--- a/edge/spoo-edge-cache/wrangler.jsonc
+++ b/edge/spoo-edge-cache/wrangler.jsonc
@@ -46,7 +46,12 @@
 			],
 			"kv_namespaces": [
 				{
-					"binding": "EDGE_CACHE"
+					"binding": "EDGE_CACHE",
+					// provisioned by the first `deploy --env production`
+					// (2026-07-05). Unlike beta, wrangler did NOT write the
+					// id back — pinned manually so the next deploy binds
+					// this namespace instead of provisioning a duplicate.
+					"id": "0cbb363671fc49afb8c87d5f2efb43f6"
 				}
 			],
 			// ~0.5-1M redirects/day through the route — sample edge logs.


### PR DESCRIPTION
First production deploy provisioned namespace 0cbb3636... but (unlike beta) wrangler did not write the id back into wrangler.jsonc — without pinning, the next deploy would provision a duplicate namespace. Types regenerated for the config hash.

## Summary by Sourcery

Pin the production KV namespace ID in the edge cache configuration to prevent duplicate namespace provisioning on subsequent deploys.

Enhancements:
- Regenerate configuration-derived types to reflect the updated wrangler.jsonc.

Build:
- Update wrangler.jsonc to include the provisioned production KV namespace ID.