### PR TITLE
ci: deploy click worker alongside the app on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,7 @@ jobs:
             wait_healthy() {
               # Caddy keeps a connection pool to app:8000 with retries, so
               # users see a brief latency bump (not 502) during the swap.
+              [ -n "$1" ] || { echo "::error::wait_healthy: missing container name"; return 1; }
               status=""
               for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
                 status=$(docker inspect "$1" --format '{{.State.Health.Status}}' 2>/dev/null || echo "missing")
@@ -156,7 +157,7 @@ jobs:
               if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$IMAGE_TAG" ]; then
                 echo "rolling back app + worker to ${PREV_TAG}"
                 set_tag "${PREV_TAG}"
-                docker compose --env-file .env -f docker-compose.prod.yml pull app || true
+                docker compose --env-file .env -f docker-compose.prod.yml pull app click-worker || true
                 docker compose --env-file .env -f docker-compose.prod.yml up -d --no-deps app click-worker
                 if wait_healthy spoo_app && wait_healthy spoo_click_worker; then
                   echo "::warning::rolled back — prod is healthy on previous image ${PREV_TAG}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,10 +115,10 @@ jobs:
               # Caddy keeps a connection pool to app:8000 with retries, so
               # users see a brief latency bump (not 502) during the swap.
               status=""
-              for i in 1 2 3 4 5 6 7 8; do
-                status=$(docker inspect spoo_app --format '{{.State.Health.Status}}' 2>/dev/null || echo "missing")
+              for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+                status=$(docker inspect "$1" --format '{{.State.Health.Status}}' 2>/dev/null || echo "missing")
                 [ "$status" = "healthy" ] && return 0
-                echo "app $status, retry $i"; sleep 3
+                echo "$1 $status, retry $i"; sleep 3
               done
               return 1
             }
@@ -127,7 +127,7 @@ jobs:
             docker compose --env-file .env -f docker-compose.prod.yml pull app
             docker compose --env-file .env -f docker-compose.prod.yml up -d --no-deps app
 
-            if ! wait_healthy; then
+            if ! wait_healthy spoo_app; then
               echo "::error::app failed to reach healthy on ${IMAGE_TAG} (last status: $status)"
               # diagnostics must never abort the rollback below (set -e)
               docker compose --env-file .env -f docker-compose.prod.yml logs --tail=100 app || true
@@ -136,7 +136,29 @@ jobs:
                 set_tag "${PREV_TAG}"
                 docker compose --env-file .env -f docker-compose.prod.yml pull app || true
                 docker compose --env-file .env -f docker-compose.prod.yml up -d --no-deps app
-                if wait_healthy; then
+                if wait_healthy spoo_app; then
+                  echo "::warning::rolled back — prod is healthy on previous image ${PREV_TAG}"
+                else
+                  echo "::error::rollback to ${PREV_TAG} also unhealthy — manual intervention needed"
+                fi
+              fi
+              exit 1
+            fi
+
+            # The click worker runs the SAME image (shared wire contract with
+            # the app) — swap it only after the app is confirmed healthy, so
+            # an app rollback leaves the worker untouched on the old pair.
+            docker compose --env-file .env -f docker-compose.prod.yml up -d --no-deps click-worker
+
+            if ! wait_healthy spoo_click_worker; then
+              echo "::error::click worker failed to reach healthy on ${IMAGE_TAG} (last status: $status)"
+              docker compose --env-file .env -f docker-compose.prod.yml logs --tail=100 click-worker || true
+              if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$IMAGE_TAG" ]; then
+                echo "rolling back app + worker to ${PREV_TAG}"
+                set_tag "${PREV_TAG}"
+                docker compose --env-file .env -f docker-compose.prod.yml pull app || true
+                docker compose --env-file .env -f docker-compose.prod.yml up -d --no-deps app click-worker
+                if wait_healthy spoo_app && wait_healthy spoo_click_worker; then
                   echo "::warning::rolled back — prod is healthy on previous image ${PREV_TAG}"
                 else
                   echo "::error::rollback to ${PREV_TAG} also unhealthy — manual intervention needed"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,14 +9,11 @@ on:
       - "uv.lock"
       - "requirements.txt"
       - ".github/workflows/tests.yaml"
+  # No paths filter on PRs: the test checks are required by branch
+  # protection, and a filtered-out workflow never reports — leaving
+  # non-code PRs stuck at "Expected" forever.
   pull_request:
     branches: [main]
-    paths:
-      - "**.py"
-      - "pyproject.toml"
-      - "uv.lock"
-      - "requirements.txt"
-      - ".github/workflows/tests.yaml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The click worker runs the same image as the app and shares its wire contracts (click event schema, edge-cache promotion), but the deploy script only ever recreated the `app` container — releases left the worker silently running the previous image (caught live after v2.0.1: app up 43s, worker up an hour).

- Worker swaps **after** the app passes its health gate, so an app rollback leaves the old matched pair untouched.
- Worker gets its own health gate (`:8001/health` through the FastStream broker).
- If the worker fails to go healthy, **both** app and worker roll back to the previous tag — never a mixed pair.
- `wait_healthy` generalized to take the container name; retry window widened to 36s to cover the worker's healthcheck start period.

No manual prod intervention — the currently-stale worker gets replaced by the first release cut after this merges.

## Summary by Sourcery

Update release workflow to deploy and health-check the click worker alongside the app, ensuring consistent image versions and coordinated rollback behavior.

Build:
- Generalize the health-check helper to accept a container name and extend its retry window for slower-starting services.

CI:
- Enhance the GitHub Actions deploy workflow to swap in the click worker after the app is healthy and to roll back both services together on worker health failures.

Deployment:
- Modify the production deploy script so both app and click worker are updated on release, with independent health gates and unified rollback in case of worker issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment recovery so service health is checked more reliably during swaps and rollbacks.
  * Added separate validation for the main application and background worker, reducing the chance of a partial or failed recovery.
  * Enhanced rollback handling to wait longer for services to become healthy and surface clearer errors when manual intervention is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->