### PR TITLE
fix(auth): propagate user email to CurrentUser for feature-flag email allowlists

### DIFF
--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -41,6 +41,12 @@ class CurrentUser:
     email_verified: bool
     api_key_doc: ApiKeyDoc | None = field(default=None)
     amr: str = "pwd"
+    # Lowercased user email — consumed by FeatureFlagService's ALLOWLIST
+    # rollout (allowlist_emails). Populated from the "email" claim on the
+    # JWT path and from the owning UserDoc on the API-key path. None for
+    # access tokens minted before the claim existed; those users match by
+    # user_id only until their next token refresh.
+    email: str | None = field(default=None)
     # UserDoc.plan value (e.g. "FREE") — consumed by FeatureFlagService's
     # TIER rollout via getattr(user, "tier"). Populated from the DB on the
     # API-key path and from the (future) "plan" claim on the JWT path.
@@ -105,6 +111,9 @@ async def get_current_user(
                 user_id=key.user_id,
                 email_verified=email_verified,
                 api_key_doc=key,
+                # The owning UserDoc is already fetched above for
+                # email_verified — no extra DB hit to carry the email.
+                email=user.email.lower() if user and user.email else None,
                 tier=user.plan.value if user and user.plan else None,
             )
 
@@ -131,11 +140,21 @@ async def get_current_user(
         user_id = ObjectId(claims["sub"])
         email_verified = bool(claims.get("email_verified", False))
         amr = claims.get("amr", ["pwd"])[0]
+        # Tolerant read — access tokens minted before the "email" claim
+        # existed simply carry email=None (never an error). Fixed on the
+        # user's next token refresh.
+        raw_email = claims.get("email")
+        email = (
+            raw_email.strip().lower()
+            if isinstance(raw_email, str) and raw_email.strip()
+            else None
+        )
         structlog.contextvars.bind_contextvars(user_id=str(user_id), auth_method="jwt")
         return CurrentUser(
             user_id=user_id,
             email_verified=email_verified,
             amr=amr,
+            email=email,
             # Not issued yet — the paid-plans launch adds the claim; TIER
             # flag rollouts become a pure data change at that point.
             tier=claims.get("plan"),

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -204,12 +204,12 @@ class FeatureFlagService:
 
 
 def _email_of(user: CurrentUser) -> str | None:
-    """Best-effort email extraction.
+    """Extract the user's lowercased email for allowlist matching.
 
-    ``CurrentUser`` has ``user_id`` always but email is not on the dataclass
-    today. When auth resolves a JWT or API key the user's email lives on the
-    underlying ``UserDoc`` and isn't propagated here. For now allowlist by
-    email is best-effort: if the email field is added later, this picks it
-    up via ``getattr`` without code changes.
+    ``CurrentUser.email`` is populated on both auth paths: from the "email"
+    JWT claim and from the owning ``UserDoc`` on the API-key path. It is
+    ``None`` only for access tokens minted before the claim existed (fixed
+    on the next refresh) — those users still match by user_id. ``getattr``
+    keeps this tolerant of CurrentUser-shaped stubs without the field.
     """
     return getattr(user, "email", None)

--- a/services/token_factory.py
+++ b/services/token_factory.py
@@ -58,6 +58,8 @@ class TokenFactory:
             iat            — issued-at (UTC epoch seconds)
             exp            — expiry (iat + access_token_ttl_seconds)
             amr            — authentication method reference list, e.g. ["pwd"]
+            email          — lowercased email from the user document (consumed
+                             by feature-flag email allowlists via CurrentUser)
             email_verified — bool from the user document
         """
         now = int(datetime.now(timezone.utc).timestamp())
@@ -68,6 +70,7 @@ class TokenFactory:
             "iat": now,
             "exp": now + self._settings.access_token_ttl_seconds,
             "amr": [amr],
+            "email": user.email.lower(),
             "email_verified": user.email_verified,
         }
         return pyjwt.encode(payload, self._signing_key(), algorithm=self._algorithm())

--- a/tests/integration/api_v1/conftest.py
+++ b/tests/integration/api_v1/conftest.py
@@ -53,11 +53,13 @@ def _make_user(
     user_id: ObjectId | None = None,
     email_verified: bool = True,
     api_key_doc: ApiKeyDoc | None = None,
+    email: str | None = None,
 ) -> CurrentUser:
     return CurrentUser(
         user_id=user_id or ObjectId(),
         email_verified=email_verified,
         api_key_doc=api_key_doc,
+        email=email,
     )
 
 

--- a/tests/unit/services/test_auth_service.py
+++ b/tests/unit/services/test_auth_service.py
@@ -146,9 +146,25 @@ class TestJWTHelpers:
         assert payload["iss"] == "spoo.me"
         assert payload["aud"] == "spoo.me.api"
         assert payload["amr"] == ["pwd"]
+        assert payload["email"] == "test@example.com"
         assert payload["email_verified"] is True
         assert "type" not in payload
         assert payload["exp"] - payload["iat"] == 900
+
+    def test_access_token_email_claim_is_lowercased(self):
+        tf = make_token_factory()
+        settings = make_jwt_settings()
+        user = make_user_doc()
+        user = user.model_copy(update={"email": "MixedCase@Example.COM"})
+        token = tf.generate_access_token(user, amr="pwd")
+        payload = pyjwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=["HS256"],
+            audience=settings.jwt_audience,
+            issuer=settings.jwt_issuer,
+        )
+        assert payload["email"] == "mixedcase@example.com"
 
     def test_refresh_token_has_type_field(self):
         tf = make_token_factory()

