### PR TITLE
feat: X-Error-Code header + edge-composed error bodies

### DIFF
--- a/config.py
+++ b/config.py
@@ -418,6 +418,12 @@ class AppSettings(BaseSettings):
     # cutover; delete the flag once the old UI is retired.
     onboarding_redirect_enabled: bool = False
 
+    # Our-deployment-only: intercepted HTML error statuses return empty
+    # bodies + X-Error-Code so Caddy can compose the Next error page at the
+    # edge. Flip EDGE_COMPOSED_ERRORS=true at frontend cutover; self-hosters
+    # never set it and keep the branded error.html exactly as today.
+    edge_composed_errors: bool = False
+
     @cached_property
     def system_default_domain(self) -> str:
         """Canonical fqdn for shorts created without an explicit custom domain."""

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -69,8 +69,13 @@ def _wants_json(request: Request) -> bool:
 
 
 # Statuses the edge intercepts when EDGE_COMPOSED_ERRORS is on — must stay
-# in sync with the Caddy handle_response matcher and routes/redirect_routes.py.
-_EDGE_INTERCEPTED_STATUSES = {404, 410, 429, 451, 500}
+# in sync with the Caddy handle_response matcher. Two intentionally
+# different sets: the app-level handlers below hand every intercepted
+# status to the edge, while the redirect hot path
+# (routes/redirect_routes.py) only intercepts resolve failures — its 403
+# bot-block page always keeps its server-rendered body.
+EDGE_INTERCEPTED_STATUSES = {404, 410, 429, 451, 500}
+REDIRECT_EDGE_INTERCEPTED_STATUSES = {404, 410, 451}
 
 
 def _error_html(
@@ -87,7 +92,7 @@ def _error_html(
     settings = getattr(request.app.state, "settings", None)
     if (
         getattr(settings, "edge_composed_errors", False)
-        and status_code in _EDGE_INTERCEPTED_STATUSES
+        and status_code in EDGE_INTERCEPTED_STATUSES
         and request.method in {"GET", "HEAD"}
     ):
         return Response(status_code=status_code, headers={"X-Error-Code": slug})

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -68,12 +68,10 @@ def _wants_json(request: Request) -> bool:
     )
 
 
-# Statuses the edge intercepts when EDGE_COMPOSED_ERRORS is on — must stay
-# in sync with the Caddy handle_response matcher. Two intentionally
-# different sets: the app-level handlers below hand every intercepted
-# status to the edge, while the redirect hot path
-# (routes/redirect_routes.py) only intercepts resolve failures — its 403
-# bot-block page always keeps its server-rendered body.
+# Statuses that return EMPTY bodies under EDGE_COMPOSED_ERRORS — must stay
+# a subset of what Caddy's handle_response matcher composes, or visitors
+# get blank pages (verify at cutover; redirect ⊆ app-level is test-pinned).
+# The redirect set is smaller on purpose: its 403 bot-block keeps its body.
 EDGE_INTERCEPTED_STATUSES = {404, 410, 429, 451, 500}
 REDIRECT_EDGE_INTERCEPTED_STATUSES = {404, 410, 451}
 
@@ -88,7 +86,8 @@ def _error_html(
     the template entirely — Caddy throws the body away and composes the Next
     error page, so rendering it would be wasted work.
     """
-    # getattr-with-default: tests build bare apps without lifespan state.
+    # settings can be absent (app built without lifespan) — default-off is
+    # the fail-safe.
     settings = getattr(request.app.state, "settings", None)
     if (
         getattr(settings, "edge_composed_errors", False)

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -68,8 +68,30 @@ def _wants_json(request: Request) -> bool:
     )
 
 
-def _error_html(request: Request, status_code: int, message: str) -> Response:
-    """Render error.html template for browser requests."""
+# Statuses the edge intercepts when EDGE_COMPOSED_ERRORS is on — must stay
+# in sync with the Caddy handle_response matcher and routes/redirect_routes.py.
+_EDGE_INTERCEPTED_STATUSES = {404, 410, 429, 451, 500}
+
+
+def _error_html(
+    request: Request, status_code: int, message: str, slug: str
+) -> Response:
+    """Render error.html template for browser requests.
+
+    Every HTML error self-describes via ``X-Error-Code`` so the edge can
+    route on it. With ``edge_composed_errors`` on, intercepted statuses skip
+    the template entirely — Caddy throws the body away and composes the Next
+    error page, so rendering it would be wasted work.
+    """
+    # getattr-with-default: tests build bare apps without lifespan state.
+    settings = getattr(request.app.state, "settings", None)
+    if (
+        getattr(settings, "edge_composed_errors", False)
+        and status_code in _EDGE_INTERCEPTED_STATUSES
+        and request.method in {"GET", "HEAD"}
+    ):
+        return Response(status_code=status_code, headers={"X-Error-Code": slug})
+
     host_url = str(request.base_url)
     return templates.TemplateResponse(
         request,
@@ -80,6 +102,7 @@ def _error_html(request: Request, status_code: int, message: str) -> Response:
             "host_url": host_url,
         },
         status_code=status_code,
+        headers={"X-Error-Code": slug},
     )
 
 
@@ -90,7 +113,9 @@ def register_error_handlers(app: FastAPI) -> None:
     async def app_error_handler(request: Request, exc: AppError) -> Response:
         if _wants_json(request):
             return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
-        return _error_html(request, exc.status_code, exc.message.upper())
+        return _error_html(
+            request, exc.status_code, exc.message.upper(), exc.error_code
+        )
 
     @app.exception_handler(RequestValidationError)
     async def request_validation_error_handler(
@@ -118,7 +143,7 @@ def register_error_handlers(app: FastAPI) -> None:
                 status_code=429,
                 content={"error": "Too many requests", "code": "rate_limit_exceeded"},
             )
-        return _error_html(request, 429, "TOO MANY REQUESTS")
+        return _error_html(request, 429, "TOO MANY REQUESTS", "rate_limit_exceeded")
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception) -> Response:
@@ -136,4 +161,4 @@ def register_error_handlers(app: FastAPI) -> None:
                     "code": "internal_error",
                 },
             )
-        return _error_html(request, 500, "INTERNAL SERVER ERROR")
+        return _error_html(request, 500, "INTERNAL SERVER ERROR", "internal_error")

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -101,7 +101,8 @@ def _error_page(request: Request, code: str, message: str, status: int) -> Respo
         )
 
     slug = _ERROR_SLUGS.get(code)
-    # getattr-with-default: tests build bare apps without lifespan state.
+    # settings can be absent (app built without lifespan) — default-off is
+    # the fail-safe.
     settings = getattr(request.app.state, "settings", None)
     if (
         slug is not None

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -23,6 +23,7 @@ from errors import (
 )
 from infrastructure.logging import get_logger, should_sample
 from infrastructure.templates import templates
+from middleware.error_handler import REDIRECT_EDGE_INTERCEPTED_STATUSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.enums.domain_status import DomainStatus
 from schemas.models.url import SchemaVersion
@@ -47,15 +48,16 @@ _TENANT_ERROR_COPY = {
 _NOINDEX_HEADER = "noindex, nofollow, noarchive"
 
 # Machine-readable slugs for the system-default error page so the edge can
-# route on X-Error-Code. Only 404/410/451 are edge-intercepted; 403 keeps its
-# body always (bot blocks stay server-rendered) but still self-describes.
+# route on X-Error-Code. Only REDIRECT_EDGE_INTERCEPTED_STATUSES (defined
+# next to the app-level set in middleware/error_handler.py) skip the body;
+# 403 keeps its body always (bot blocks stay server-rendered) but still
+# self-describes.
 _ERROR_SLUGS = {
     "404": "not_found",
     "410": "gone",
     "451": "blocked",
     "403": "forbidden",
 }
-_EDGE_INTERCEPTED_CODES = {"404", "410", "451"}
 
 
 def _error_page(request: Request, code: str, message: str, status: int) -> Response:
@@ -104,7 +106,7 @@ def _error_page(request: Request, code: str, message: str, status: int) -> Respo
     if (
         slug is not None
         and getattr(settings, "edge_composed_errors", False)
-        and code in _EDGE_INTERCEPTED_CODES
+        and status in REDIRECT_EDGE_INTERCEPTED_STATUSES
         and request.method in {"GET", "HEAD"}
     ):
         # Caddy discards the body and composes the Next error page — skip

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -46,6 +46,17 @@ _TENANT_ERROR_COPY = {
 }
 _NOINDEX_HEADER = "noindex, nofollow, noarchive"
 
+# Machine-readable slugs for the system-default error page so the edge can
+# route on X-Error-Code. Only 404/410/451 are edge-intercepted; 403 keeps its
+# body always (bot blocks stay server-rendered) but still self-describes.
+_ERROR_SLUGS = {
+    "404": "not_found",
+    "410": "gone",
+    "451": "blocked",
+    "403": "forbidden",
+}
+_EDGE_INTERCEPTED_CODES = {"404", "410", "451"}
+
 
 def _error_page(request: Request, code: str, message: str, status: int) -> Response:
     """Render the error page for a resolve/redirect failure.
@@ -87,6 +98,19 @@ def _error_page(request: Request, code: str, message: str, status: int) -> Respo
             headers={"X-Robots-Tag": _NOINDEX_HEADER},
         )
 
+    slug = _ERROR_SLUGS.get(code)
+    # getattr-with-default: tests build bare apps without lifespan state.
+    settings = getattr(request.app.state, "settings", None)
+    if (
+        slug is not None
+        and getattr(settings, "edge_composed_errors", False)
+        and code in _EDGE_INTERCEPTED_CODES
+        and request.method in {"GET", "HEAD"}
+    ):
+        # Caddy discards the body and composes the Next error page — skip
+        # the template render on the hot path.
+        return Response(status_code=status, headers={"X-Error-Code": slug})
+
     return templates.TemplateResponse(
         request,
         "error.html",
@@ -96,6 +120,7 @@ def _error_page(request: Request, code: str, message: str, status: int) -> Respo
             "host_url": str(request.base_url),
         },
         status_code=status,
+        headers={"X-Error-Code": slug} if slug is not None else None,
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,12 +5,25 @@ Shared fixtures for all integration tests.
 from __future__ import annotations
 
 import os
+from unittest.mock import patch
 
 import pytest
 
 os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 
 from middleware.rate_limiter import limiter
+
+
+@pytest.fixture
+def edge_composed_errors():
+    """Flip EDGE_COMPOSED_ERRORS on for apps built inside the test.
+
+    Every test app builder constructs ``AppSettings()`` at call time, so
+    patching the env for the test's duration is enough — no lifespan surgery
+    needed.
+    """
+    with patch.dict(os.environ, {"EDGE_COMPOSED_ERRORS": "true"}, clear=False):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.staticfiles import StaticFiles
@@ -115,6 +115,11 @@ async def page_validation(request: Request):
     raise ValidationError("bad page input")
 
 
+@_page_router.post("/page/trigger-not-found-post")
+async def page_not_found_post(request: Request):
+    raise NotFoundError("page not found")
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -192,6 +197,7 @@ def test_app_error_html_on_page_route():
         resp = c.get("/page/trigger-not-found")
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "not_found"
 
 
 def test_app_error_json_when_accept_json():
@@ -300,6 +306,7 @@ def test_unhandled_exception_returns_500_html():
         resp = c.get("/page/trigger-unhandled")
     assert resp.status_code == 500
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "internal_error"
 
 
 # ── Error shape verification ─────────────────────────────────────────────────
@@ -368,6 +375,7 @@ def test_page_forbidden_returns_html():
         resp = c.get("/page/trigger-forbidden")
     assert resp.status_code == 403
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "forbidden"
 
 
 def test_page_gone_returns_html():
@@ -377,3 +385,72 @@ def test_page_gone_returns_html():
         resp = c.get("/page/trigger-gone")
     assert resp.status_code == 410
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "gone"
+
+
+# ── Edge-composed errors (EDGE_COMPOSED_ERRORS) ──────────────────────────────
+
+
+def _build_edge_composed_app() -> FastAPI:
+    """Build the test app with the edge-composition flag on.
+
+    AppSettings is constructed inside _build_test_app, so patching the env
+    around the build is enough — no lifespan surgery needed.
+    """
+    with patch.dict(os.environ, {"EDGE_COMPOSED_ERRORS": "true"}, clear=False):
+        return _build_test_app()
+
+
+def test_edge_composed_intercepted_status_returns_empty_body():
+    """Flag on: intercepted statuses return no body — Caddy composes the page."""
+    app = _build_edge_composed_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/page/trigger-not-found")
+    assert resp.status_code == 404
+    assert resp.headers["X-Error-Code"] == "not_found"
+    assert resp.content == b""
+
+
+def test_edge_composed_500_returns_empty_body():
+    """Flag on: unhandled exceptions on page routes also skip the template."""
+    app = _build_edge_composed_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/page/trigger-unhandled")
+    assert resp.status_code == 500
+    assert resp.headers["X-Error-Code"] == "internal_error"
+    assert resp.content == b""
+
+
+def test_edge_composed_non_intercepted_status_keeps_body():
+    """403 is not in the intercept set — the branded page still renders."""
+    app = _build_edge_composed_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/page/trigger-forbidden")
+    assert resp.status_code == 403
+    assert resp.headers["X-Error-Code"] == "forbidden"
+    assert "text/html" in resp.headers["content-type"]
+    assert resp.content
+
+
+def test_edge_composed_post_keeps_body():
+    """Flag on: non-GET/HEAD methods keep the rendered body (edge only
+    intercepts GET/HEAD)."""
+    app = _build_edge_composed_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.post("/page/trigger-not-found-post")
+    assert resp.status_code == 404
+    assert resp.headers["X-Error-Code"] == "not_found"
+    assert "text/html" in resp.headers["content-type"]
+    assert resp.content
+
+
+def test_edge_composed_json_path_unaffected():
+    """Flag on: JSON error responses are byte-identical to flag-off."""
+    app = _build_edge_composed_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/api/v1/trigger-not-found")
+    assert resp.status_code == 404
+    data = resp.json()
+    assert data["error"] == "resource not found"
+    assert data["code"] == "not_found"
+    assert "X-Error-Code" not in resp.headers

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -404,6 +404,17 @@ def test_page_gone_returns_html():
 # ── Edge-composed errors (EDGE_COMPOSED_ERRORS) ──────────────────────────────
 
 
+def test_redirect_intercept_set_is_subset_of_app_level_set():
+    """An origin-empty status the edge doesn't compose is a blank page —
+    the hot path may only empty-body what the app-level set covers."""
+    from middleware.error_handler import (
+        EDGE_INTERCEPTED_STATUSES,
+        REDIRECT_EDGE_INTERCEPTED_STATUSES,
+    )
+
+    assert REDIRECT_EDGE_INTERCEPTED_STATUSES <= EDGE_INTERCEPTED_STATUSES
+
+
 @pytest.mark.parametrize(
     ("path", "status", "slug"),
     [

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import os
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
@@ -23,10 +24,12 @@ os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 from config import AppSettings
 from errors import (
     AuthenticationError,
+    BlockedUrlError,
     ConflictError,
     ForbiddenError,
     GoneError,
     NotFoundError,
+    RateLimitError,
     ValidationError,
 )
 from middleware.error_handler import register_error_handlers
@@ -103,6 +106,16 @@ async def page_forbidden(request: Request):
 @_page_router.get("/page/trigger-gone")
 async def page_gone(request: Request):
     raise GoneError("page expired")
+
+
+@_page_router.get("/page/trigger-blocked")
+async def page_blocked(request: Request):
+    raise BlockedUrlError("page blocked")
+
+
+@_page_router.get("/page/trigger-rate-limited")
+async def page_rate_limited(request: Request):
+    raise RateLimitError("too many requests")
 
 
 @_page_router.get("/page/trigger-unhandled")
@@ -391,39 +404,35 @@ def test_page_gone_returns_html():
 # ── Edge-composed errors (EDGE_COMPOSED_ERRORS) ──────────────────────────────
 
 
-def _build_edge_composed_app() -> FastAPI:
-    """Build the test app with the edge-composition flag on.
+@pytest.mark.parametrize(
+    ("path", "status", "slug"),
+    [
+        ("/page/trigger-not-found", 404, "not_found"),
+        ("/page/trigger-gone", 410, "gone"),
+        ("/page/trigger-rate-limited", 429, "rate_limit_exceeded"),
+        ("/page/trigger-blocked", 451, "blocked"),
+        ("/page/trigger-unhandled", 500, "internal_error"),
+    ],
+)
+def test_edge_composed_intercepted_status_returns_empty_body(
+    edge_composed_errors, path, status, slug
+):
+    """Flag on: intercepted statuses return no body — Caddy composes the page.
 
-    AppSettings is constructed inside _build_test_app, so patching the env
-    around the build is enough — no lifespan surgery needed.
+    Covers the full EDGE_INTERCEPTED_STATUSES set so an accidental change to
+    the set fails here.
     """
-    with patch.dict(os.environ, {"EDGE_COMPOSED_ERRORS": "true"}, clear=False):
-        return _build_test_app()
-
-
-def test_edge_composed_intercepted_status_returns_empty_body():
-    """Flag on: intercepted statuses return no body — Caddy composes the page."""
-    app = _build_edge_composed_app()
+    app = _build_test_app()
     with TestClient(app, raise_server_exceptions=False) as c:
-        resp = c.get("/page/trigger-not-found")
-    assert resp.status_code == 404
-    assert resp.headers["X-Error-Code"] == "not_found"
+        resp = c.get(path)
+    assert resp.status_code == status
+    assert resp.headers["X-Error-Code"] == slug
     assert resp.content == b""
 
 
-def test_edge_composed_500_returns_empty_body():
-    """Flag on: unhandled exceptions on page routes also skip the template."""
-    app = _build_edge_composed_app()
-    with TestClient(app, raise_server_exceptions=False) as c:
-        resp = c.get("/page/trigger-unhandled")
-    assert resp.status_code == 500
-    assert resp.headers["X-Error-Code"] == "internal_error"
-    assert resp.content == b""
-
-
-def test_edge_composed_non_intercepted_status_keeps_body():
+def test_edge_composed_non_intercepted_status_keeps_body(edge_composed_errors):
     """403 is not in the intercept set — the branded page still renders."""
-    app = _build_edge_composed_app()
+    app = _build_test_app()
     with TestClient(app, raise_server_exceptions=False) as c:
         resp = c.get("/page/trigger-forbidden")
     assert resp.status_code == 403
@@ -432,10 +441,10 @@ def test_edge_composed_non_intercepted_status_keeps_body():
     assert resp.content
 
 
-def test_edge_composed_post_keeps_body():
+def test_edge_composed_post_keeps_body(edge_composed_errors):
     """Flag on: non-GET/HEAD methods keep the rendered body (edge only
     intercepts GET/HEAD)."""
-    app = _build_edge_composed_app()
+    app = _build_test_app()
     with TestClient(app, raise_server_exceptions=False) as c:
         resp = c.post("/page/trigger-not-found-post")
     assert resp.status_code == 404
@@ -444,9 +453,9 @@ def test_edge_composed_post_keeps_body():
     assert resp.content
 
 
-def test_edge_composed_json_path_unaffected():
+def test_edge_composed_json_path_unaffected(edge_composed_errors):
     """Flag on: JSON error responses are byte-identical to flag-off."""
-    app = _build_edge_composed_app()
+    app = _build_test_app()
     with TestClient(app, raise_server_exceptions=False) as c:
         resp = c.get("/api/v1/trigger-not-found")
     assert resp.status_code == 404

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -140,6 +140,7 @@ def test_rate_limit_html_response_on_page_route():
         resp = c.get("/page/test-limited")
     assert resp.status_code == 429
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "rate_limit_exceeded"
 
 
 def test_rate_limit_key_uses_ip_for_anonymous():

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -143,6 +143,19 @@ def test_rate_limit_html_response_on_page_route():
     assert resp.headers["X-Error-Code"] == "rate_limit_exceeded"
 
 
+def test_rate_limit_html_edge_composed_returns_empty_body(edge_composed_errors):
+    """Flag on: the HTML 429 skips the template — Caddy composes the page."""
+    _reset_limiter()
+    router = _make_limited_router("1/minute", prefix="/page")
+    app = _build_test_app(extra_routers=[router])
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.get("/page/test-limited")
+        resp = c.get("/page/test-limited")
+    assert resp.status_code == 429
+    assert resp.headers["X-Error-Code"] == "rate_limit_exceeded"
+    assert resp.content == b""
+
+
 def test_rate_limit_key_uses_ip_for_anonymous():
     """Anonymous requests (no auth header, no cookie) should be keyed by client IP."""
     _reset_limiter()

--- a/tests/integration/test_redirect_routes.py
+++ b/tests/integration/test_redirect_routes.py
@@ -8,8 +8,7 @@ The redirect route emits ClickEvents through a ClickEventSink; these tests overr
 
 from __future__ import annotations
 
-import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
@@ -147,20 +146,54 @@ def test_redirect_expired_url_returns_410_html():
     assert resp.headers["X-Error-Code"] == "gone"
 
 
-def test_redirect_not_found_edge_composed_returns_empty_body():
+def test_redirect_not_found_edge_composed_returns_empty_body(edge_composed_errors):
     """EDGE_COMPOSED_ERRORS on: the hot-path 404 skips the template — Caddy
     discards the body and composes the Next error page from X-Error-Code."""
     url_svc = MagicMock()
     url_svc.resolve = AsyncMock(side_effect=NotFoundError("not found"))
-    # build_test_app constructs AppSettings() at call time — patching the
-    # env around the build is enough to flip the flag.
-    with patch.dict(os.environ, {"EDGE_COMPOSED_ERRORS": "true"}, clear=False):
-        app = _build_app(url_svc)
+    app = _build_app(url_svc)
     with TestClient(app) as client:
         resp = client.get("/notexist")
     assert resp.status_code == 404
     assert resp.headers["X-Error-Code"] == "not_found"
     assert resp.content == b""
+
+
+def test_redirect_expired_edge_composed_returns_empty_body(edge_composed_errors):
+    """EDGE_COMPOSED_ERRORS on: the hot-path 410 also skips the template."""
+    url_svc = MagicMock()
+    url_svc.resolve = AsyncMock(side_effect=GoneError("expired"))
+    app = _build_app(url_svc)
+    with TestClient(app) as client:
+        resp = client.get("/expired1")
+    assert resp.status_code == 410
+    assert resp.headers["X-Error-Code"] == "gone"
+    assert resp.content == b""
+
+
+def test_redirect_blocked_edge_composed_returns_empty_body(edge_composed_errors):
+    """EDGE_COMPOSED_ERRORS on: the hot-path 451 also skips the template."""
+    url_svc = MagicMock()
+    url_svc.resolve = AsyncMock(side_effect=BlockedUrlError("blocked"))
+    app = _build_app(url_svc)
+    with TestClient(app) as client:
+        resp = client.get("/blocked1")
+    assert resp.status_code == 451
+    assert resp.headers["X-Error-Code"] == "blocked"
+    assert resp.content == b""
+
+
+def test_redirect_bot_block_edge_composed_keeps_body(edge_composed_errors):
+    """403 is excluded from the redirect intercept set — the bot-block page
+    stays server-rendered while still self-describing via X-Error-Code."""
+    url_data = _make_url_cache(schema="v1", block_bots=True)
+    app = _build_app(_mock_url_service(url_data, schema="v1"))
+    with TestClient(app) as client:
+        resp = client.get("/abc123", headers={"User-Agent": BOT_UA})
+    assert resp.status_code == 403
+    assert resp.headers["X-Error-Code"] == "forbidden"
+    assert "text/html" in resp.headers["content-type"]
+    assert resp.content
 
 
 def test_redirect_password_protected_no_password_returns_401_html():

--- a/tests/integration/test_redirect_routes.py
+++ b/tests/integration/test_redirect_routes.py
@@ -8,7 +8,8 @@ The redirect route emits ClickEvents through a ClickEventSink; these tests overr
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -121,6 +122,7 @@ def test_redirect_not_found_returns_404_html():
         resp = client.get("/notexist")
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "not_found"
 
 
 def test_redirect_blocked_url_returns_451_html():
@@ -131,6 +133,7 @@ def test_redirect_blocked_url_returns_451_html():
         resp = client.get("/blocked1")
     assert resp.status_code == 451
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "blocked"
 
 
 def test_redirect_expired_url_returns_410_html():
@@ -141,6 +144,23 @@ def test_redirect_expired_url_returns_410_html():
         resp = client.get("/expired1")
     assert resp.status_code == 410
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "gone"
+
+
+def test_redirect_not_found_edge_composed_returns_empty_body():
+    """EDGE_COMPOSED_ERRORS on: the hot-path 404 skips the template — Caddy
+    discards the body and composes the Next error page from X-Error-Code."""
+    url_svc = MagicMock()
+    url_svc.resolve = AsyncMock(side_effect=NotFoundError("not found"))
+    # build_test_app constructs AppSettings() at call time — patching the
+    # env around the build is enough to flip the flag.
+    with patch.dict(os.environ, {"EDGE_COMPOSED_ERRORS": "true"}, clear=False):
+        app = _build_app(url_svc)
+    with TestClient(app) as client:
+        resp = client.get("/notexist")
+    assert resp.status_code == 404
+    assert resp.headers["X-Error-Code"] == "not_found"
+    assert resp.content == b""
 
 
 def test_redirect_password_protected_no_password_returns_401_html():
@@ -194,6 +214,7 @@ def test_redirect_sink_forbidden_blocks_redirect():
         resp = client.get("/abc123", headers={"User-Agent": BROWSER_UA})
     assert resp.status_code == 403
     assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "forbidden"
 
 
 def test_redirect_sink_unexpected_error_still_redirects():

--- a/tests/smoke/test_config_defaults.py
+++ b/tests/smoke/test_config_defaults.py
@@ -84,6 +84,16 @@ def test_flask_secret_key_fallback() -> None:
         assert settings.secret_key == "flask-secret-123"
 
 
+def test_default_edge_composed_errors_false() -> None:
+    """EDGE_COMPOSED_ERRORS defaults off — self-hosters keep branded error pages.
+
+    Verify the schema default rather than the resolved value so a local .env
+    can't flip this test.
+    """
+    field = AppSettings.model_fields["edge_composed_errors"]
+    assert field.default is False
+
+
 def test_is_production_false_for_development() -> None:
     """is_production should return False for development env."""
     settings = AppSettings()


### PR DESCRIPTION
The backend half of the error-pages system: HTML error responses self-describe so the edge can compose branded Next pages, while self-hosters keep today's behavior byte-for-byte. Companion frontend PR: spoo-me/frontend#5. Caddy wiring lands separately after the beta handle_response spike.

## What

- `X-Error-Code: <error_code slug>` on every HTML error response, on BOTH render paths:
  - `middleware/error_handler.py::_error_html` (AppError → its slug; slowapi 429 → `rate_limit_exceeded`; catch-all → `internal_error`)
  - `routes/redirect_routes.py::_error_page` system-default branch (`not_found` / `gone` / `blocked` / `forbidden`) — the hot path renders its own errors and never reaches the app-level handler, so it needs its own treatment. Tenant branch untouched.
- `EDGE_COMPOSED_ERRORS` (new AppSettings bool, default **false**): when on, intercepted statuses ({404, 410, 429, 451, 500} app-level; {404, 410, 451} hot path) return an empty body + header on GET/HEAD — Caddy discards the body anyway, so the template render is skipped. 403s (bot block, password) always keep their bodies.
- JSON error contract untouched, byte-for-byte. `_wants_json` untouched.
- The 400 password-form path carries no slug today and gets no header (one dict line when needed).

## Tests

75 pass across the four touched files; full integration + smoke sweep 522 pass (includes the tenant and custom-domain error paths). New coverage: header slugs on every HTML error family, flag-on empty bodies for 404/500 and the hot-path 404, 403 body retention, POST body retention, JSON untouched, config default.

## Not this PR

- Caddy `handle_response` blocks (beta spike first — placeholder syntax + status preservation verified empirically before prod).
- Splitting the `blocked` slug into safety-vs-takedown (the 451 page copy keys on the slug, so finer wordings come free later).
- Accept-header gating for `*/*` scanner probes (lives in Caddy's matcher, not here).

## Summary by Sourcery

Introduce machine-readable X-Error-Code headers on HTML error responses and add an edge_composed_errors flag to allow edge infrastructure to compose branded error pages while preserving existing JSON contracts and default behavior.

New Features:
- Expose X-Error-Code slugs on all HTML error responses from both application and redirect error paths.
- Add the EDGE_COMPOSED_ERRORS configuration flag to allow intercepted HTML error statuses to return empty bodies for edge-composed error pages while keeping 403 and non-GET/HEAD responses rendered.

Tests:
- Extend integration, redirect, rate-limiting, and config smoke tests to cover X-Error-Code headers, edge-composed empty-body behavior, JSON error invariants, and the new configuration default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added machine-readable `X-Error-Code` headers to relevant HTML error responses (e.g., not found, forbidden, rate limit exceeded, gone/blocked, and server errors).
  - Introduced an optional edge-composed error mode for selected statuses that returns an empty body on GET/HEAD while still sending `X-Error-Code`.
  - Preserved the existing branded HTML error-page behavior by default, and kept JSON API error responses unchanged.
- **Tests**
  - Expanded integration and smoke test coverage for error handling, redirects, and rate limiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->