--- a/tests/unit/services/test_feature_flag_service.py
+++ b/tests/unit/services/test_feature_flag_service.py
@@ -171,6 +171,20 @@ class TestRolloutAllowlist:
         assert await service.is_enabled("test_flag", _user(USER_A)) is True
 
     @pytest.mark.asyncio
+    async def test_email_only_allowlist_denies_stub_without_email_attribute(self):
+        # Pins _email_of's getattr fallback: a user object with NO email
+        # attribute at all (not CurrentUser with email=None) against an
+        # email-ONLY allowlist → graceful deny, no AttributeError.
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_emails=["alice@example.com"],
+        )
+        service, _, _ = make_service(flag=flag)
+        stub = _user(USER_A)  # SimpleNamespace; email attribute omitted
+        assert not hasattr(stub, "email")
+        assert await service.is_enabled("test_flag", stub) is False
+
+    @pytest.mark.asyncio
     async def test_current_user_email_field_flows_through(self):
         """CurrentUser.email (JWT "email" claim / UserDoc email) satisfies
         email-only allowlists — the real dataclass, not a stub."""

--- a/tests/unit/services/test_feature_flag_service.py
+++ b/tests/unit/services/test_feature_flag_service.py
@@ -164,11 +164,73 @@ class TestRolloutAllowlist:
 
     @pytest.mark.asyncio
     async def test_no_email_attribute_falls_back_to_user_id(self):
-        # CurrentUser today doesn't carry email — service must not crash.
+        # Stubs without an email attribute — service must not crash.
         flag = _flag(rollout_type=RolloutType.ALLOWLIST, allowlist_user_ids=[USER_A])
         service, _, _ = make_service(flag=flag)
         # _user() with no email omits the attribute; getattr returns None.
         assert await service.is_enabled("test_flag", _user(USER_A)) is True
+
+    @pytest.mark.asyncio
+    async def test_current_user_email_field_flows_through(self):
+        """CurrentUser.email (JWT "email" claim / UserDoc email) satisfies
+        email-only allowlists — the real dataclass, not a stub."""
+        from dependencies.auth import CurrentUser
+
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_emails=["alice@example.com"],
+        )
+        service, _, _ = make_service(flag=flag)
+        alice = CurrentUser(
+            user_id=USER_A, email_verified=True, email="alice@example.com"
+        )
+        bob = CurrentUser(user_id=USER_B, email_verified=True, email="bob@example.com")
+        assert await service.is_enabled("test_flag", alice) is True
+        assert await service.is_enabled("test_flag", bob) is False
+
+    @pytest.mark.asyncio
+    async def test_current_user_mixed_case_email_matches(self):
+        # Doc validator lowercases allowlist entries; is_user_in_allowlist
+        # lowercases the user's email — any casing on either side matches.
+        from dependencies.auth import CurrentUser
+
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_emails=["Alice@Example.COM"],
+        )
+        service, _, _ = make_service(flag=flag)
+        alice = CurrentUser(
+            user_id=USER_A, email_verified=True, email="ALICE@example.com"
+        )
+        assert await service.is_enabled("test_flag", alice) is True
+
+    @pytest.mark.asyncio
+    async def test_current_user_none_email_denied_without_error(self):
+        # Old access tokens (pre-"email" claim) resolve to email=None —
+        # email-only allowlists deny them, and nothing raises.
+        from dependencies.auth import CurrentUser
+
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_emails=["alice@example.com"],
+        )
+        service, _, _ = make_service(flag=flag)
+        old_token_user = CurrentUser(user_id=USER_A, email_verified=True)
+        assert old_token_user.email is None
+        assert await service.is_enabled("test_flag", old_token_user) is False
+
+    @pytest.mark.asyncio
+    async def test_current_user_none_email_still_matches_by_user_id(self):
+        from dependencies.auth import CurrentUser
+
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_user_ids=[USER_A],
+            allowlist_emails=["alice@example.com"],
+        )
+        service, _, _ = make_service(flag=flag)
+        old_token_user = CurrentUser(user_id=USER_A, email_verified=True)
+        assert await service.is_enabled("test_flag", old_token_user) is True
 
 
 # ── PERCENTAGE ───────────────────────────────────────────────────────────────

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -74,7 +74,11 @@ def make_key_doc(revoked: bool = False, expires_at=None, scopes=None):
     )
 
 
-def make_jwt_token(token_type: str = "access", ttl_seconds: int = 900):
+def make_jwt_token(
+    token_type: str = "access",
+    ttl_seconds: int = 900,
+    email: str | None = None,
+):
     now = datetime.now(timezone.utc)
     payload = {
         "sub": str(USER_OID),
@@ -85,6 +89,8 @@ def make_jwt_token(token_type: str = "access", ttl_seconds: int = 900):
         "iat": now,
         "exp": now + timedelta(seconds=ttl_seconds),
     }
+    if email is not None:
+        payload["email"] = email
     return pyjwt.encode(payload, JWT_SECRET, algorithm="HS256")
 
 
@@ -102,7 +108,7 @@ class TestGetCurrentUser:
     @pytest.mark.asyncio
     async def test_api_key_valid_returns_current_user(self):
         key_doc = make_key_doc()
-        user_mock = MagicMock(email_verified=True)
+        user_mock = MagicMock(email_verified=True, email="Owner@Example.com")
 
         with (
             patch("dependencies.auth.get_settings", return_value=make_settings()),
@@ -119,6 +125,8 @@ class TestGetCurrentUser:
         assert result.user_id == USER_OID
         assert result.api_key_doc == key_doc
         assert result.email_verified is True
+        # Email comes from the owning UserDoc (already fetched), lowercased.
+        assert result.email == "owner@example.com"
 
     @pytest.mark.asyncio
     async def test_api_key_revoked_returns_none(self):
@@ -191,6 +199,70 @@ class TestGetCurrentUser:
         assert result.user_id == USER_OID
         assert result.email_verified is True
         assert result.api_key_doc is None
+
+    @pytest.mark.asyncio
+    async def test_jwt_email_claim_populates_current_user_lowercased(self):
+        token = make_jwt_token(email="Alice@Example.COM")
+        req = make_request(auth_header=f"Bearer {token}")
+
+        with patch("dependencies.auth.get_settings", return_value=make_settings()):
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is not None
+        assert result.email == "alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_jwt_without_email_claim_yields_none_email(self):
+        # Old access tokens minted before the "email" claim existed must
+        # still authenticate — email is simply None, never an error.
+        token = make_jwt_token()
+        req = make_request(auth_header=f"Bearer {token}")
+
+        with patch("dependencies.auth.get_settings", return_value=make_settings()):
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is not None
+        assert result.email is None
+
+    @pytest.mark.asyncio
+    async def test_jwt_blank_email_claim_yields_none_email(self):
+        token = make_jwt_token(email="   ")
+        req = make_request(auth_header=f"Bearer {token}")
+
+        with patch("dependencies.auth.get_settings", return_value=make_settings()):
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is not None
+        assert result.email is None
+
+    @pytest.mark.asyncio
+    async def test_token_factory_round_trip_populates_email(self):
+        # Mint with the real TokenFactory → resolve via get_current_user:
+        # the email claim survives the round trip and is lowercased.
+        from schemas.models.user import UserDoc
+        from services.token_factory import TokenFactory
+
+        user_doc = UserDoc.from_mongo(
+            {
+                "_id": USER_OID,
+                "email": "Round.Trip@Example.COM",
+                "email_verified": True,
+                "user_name": "Round Trip",
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
+        )
+        token = TokenFactory(make_jwt_settings()).generate_access_token(
+            user_doc, amr="pwd"
+        )
+        req = make_request(auth_header=f"Bearer {token}")
+
+        with patch("dependencies.auth.get_settings", return_value=make_settings()):
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is not None
+        assert result.user_id == USER_OID
+        assert result.email == "round.trip@example.com"
 
     @pytest.mark.asyncio
     async def test_jwt_refresh_token_rejected(self):

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -236,6 +236,21 @@ class TestGetCurrentUser:
         assert result.email is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_email", [42, ["alice@example.com"]])
+    async def test_jwt_non_string_email_claim_yields_none_email(self, bad_email):
+        # A token whose "email" claim is not a string (int, list, …) must
+        # still authenticate — the claim parses to None, never an error.
+        token = make_jwt_token(email=bad_email)
+        req = make_request(auth_header=f"Bearer {token}")
+
+        with patch("dependencies.auth.get_settings", return_value=make_settings()):
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is not None
+        assert result.user_id == USER_OID
+        assert result.email is None
+
+    @pytest.mark.asyncio
     async def test_token_factory_round_trip_populates_email(self):
         # Mint with the real TokenFactory → resolve via get_current_user:
         # the email claim survives the round trip and is lowercased.


### PR DESCRIPTION
## The bug

Feature-flag email allowlisting was a **silent no-op**. `FeatureFlagDoc.allowlist_emails` is documented, validated (lowercased by a field validator), and consulted by `FeatureFlagService.is_enabled` via `flag.is_user_in_allowlist(user.user_id, _email_of(user))` — but `_email_of` is `getattr(user, "email", None)` and `CurrentUser` never had an `email` field. The email arm always compared against `None`, so every email-configured allowlist silently denied. Only `allowlist_user_ids` ever worked.

## The fix (claims-based, no DB hits)

- **`CurrentUser.email: str | None = None`** — lowercased, consumed by the ALLOWLIST rollout.
- **Mint time** (`TokenFactory.generate_access_token`): access tokens now carry an `"email"` claim, lowercased from the `UserDoc`. All mint sites (credentials, oauth `_make_tokens`, device, verification, refresh) funnel through this one method.
- **JWT path** (`get_current_user`): reads the claim tolerantly — non-string or blank values parse to `None`, never an error. Preserves the no-DB-hit property of the JWT path.
- **API-key path**: the owning `UserDoc` was *already* fetched for `email_verified`, so the email is populated from it — zero additional DB hits.
- `_email_of` in `FeatureFlagService` is unchanged in behavior (it `getattr`s, so it picks the field up automatically); its docstring no longer claims the email "isn't propagated".

## Old-token behavior

Access tokens minted before this change lack the claim: they still authenticate fine, resolve with `email=None`, and email-only allowlists deny them gracefully (user-id allowlist entries still match). The email arm starts working on the user's next token refresh — the refresh flow re-fetches the `UserDoc` and re-mints through the same factory, so it self-heals within one access-token TTL.

## Security note

Carrying the email in JWT claims is standard practice (it's a registered OIDC claim, same tier as the existing `email_verified`); tokens are transported via HttpOnly cookies, and JWTs were never a confidentiality boundary.

## Tests

- Real-`CurrentUser` allowlist tests: email-only match, mixed-case doc/user match via lowercasing, `email=None` (old token) denies without raising, `None`-email still matches by user_id.
- `get_current_user`: email claim lowercased, missing claim → `None`, blank claim → `None`, API-key path populates from `UserDoc`.
- Full round-trip: `TokenFactory` mint → `get_current_user` decode → `CurrentUser.email` populated and lowercased.
- Mint-time claim assertions in the existing token-claims tests.

`uv run pytest -q`: **2080 passed** in ~15s. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Propagate user email into auth context and JWTs so feature-flag email allowlists function correctly while preserving backward compatibility for existing tokens.

New Features:
- Expose a lowercased email field on CurrentUser populated from JWT claims or the owning UserDoc for API key auth.

Bug Fixes:
- Ensure feature-flag email allowlists correctly evaluate users by propagating email into CurrentUser and using it in allowlist checks.

Enhancements:
- Include a lowercased email claim in access tokens generated by TokenFactory for consistent downstream usage.

Tests:
- Add unit tests covering JWT and API-key paths populating CurrentUser.email, behavior with missing or blank email claims, round-trip token decoding, and feature-flag allowlist evaluation with various email and user_id scenarios.