### PR TITLE
feat: public link preview endpoint

### DIFF
--- a/dependencies/services.py
+++ b/dependencies/services.py
@@ -31,6 +31,7 @@ from services.feature_flag_service import FeatureFlagService
 from services.oauth_service import OAuthService
 from services.page_layout_service import PageLayoutService
 from services.profile_picture_service import ProfilePictureService
+from services.public_preview_service import PublicPreviewService
 from services.stats_service import StatsService
 from services.url_service import UrlService
 
@@ -119,6 +120,10 @@ def get_custom_domain_service(request: Request) -> CustomDomainService:
     return request.app.state.custom_domain_service
 
 
+def get_public_preview_service(request: Request) -> PublicPreviewService:
+    return request.app.state.public_preview_service
+
+
 # ── Annotated type aliases — Depends shortcuts for route signatures ──────────
 
 UrlSvc = Annotated[UrlService, Depends(get_url_service)]
@@ -141,3 +146,4 @@ ClickSink = Annotated[ClickEventSink, Depends(get_click_sink)]
 AppGrantRepo = Annotated[AppGrantRepository, Depends(get_app_grant_repo)]
 FeatureFlagSvc = Annotated[FeatureFlagService, Depends(get_feature_flag_service)]
 CustomDomainSvc = Annotated[CustomDomainService, Depends(get_custom_domain_service)]
+PublicPreviewSvc = Annotated[PublicPreviewService, Depends(get_public_preview_service)]

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -56,6 +56,7 @@ from services.mock_dcv_backend import MockDcvBackend
 from services.oauth_service import OAuthService
 from services.page_layout_service import PageLayoutService
 from services.profile_picture_service import ProfilePictureService
+from services.public_preview_service import PublicPreviewService
 from services.stats_service import StatsService
 from services.tenant_resolver import CachedMongoTenantResolver
 from services.token_factory import TokenFactory
@@ -205,6 +206,12 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         click_repo,
         url_repo,
         max_date_range_days=settings.max_date_range_days,
+    )
+    app.state.public_preview_service = PublicPreviewService(
+        url_repo,
+        legacy_repo,
+        emoji_repo,
+        system_default_domain=settings.system_default_domain,
     )
     app.state.export_service = ExportService(
         app.state.stats_service,

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -113,6 +113,11 @@ class Limits:
     # Password-protected URL check
     PASSWORD_CHECK = "10 per minute; 30 per hour"
 
+    # Public link preview (the /{code}+ wire). Like the redirect (which is
+    # limiter-exempt) this endpoint is an existence oracle by design, so it
+    # gets its own bounded budget instead of riding the anon API tier.
+    PUBLIC_PREVIEW = "30 per minute; 2000 per day"
+
 
 # ── Key resolution ───────────────────────────────────────────────────────────
 

--- a/routes/api_v1/__init__.py
+++ b/routes/api_v1/__init__.py
@@ -9,6 +9,7 @@ from routes.api_v1 import (
     management,
     me,
     metadata,
+    public_preview,
     shorten,
     stats,
     urls,
@@ -24,3 +25,4 @@ router.include_router(keys.router)
 router.include_router(custom_domains.router)
 router.include_router(metadata.router)
 router.include_router(me.router)
+router.include_router(public_preview.router)

--- a/routes/api_v1/public_preview.py
+++ b/routes/api_v1/public_preview.py
@@ -1,0 +1,47 @@
+"""GET /api/v1/public/preview/{short_code} — public link preview.
+
+The wire behind the frontend's /{code}+ page. No auth dependency at all:
+the response is identical for everyone, owners included. Resolution is
+status-agnostic (expired / inactive / blocked links still answer 200 with
+their status stated; only truly missing codes 404), but the destination
+rides the wire only while the link is active and not password-protected.
+Ships dark until the frontend + Caddy serve the page.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from dependencies.services import PublicPreviewSvc
+from middleware.openapi import ERROR_RESPONSES, PUBLIC_SECURITY
+from middleware.rate_limiter import Limits, limiter
+from schemas.dto.responses.public_preview import PublicPreviewResponse
+
+router = APIRouter(tags=["Public"])
+
+
+@router.get(
+    "/public/preview/{short_code}",
+    responses=ERROR_RESPONSES,
+    openapi_extra=PUBLIC_SECURITY,
+    operation_id="getPublicPreview",
+    summary="Public Link Preview",
+)
+@limiter.limit(Limits.PUBLIC_PREVIEW)
+async def public_preview(
+    short_code: str,
+    request: Request,
+    preview_service: PublicPreviewSvc,
+) -> PublicPreviewResponse:
+    """Preview where a short link leads before following it.
+
+    Returns the link's resolved facts — status, creation date, whether a
+    password gates it, and (only while the link is active and unlocked)
+    the destination plus every geo-targeted destination, grouped by URL.
+
+    **Authentication**: None. The preview shows the same resolved facts to
+    everyone; owner-set social meta never appears here.
+
+    **Rate Limits**: 30/min, 2,000/day.
+    """
+    return await preview_service.get_preview(short_code)

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, RedirectResponse, Response
@@ -31,6 +31,7 @@ from repositories.legacy.legacy_url_repository import LegacyUrlRepository
 from repositories.url_repository import UrlRepository
 from routes.legacy.helpers import humanize_number, is_positive_integer
 from shared.generators import generate_emoji_alias, generate_short_code
+from shared.url_utils import split_destination
 from shared.validators import (
     is_emoji_alias,
     validate_alias,
@@ -415,20 +416,6 @@ async def result(
 # ── Preview page ──────────────────────────────────────────────────────────────
 
 
-def _split_destination(url: str) -> dict:
-    """Split a destination URL into display parts for the preview template."""
-    parsed = urlparse(url)
-    domain = parsed.netloc or parsed.path.split("/")[0]
-    path = (
-        parsed.path
-        + ("?" + parsed.query if parsed.query else "")
-        + ("#" + parsed.fragment if parsed.fragment else "")
-    )
-    if path == "/":
-        path = ""
-    return {"domain": domain, "path": path, "is_https": parsed.scheme == "https"}
-
-
 @router.get("/{short_code}+")
 @limiter.limit(Limits.SHORTEN_LEGACY)
 async def preview_url(
@@ -537,7 +524,7 @@ async def preview_url(
             },
         )
 
-    default_dest = _split_destination(long_url)
+    default_dest = split_destination(long_url)
 
     # Geo-targeted links list EVERY destination — the preview page is the
     # anti-cloaking transparency surface, so no rule is ever hidden. Grouped
@@ -548,7 +535,7 @@ async def preview_url(
         for code, dest in url_data["geo_rules"].items():
             grouped.setdefault(dest, []).append(code)
         geo_destinations = [
-            {"countries": sorted(codes), **_split_destination(dest)}
+            {"countries": sorted(codes), **split_destination(dest)}
             for dest, codes in grouped.items()
         ]
 

--- a/schemas/dto/responses/public_preview.py
+++ b/schemas/dto/responses/public_preview.py
@@ -1,0 +1,51 @@
+"""
+Response DTOs for GET /api/v1/public/preview/{short_code}.
+
+The wire shape is frozen against the spoo-landing preview page
+(lib/api/public-preview.ts). DTOs serialize only — all derivation
+(status, withholding, destination splitting) lives in
+services/public_preview_service.py.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from schemas.dto.base import ResponseBase
+
+
+class PreviewDestination(ResponseBase):
+    """A destination URL split into display parts."""
+
+    url: str
+    domain: str
+    path: str
+    is_https: bool
+
+
+class PreviewGeoDestination(PreviewDestination):
+    """One geo-rule destination group.
+
+    ``countries`` are ISO 3166-1 alpha-2 codes, sorted ascending — every
+    rule is listed, nothing summarized (anti-cloaking transparency).
+    """
+
+    countries: list[str]
+
+
+class PublicPreviewResponse(ResponseBase):
+    """Response body for the public link preview endpoint.
+
+    ``destination`` and ``geo_destinations`` are non-null only while the
+    link is active and not password-protected — the preview never reveals
+    more than the redirect would.
+    """
+
+    generation: Literal["v1", "v2"]
+    alias: str
+    short_url: str
+    status: Literal["active", "inactive", "expired", "blocked"]
+    created_at: str | None
+    password_protected: bool
+    destination: PreviewDestination | None
+    geo_destinations: list[PreviewGeoDestination] | None

--- a/schemas/dto/responses/public_preview.py
+++ b/schemas/dto/responses/public_preview.py
@@ -38,7 +38,7 @@ class PublicPreviewResponse(ResponseBase):
 
     ``destination`` and ``geo_destinations`` are non-null only while the
     link is active and not password-protected — the preview never reveals
-    more than the redirect would.
+    a destination the redirect would refuse to serve.
     """
 
     generation: Literal["v1", "v2"]

--- a/services/public_preview_service.py
+++ b/services/public_preview_service.py
@@ -5,14 +5,18 @@ Resolves a short code across both URL generations WITHOUT status gating
 (expired / inactive / blocked links still answer; only truly missing codes
 404) and derives the preview wire shape. The safety semantic the page is
 built on: the destination (and geo rules) ride the wire ONLY while the
-link is active and not password-protected — the preview never reveals
-more than the redirect would.
+link is active and not password-protected — the preview never reveals a
+destination the redirect would refuse to serve. For geo-targeted links
+that means enumerating the full country→destination map while a single
+redirect follows only one rule: deliberate anti-cloaking transparency,
+not a leak.
 
 Deliberately does NOT use ``UrlService.resolve`` — it raises on non-active
 statuses and its cache shape lacks ``created_at``. Raw docs are resolved
-here with the same dispatch heuristic (``UrlService._dispatch``), scoped
-to the system default domain. Custom-tenant aliases never resolve on this
-endpoint (known gap, out of scope).
+here instead, in the order ``shared.alias_dispatch.resolution_order``
+prescribes (the same single source of truth the redirect dispatches on).
+Lookups are scoped to the system default domain: custom-domain aliases
+resolve only via the redirect; this endpoint is system-domain-only.
 
 Everything is derived READ-ONLY — this endpoint never writes.
 """
@@ -21,7 +25,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote
 
 from errors import NotFoundError
 from infrastructure.logging import get_logger
@@ -33,36 +37,12 @@ from schemas.dto.responses.public_preview import (
     PreviewGeoDestination,
     PublicPreviewResponse,
 )
-from schemas.models.url import UrlStatus, UrlV2Doc
+from schemas.models.url import SchemaVersion, UrlStatus, UrlV2Doc
+from shared.alias_dispatch import resolution_order
 from shared.datetime_utils import convert_to_gmt, parse_datetime
-from shared.validators import is_emoji_alias
+from shared.url_utils import split_destination
 
 log = get_logger(__name__)
-
-
-def _split_destination(url: str) -> dict:
-    """Split a destination URL into display parts.
-
-    Lifted from the legacy Jinja preview's ``_split_destination``
-    (routes/legacy/url_shortener.py) — importing the route module would
-    drag in template/limiter side-effects. Keep the two in lockstep; the
-    spoo-landing mock mirrors this exact logic.
-    """
-    parsed = urlparse(url)
-    domain = parsed.netloc or parsed.path.split("/")[0]
-    path = (
-        parsed.path
-        + ("?" + parsed.query if parsed.query else "")
-        + ("#" + parsed.fragment if parsed.fragment else "")
-    )
-    if path == "/":
-        path = ""
-    return {
-        "url": url,
-        "domain": domain,
-        "path": path,
-        "is_https": parsed.scheme == "https",
-    }
 
 
 class PublicPreviewService:
@@ -86,38 +66,33 @@ class PublicPreviewService:
     async def get_preview(self, short_code: str) -> PublicPreviewResponse:
         """Resolve *short_code* (status-agnostic) and build the preview.
 
+        Generation lookup order comes from ``resolution_order`` — shared
+        with the redirect so both surfaces always answer a given code from
+        the same generation. Lookups are exact matches; case is never
+        normalized ("/Docs" and "/docs" are different links).
+
         Raises:
             NotFoundError: the code exists in neither generation.
         """
         # Emoji aliases arrive percent-encoded — same as the redirect path.
         short_code = unquote(short_code)
 
-        # Dispatch mirrors UrlService._dispatch: emoji → emojis collection;
-        # 6 chars → v1 first, v2 fallback; anything else → v2 first, v1
-        # fallback. Lookups are exact matches — case is never normalized,
-        # exactly like the redirect ("/Docs" and "/docs" are different links).
-        if is_emoji_alias(short_code):
-            emoji_doc = await self._find_v1_raw(self._emoji_repo, short_code)
-            if emoji_doc is not None:
-                return self._v1_preview(short_code, emoji_doc)
-        elif len(short_code) == 6:
-            v1_doc = await self._find_v1_raw(self._legacy_repo, short_code)
-            if v1_doc is not None:
-                return self._v1_preview(short_code, v1_doc)
-            v2_doc = await self._url_repo.find_by_alias(
-                short_code, self._system_default_domain
-            )
-            if v2_doc is not None:
-                return self._v2_preview(v2_doc)
-        else:
-            v2_doc = await self._url_repo.find_by_alias(
-                short_code, self._system_default_domain
-            )
-            if v2_doc is not None:
-                return self._v2_preview(v2_doc)
-            v1_doc = await self._find_v1_raw(self._legacy_repo, short_code)
-            if v1_doc is not None:
-                return self._v1_preview(short_code, v1_doc)
+        for generation in resolution_order(short_code):
+            if generation is SchemaVersion.V2:
+                v2_doc = await self._url_repo.find_by_alias(
+                    short_code, self._system_default_domain
+                )
+                if v2_doc is not None:
+                    return self._v2_preview(v2_doc)
+            else:
+                repo = (
+                    self._emoji_repo
+                    if generation is SchemaVersion.EMOJI
+                    else self._legacy_repo
+                )
+                v1_doc = await self._find_v1_raw(repo, short_code)
+                if v1_doc is not None:
+                    return self._v1_preview(short_code, v1_doc)
 
         log.info("public_preview_not_found", short_code=short_code)
         raise NotFoundError("short_code not found")
@@ -150,7 +125,7 @@ class PublicPreviewService:
         destination: PreviewDestination | None = None
         geo_destinations: list[PreviewGeoDestination] | None = None
         if status == "active" and not password_protected:
-            destination = PreviewDestination(**_split_destination(doc.long_url))
+            destination = PreviewDestination(**split_destination(doc.long_url))
             geo_destinations = self._group_geo_rules(doc.geo_rules)
 
         created_at = parse_datetime(doc.created_at)
@@ -170,9 +145,14 @@ class PublicPreviewService:
 
         The persisted status flip happens on the click path
         (``UrlRepository.expire_if_max_clicks``); a time-based flip has no
-        writer at all. The preview must agree with what the redirect would
-        do, so an ACTIVE doc whose ``expire_after`` has passed or whose
-        max-clicks budget is exhausted reads ``expired`` — derived here,
+        writer at all — the redirect never compares ``expire_after`` to
+        now. The invariant this endpoint holds is one-directional: the
+        preview never reveals a destination the redirect would refuse.
+        Deriving time-based expiry here is therefore DELIBERATELY STRICTER
+        than the expiry-blind redirect (a lapsed-but-still-ACTIVE link
+        reads ``expired`` and withholds its destination even though the
+        redirect would still serve it). Do not "fix" that divergence by
+        deleting the check — it errs in the safe direction. Derived here,
         never written back.
         """
         if doc.status == UrlStatus.ACTIVE:
@@ -199,7 +179,7 @@ class PublicPreviewService:
         for country, dest in geo_rules.items():
             grouped.setdefault(dest, []).append(country)
         return [
-            PreviewGeoDestination(countries=sorted(codes), **_split_destination(dest))
+            PreviewGeoDestination(countries=sorted(codes), **split_destination(dest))
             for dest, codes in grouped.items()
         ]
 
@@ -212,9 +192,7 @@ class PublicPreviewService:
 
         destination: PreviewDestination | None = None
         if status == "active" and not password_protected:
-            destination = PreviewDestination(
-                **_split_destination(data.get("url") or "")
-            )
+            destination = PreviewDestination(**split_destination(data.get("url") or ""))
 
         return PublicPreviewResponse(
             generation="v1",

--- a/services/public_preview_service.py
+++ b/services/public_preview_service.py
@@ -1,0 +1,284 @@
+"""
+Public link preview service — GET /api/v1/public/preview/{short_code}.
+
+Resolves a short code across both URL generations WITHOUT status gating
+(expired / inactive / blocked links still answer; only truly missing codes
+404) and derives the preview wire shape. The safety semantic the page is
+built on: the destination (and geo rules) ride the wire ONLY while the
+link is active and not password-protected — the preview never reveals
+more than the redirect would.
+
+Deliberately does NOT use ``UrlService.resolve`` — it raises on non-active
+statuses and its cache shape lacks ``created_at``. Raw docs are resolved
+here with the same dispatch heuristic (``UrlService._dispatch``), scoped
+to the system default domain. Custom-tenant aliases never resolve on this
+endpoint (known gap, out of scope).
+
+Everything is derived READ-ONLY — this endpoint never writes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from errors import NotFoundError
+from infrastructure.logging import get_logger
+from repositories.legacy.emoji_url_repository import EmojiUrlRepository
+from repositories.legacy.legacy_url_repository import LegacyUrlRepository
+from repositories.url_repository import UrlRepository
+from schemas.dto.responses.public_preview import (
+    PreviewDestination,
+    PreviewGeoDestination,
+    PublicPreviewResponse,
+)
+from schemas.models.url import UrlStatus, UrlV2Doc
+from shared.datetime_utils import convert_to_gmt, parse_datetime
+from shared.validators import is_emoji_alias
+
+log = get_logger(__name__)
+
+
+def _split_destination(url: str) -> dict:
+    """Split a destination URL into display parts.
+
+    Lifted from the legacy Jinja preview's ``_split_destination``
+    (routes/legacy/url_shortener.py) — importing the route module would
+    drag in template/limiter side-effects. Keep the two in lockstep; the
+    spoo-landing mock mirrors this exact logic.
+    """
+    parsed = urlparse(url)
+    domain = parsed.netloc or parsed.path.split("/")[0]
+    path = (
+        parsed.path
+        + ("?" + parsed.query if parsed.query else "")
+        + ("#" + parsed.fragment if parsed.fragment else "")
+    )
+    if path == "/":
+        path = ""
+    return {
+        "url": url,
+        "domain": domain,
+        "path": path,
+        "is_https": parsed.scheme == "https",
+    }
+
+
+class PublicPreviewService:
+    """Resolution + derivation for the public link preview wire."""
+
+    def __init__(
+        self,
+        url_repo: UrlRepository,
+        legacy_repo: LegacyUrlRepository,
+        emoji_repo: EmojiUrlRepository,
+        *,
+        system_default_domain: str,
+    ) -> None:
+        self._url_repo = url_repo
+        self._legacy_repo = legacy_repo
+        self._emoji_repo = emoji_repo
+        self._system_default_domain = system_default_domain
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    async def get_preview(self, short_code: str) -> PublicPreviewResponse:
+        """Resolve *short_code* (status-agnostic) and build the preview.
+
+        Raises:
+            NotFoundError: the code exists in neither generation.
+        """
+        # Emoji aliases arrive percent-encoded — same as the redirect path.
+        short_code = unquote(short_code)
+
+        # Dispatch mirrors UrlService._dispatch: emoji → emojis collection;
+        # 6 chars → v1 first, v2 fallback; anything else → v2 first, v1
+        # fallback. Lookups are exact matches — case is never normalized,
+        # exactly like the redirect ("/Docs" and "/docs" are different links).
+        if is_emoji_alias(short_code):
+            emoji_doc = await self._find_v1_raw(self._emoji_repo, short_code)
+            if emoji_doc is not None:
+                return self._v1_preview(short_code, emoji_doc)
+        elif len(short_code) == 6:
+            v1_doc = await self._find_v1_raw(self._legacy_repo, short_code)
+            if v1_doc is not None:
+                return self._v1_preview(short_code, v1_doc)
+            v2_doc = await self._url_repo.find_by_alias(
+                short_code, self._system_default_domain
+            )
+            if v2_doc is not None:
+                return self._v2_preview(v2_doc)
+        else:
+            v2_doc = await self._url_repo.find_by_alias(
+                short_code, self._system_default_domain
+            )
+            if v2_doc is not None:
+                return self._v2_preview(v2_doc)
+            v1_doc = await self._find_v1_raw(self._legacy_repo, short_code)
+            if v1_doc is not None:
+                return self._v1_preview(short_code, v1_doc)
+
+        log.info("public_preview_not_found", short_code=short_code)
+        raise NotFoundError("short_code not found")
+
+    # ── Resolution helpers ────────────────────────────────────────────────
+
+    @staticmethod
+    async def _find_v1_raw(
+        repo: LegacyUrlRepository | EmojiUrlRepository, short_code: str
+    ) -> dict | None:
+        """Fetch a v1/emoji document as a RAW dict by exact ``_id`` match.
+
+        Not ``find_by_id``: that returns a typed ``LegacyUrlDoc``, which
+        silently drops ``creation-date`` / ``creation-time`` (the model
+        doesn't declare them and pydantic ignores extras) — and the preview
+        needs them for ``created_at``. The public ``aggregate`` helper is
+        how the legacy stats page reads raw v1 docs too.
+        """
+        return await repo.aggregate([{"$match": {"_id": short_code}}])
+
+    # ── v2 derivation ─────────────────────────────────────────────────────
+
+    def _v2_preview(self, doc: UrlV2Doc) -> PublicPreviewResponse:
+        status = self._v2_effective_status(doc)
+        password_protected = bool(doc.password)
+
+        # Destination-only-while-active: password, expiry, pause and block
+        # all withhold it (time-sensitive links stay dead, blocked
+        # destinations stay unreachable). There is no password unlock here.
+        destination: PreviewDestination | None = None
+        geo_destinations: list[PreviewGeoDestination] | None = None
+        if status == "active" and not password_protected:
+            destination = PreviewDestination(**_split_destination(doc.long_url))
+            geo_destinations = self._group_geo_rules(doc.geo_rules)
+
+        created_at = parse_datetime(doc.created_at)
+        return PublicPreviewResponse(
+            generation="v2",
+            alias=doc.alias,
+            short_url=f"https://{self._system_default_domain}/{doc.alias}",
+            status=status,
+            created_at=created_at.isoformat() if created_at else None,
+            password_protected=password_protected,
+            destination=destination,
+            geo_destinations=geo_destinations,
+        )
+
+    def _v2_effective_status(self, doc: UrlV2Doc) -> str:
+        """Lowercase wire status, folding derived expiry into ``expired``.
+
+        The persisted status flip happens on the click path
+        (``UrlRepository.expire_if_max_clicks``); a time-based flip has no
+        writer at all. The preview must agree with what the redirect would
+        do, so an ACTIVE doc whose ``expire_after`` has passed or whose
+        max-clicks budget is exhausted reads ``expired`` — derived here,
+        never written back.
+        """
+        if doc.status == UrlStatus.ACTIVE:
+            expire_after = self._as_aware_utc(doc.expire_after)
+            if expire_after is not None and expire_after <= datetime.now(timezone.utc):
+                return "expired"
+            if doc.max_clicks is not None and doc.total_clicks >= doc.max_clicks:
+                return "expired"
+        return doc.status.value.lower()
+
+    @staticmethod
+    def _group_geo_rules(
+        geo_rules: dict[str, str] | None,
+    ) -> list[PreviewGeoDestination] | None:
+        """Group geo rules by destination URL, countries sorted ascending.
+
+        Anti-cloaking rule: EVERY rule is listed, nothing summarized —
+        the preview is the transparency surface. Same display grouping as
+        the legacy Jinja preview (storage stays a flat code→url map).
+        """
+        if not geo_rules:
+            return None
+        grouped: dict[str, list[str]] = {}
+        for country, dest in geo_rules.items():
+            grouped.setdefault(dest, []).append(country)
+        return [
+            PreviewGeoDestination(countries=sorted(codes), **_split_destination(dest))
+            for dest, codes in grouped.items()
+        ]
+
+    # ── v1 / emoji derivation ─────────────────────────────────────────────
+
+    def _v1_preview(self, alias: str, data: dict) -> PublicPreviewResponse:
+        # v1 has no status field and can never be inactive or blocked.
+        status = "expired" if self._v1_is_expired(data) else "active"
+        password_protected = bool(data.get("password"))
+
+        destination: PreviewDestination | None = None
+        if status == "active" and not password_protected:
+            destination = PreviewDestination(
+                **_split_destination(data.get("url") or "")
+            )
+
+        return PublicPreviewResponse(
+            generation="v1",
+            alias=alias,
+            short_url=f"https://{self._system_default_domain}/{alias}",
+            status=status,
+            created_at=self._v1_created_at(data),
+            password_protected=password_protected,
+            destination=destination,
+            geo_destinations=None,  # geo targeting is v2-only
+        )
+
+    @staticmethod
+    def _v1_is_expired(data: dict) -> bool:
+        """Mirror the legacy stats page's expired logic (routes/legacy/
+        stats.py): max-clicks reached or ``expiration-time`` passed.
+
+        Like ``convert_to_gmt``, a timezone-naive expiration is ambiguous
+        and never counts as expired; unparseable ancient values are
+        treated the same rather than 500-ing a public page.
+        """
+        max_clicks = data.get("max-clicks")
+        if max_clicks is not None:
+            try:
+                if int(data.get("total-clicks") or 0) >= int(max_clicks):
+                    return True
+            except (TypeError, ValueError):
+                pass
+
+        raw_expiration = data.get("expiration-time")
+        if raw_expiration is None:
+            return False
+        if isinstance(raw_expiration, datetime):
+            expires_at = raw_expiration if raw_expiration.tzinfo else None
+        else:
+            try:
+                expires_at = convert_to_gmt(str(raw_expiration))
+            except (TypeError, ValueError):
+                expires_at = None
+        return expires_at is not None and expires_at.astimezone(
+            timezone.utc
+        ) <= datetime.now(timezone.utc)
+
+    @staticmethod
+    def _v1_created_at(data: dict) -> str | None:
+        """Combine v1 ``creation-date`` + ``creation-time`` (both set at
+        shorten time) into an ISO string; either missing or unparseable →
+        ``None`` — ancient rows lack them and the frontend omits the line.
+        """
+        date = data.get("creation-date")
+        time = data.get("creation-time")
+        if not date or not time:
+            return None
+        created_at = parse_datetime(f"{date}T{time}")
+        return created_at.isoformat() if created_at else None
+
+    # ── Shared helpers ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _as_aware_utc(dt: Any) -> datetime | None:
+        """Normalize a stored datetime for comparison — Mongo returns naive
+        UTC datetimes by default (the client is not ``tz_aware``)."""
+        if not isinstance(dt, datetime):
+            return None
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -64,12 +64,12 @@ from schemas.models.url import (
     UrlStatus,
     UrlV2Doc,
 )
+from shared.alias_dispatch import resolution_order
 from shared.datetime_utils import parse_datetime
 from shared.generators import generate_short_code_v2
 from shared.reserved_aliases import is_reserved_alias
 from shared.url_utils import extract_hostname
 from shared.validators import (
-    is_emoji_alias,
     validate_alias,
     validate_blocked_url,
     validate_emoji_alias,
@@ -1111,13 +1111,13 @@ class UrlService:
         """
         Determine URL schema and fetch from the appropriate collection.
 
-        Mirrors get_url_by_length_and_type() exactly:
-          emoji → emojis, schema "emoji"
-          7 chars → urlsV2 first, urls fallback
-          6 chars → urls first, urlsV2 fallback
-          other   → urlsV2 first, urls fallback
+        The lookup order comes from ``shared.alias_dispatch.resolution_order``
+        — the single source of truth shared with the public preview endpoint,
+        so every resolving surface answers a given code from the same
+        generation. Only the per-generation lookup/conversion lives here.
         """
-        if is_emoji_alias(short_code):
+        order = resolution_order(short_code)
+        if order[0] == SchemaVersion.EMOJI:
             doc = await self._emoji_repo.find_by_id(short_code)
             if doc is not None:
                 return (
@@ -1125,14 +1125,9 @@ class UrlService:
                     SchemaVersion.EMOJI,
                 )
             return None, SchemaVersion.EMOJI
-
-        code_len = len(short_code)
-        if code_len == 7:
-            return await self._try_v2_then_v1(short_code)
-        elif code_len == 6:
+        if order[0] == SchemaVersion.V1:
             return await self._try_v1_then_v2(short_code)
-        else:
-            return await self._try_v2_then_v1(short_code)
+        return await self._try_v2_then_v1(short_code)
 
     async def _dispatch_custom_domain(
         self, short_code: str, domain: str

--- a/shared/alias_dispatch.py
+++ b/shared/alias_dispatch.py
@@ -1,0 +1,37 @@
+"""Alias-resolution dispatch order — single source of truth.
+
+Which URL generation answers a short code is a public contract shared by
+every resolving surface (the redirect via ``UrlService._dispatch`` and
+the public preview endpoint). The order lives here as one pure function
+so the surfaces can never drift: if the length heuristic ever changes,
+both learn about it together — otherwise the preview could describe one
+link while the redirect serves another under the same code.
+
+Mirrors the original get_url_by_length_and_type() heuristic:
+  emoji alias → the emojis collection only
+  6 chars     → urls (v1) first, urlsV2 fallback
+  anything else → urlsV2 first, urls (v1) fallback
+(7-char codes were historically an explicit branch, but their v2-first
+order is identical to the default.)
+"""
+
+from __future__ import annotations
+
+from schemas.models.url import SchemaVersion
+from shared.validators import is_emoji_alias
+
+_V1_FIRST_LENGTH = 6  # v1 codes were generated at exactly this length
+
+
+def resolution_order(short_code: str) -> tuple[SchemaVersion, ...]:
+    """Return the generation lookup order for *short_code*.
+
+    The code must already be percent-decoded (``urllib.parse.unquote``);
+    emoji detection tolerates encoded input, but the repositories match
+    the decoded form exactly.
+    """
+    if is_emoji_alias(short_code):
+        return (SchemaVersion.EMOJI,)
+    if len(short_code) == _V1_FIRST_LENGTH:
+        return (SchemaVersion.V1, SchemaVersion.V2)
+    return (SchemaVersion.V2, SchemaVersion.V1)

--- a/shared/url_utils.py
+++ b/shared/url_utils.py
@@ -45,6 +45,43 @@ def extract_fqdn(url: str) -> str:
     return host.lower().rstrip(".")
 
 
+def split_destination(url: str) -> dict:
+    """Split a destination URL into display parts for preview surfaces.
+
+    Single source of truth for the legacy Jinja preview page AND the
+    public preview API (the spoo-landing mock mirrors this logic):
+    ``{url, domain, path, is_https}`` where ``path`` keeps query and
+    fragment and collapses a bare ``"/"`` to ``""``.
+
+    ``urlparse`` raises ``ValueError`` on some malformed inputs (e.g. an
+    unclosed IPv6 bracket) and legacy v1 ``url`` values are raw — a public
+    endpoint must not 500 on them. Such values fall back to being treated
+    as the domain themselves, matching the frontend mock's try/catch.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return {
+            "url": url,
+            "domain": url.split("/")[0],
+            "path": "",
+            "is_https": False,
+        }
+    path = (
+        parsed.path
+        + ("?" + parsed.query if parsed.query else "")
+        + ("#" + parsed.fragment if parsed.fragment else "")
+    )
+    if path == "/":
+        path = ""
+    return {
+        "url": url,
+        "domain": parsed.netloc or parsed.path.split("/")[0],
+        "path": path,
+        "is_https": parsed.scheme == "https",
+    }
+
+
 def normalise_fqdn(value: object) -> str:
     """Strict canonical form for custom-domain fqdns.
 

--- a/tests/integration/api_v1/test_public_preview.py
+++ b/tests/integration/api_v1/test_public_preview.py
@@ -1,0 +1,374 @@
+"""Tests for GET /api/v1/public/preview/{short_code}.
+
+The wire contract is frozen against the spoo-landing preview page mock —
+status-agnostic resolution, destination-only-while-active withholding,
+geo grouping. All repos are dict-backed mocks; the real
+PublicPreviewService runs against them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dependencies.services import get_public_preview_service
+from schemas.models.url import UrlV2Doc
+from services.public_preview_service import PublicPreviewService
+
+from .conftest import _build_test_app, _make_url_doc
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────────────
+
+
+def _make_v2(alias: str = "testme", **overrides) -> UrlV2Doc:
+    """A validated UrlV2Doc variant of the shared conftest doc."""
+    return UrlV2Doc(**{**_make_url_doc(alias).to_mongo(), **overrides})
+
+
+def _make_v1(**overrides) -> dict:
+    """A raw v1 document dict, as the legacy repos return them."""
+    doc = {
+        "_id": "abc123",
+        "url": "https://example.com/page",
+        "password": None,
+        "total-clicks": 42,
+        "max-clicks": None,
+        "expiration-time": None,
+        "creation-date": "2024-03-10",
+        "creation-time": "12:00:00",
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _make_service(
+    v2_docs: tuple[UrlV2Doc, ...] = (),
+    v1_docs: dict[str, dict] | None = None,
+    emoji_docs: dict[str, dict] | None = None,
+) -> PublicPreviewService:
+    """Real service over dict-backed repo mocks (exact-match lookups)."""
+    v2_by_key = {(d.alias, d.domain): d for d in v2_docs}
+    url_repo = AsyncMock()
+    url_repo.find_by_alias = AsyncMock(
+        side_effect=lambda alias, domain: v2_by_key.get((alias, domain))
+    )
+
+    v1_map = v1_docs or {}
+    legacy_repo = AsyncMock()
+    legacy_repo.aggregate = AsyncMock(
+        side_effect=lambda pipeline: v1_map.get(pipeline[0]["$match"]["_id"])
+    )
+
+    emoji_map = emoji_docs or {}
+    emoji_repo = AsyncMock()
+    emoji_repo.aggregate = AsyncMock(
+        side_effect=lambda pipeline: emoji_map.get(pipeline[0]["$match"]["_id"])
+    )
+
+    return PublicPreviewService(
+        url_repo,
+        legacy_repo,
+        emoji_repo,
+        system_default_domain="spoo.me",
+    )
+
+
+def _get(service: PublicPreviewService, code: str):
+    application = _build_test_app({get_public_preview_service: lambda: service})
+    with TestClient(application, raise_server_exceptions=False) as client:
+        return client.get(f"/api/v1/public/preview/{code}")
+
+
+# ── 404 ────────────────────────────────────────────────────────────────────────
+
+
+def test_missing_code_returns_404_not_found():
+    resp = _get(_make_service(), "noexist")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "short_code not found", "code": "not_found"}
+
+
+# ── v2, active ─────────────────────────────────────────────────────────────────
+
+
+def test_v2_active_plain_full_body():
+    resp = _get(_make_service(v2_docs=(_make_v2(),)), "testme")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "generation": "v2",
+        "alias": "testme",
+        "short_url": "https://spoo.me/testme",
+        "status": "active",
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "password_protected": False,
+        "destination": {
+            "url": "https://example.com/long",
+            "domain": "example.com",
+            "path": "/long",
+            "is_https": True,
+        },
+        "geo_destinations": None,
+    }
+
+
+def test_v2_destination_bare_host_has_empty_path():
+    doc = _make_v2(long_url="https://example.com/")
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    assert resp.json()["destination"] == {
+        "url": "https://example.com/",
+        "domain": "example.com",
+        "path": "",
+        "is_https": True,
+    }
+
+
+def test_v2_destination_preserves_query_and_fragment():
+    doc = _make_v2(long_url="http://sub.example.com/a/b?x=1&y=2#frag")
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    assert resp.json()["destination"] == {
+        "url": "http://sub.example.com/a/b?x=1&y=2#frag",
+        "domain": "sub.example.com",
+        "path": "/a/b?x=1&y=2#frag",
+        "is_https": False,
+    }
+
+
+def test_v2_geo_rules_grouped_by_url_countries_sorted():
+    doc = _make_v2(
+        geo_rules={
+            "US": "https://us.example.com/promo",
+            "DE": "https://eu.example.com/",
+            "CA": "https://us.example.com/promo",
+        }
+    )
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Every rule listed, grouped by destination URL, countries sorted.
+    assert body["geo_destinations"] == [
+        {
+            "countries": ["CA", "US"],
+            "url": "https://us.example.com/promo",
+            "domain": "us.example.com",
+            "path": "/promo",
+            "is_https": True,
+        },
+        {
+            "countries": ["DE"],
+            "url": "https://eu.example.com/",
+            "domain": "eu.example.com",
+            "path": "",
+            "is_https": True,
+        },
+    ]
+    # The plain destination stays the unmatched-country fallback long_url.
+    assert body["destination"]["url"] == "https://example.com/long"
+
+
+# ── v2, withholding ────────────────────────────────────────────────────────────
+
+
+def test_v2_password_protected_withholds_destination_and_geo():
+    doc = _make_v2(
+        password="$argon2id$fakehash",
+        geo_rules={"US": "https://us.example.com/"},
+    )
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "active"
+    assert body["password_protected"] is True
+    assert body["destination"] is None
+    assert body["geo_destinations"] is None
+    # No password unlock exists on this wire — the hash must never leak.
+    assert "argon2" not in resp.text
+
+
+@pytest.mark.parametrize("status", ["EXPIRED", "INACTIVE", "BLOCKED"])
+def test_v2_non_active_status_lowercased_and_destination_withheld(status):
+    doc = _make_v2(status=status, geo_rules={"US": "https://us.example.com/"})
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200  # status-agnostic resolution: still answers
+    body = resp.json()
+    assert body["status"] == status.lower()
+    assert body["destination"] is None
+    assert body["geo_destinations"] is None
+
+
+def test_v2_active_with_past_expire_after_reads_expired():
+    # Naive datetime, as pymongo returns them (naive == UTC).
+    past = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+    doc = _make_v2(expire_after=past)
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "expired"
+    assert body["destination"] is None
+
+
+def test_v2_active_with_max_clicks_reached_reads_expired():
+    doc = _make_v2(max_clicks=5, total_clicks=5)
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "expired"
+    assert body["destination"] is None
+
+
+# ── v1 / emoji ─────────────────────────────────────────────────────────────────
+
+
+def test_v1_active_full_body():
+    # A timezone-naive expiration is ambiguous and must NOT expire the link
+    # (mirrors convert_to_gmt on the legacy stats page).
+    doc = _make_v1(**{"expiration-time": "2000-01-01T00:00:00"})
+    resp = _get(_make_service(v1_docs={"abc123": doc}), "abc123")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "generation": "v1",
+        "alias": "abc123",
+        "short_url": "https://spoo.me/abc123",
+        "status": "active",
+        "created_at": "2024-03-10T12:00:00+00:00",
+        "password_protected": False,
+        "destination": {
+            "url": "https://example.com/page",
+            "domain": "example.com",
+            "path": "/page",
+            "is_https": True,
+        },
+        "geo_destinations": None,
+    }
+
+
+def test_v1_expiration_time_passed_reads_expired_and_withholds():
+    doc = _make_v1(**{"expiration-time": "2020-01-01T00:00:00+00:00"})
+    resp = _get(_make_service(v1_docs={"abc123": doc}), "abc123")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "expired"
+    assert body["destination"] is None
+
+
+def test_v1_max_clicks_reached_reads_expired_and_withholds():
+    doc = _make_v1(**{"max-clicks": 10, "total-clicks": 10})
+    resp = _get(_make_service(v1_docs={"abc123": doc}), "abc123")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "expired"
+    assert body["destination"] is None
+
+
+def test_v1_plaintext_password_withholds_destination():
+    doc = _make_v1(password="hunter2@1")
+    resp = _get(_make_service(v1_docs={"abc123": doc}), "abc123")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["password_protected"] is True
+    assert body["destination"] is None
+    # The plaintext password itself must never leak.
+    assert "hunter2" not in resp.text
+
+
+def test_v1_missing_creation_date_gives_null_created_at():
+    doc = _make_v1()
+    del doc["creation-date"]
+    resp = _get(_make_service(v1_docs={"abc123": doc}), "abc123")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created_at"] is None
+    assert body["generation"] == "v1"
+
+
+def test_emoji_alias_percent_encoded_resolves_as_v1():
+    doc = _make_v1(_id="🚀✨", url="https://docs.spoo.me/emoji-urls")
+    resp = _get(
+        _make_service(emoji_docs={"🚀✨": doc}),
+        "%F0%9F%9A%80%E2%9C%A8",
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["generation"] == "v1"
+    assert body["alias"] == "🚀✨"
+    assert body["short_url"] == "https://spoo.me/🚀✨"
+    assert body["destination"]["domain"] == "docs.spoo.me"
+
+
+# ── Fields that must never influence / ride the wire ───────────────────────────
+
+
+def test_private_stats_link_previews_normally():
+    doc = _make_v2(private_stats=True)
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    assert resp.json()["destination"] is not None  # preview ≠ stats
+
+
+def test_owner_meta_tags_never_on_the_wire():
+    doc = _make_v2(meta_tags={"title": "Owner Bait Title", "description": "Owner copy"})
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "meta_tags" not in body
+    assert "title" not in body
+    assert "Owner Bait Title" not in resp.text
+    # The link itself previews normally — omission isn't withholding.
+    assert body["destination"]["url"] == "https://example.com/long"
+
+
+# ── Resolution behavior ────────────────────────────────────────────────────────
+
+
+def test_lookups_are_case_sensitive():
+    service = _make_service(v2_docs=(_make_v2(alias="Docs"),))
+
+    hit = _get(service, "Docs")
+    assert hit.status_code == 200
+    assert hit.json()["alias"] == "Docs"
+
+    miss = _get(service, "docs")
+    assert miss.status_code == 404
+
+
+def test_six_char_code_in_both_generations_resolves_v1_first():
+    service = _make_service(
+        v2_docs=(_make_v2(alias="sixsix"),),
+        v1_docs={"sixsix": _make_v1(_id="sixsix")},
+    )
+    resp = _get(service, "sixsix")
+
+    assert resp.status_code == 200
+    assert resp.json()["generation"] == "v1"
+
+
+def test_seven_char_code_in_both_generations_resolves_v2_first():
+    service = _make_service(
+        v2_docs=(_make_v2(alias="sevens7"),),
+        v1_docs={"sevens7": _make_v1(_id="sevens7")},
+    )
+    resp = _get(service, "sevens7")
+
+    assert resp.status_code == 200
+    assert resp.json()["generation"] == "v2"

--- a/tests/integration/api_v1/test_public_preview.py
+++ b/tests/integration/api_v1/test_public_preview.py
@@ -299,6 +299,21 @@ def test_v1_missing_creation_date_gives_null_created_at():
     assert body["generation"] == "v1"
 
 
+def test_v1_malformed_destination_url_still_answers_200():
+    # Raw legacy `url` values can be garbage urlparse refuses (unclosed
+    # IPv6 bracket raises ValueError) — a public endpoint must not 500.
+    doc = _make_v1(url="http://[::1")
+    resp = _get(_make_service(v1_docs={"abc123": doc}), "abc123")
+
+    assert resp.status_code == 200
+    assert resp.json()["destination"] == {
+        "url": "http://[::1",
+        "domain": "http:",
+        "path": "",
+        "is_https": False,
+    }
+
+
 def test_emoji_alias_percent_encoded_resolves_as_v1():
     doc = _make_v1(_id="🚀✨", url="https://docs.spoo.me/emoji-urls")
     resp = _get(

--- a/tests/unit/shared/test_alias_dispatch.py
+++ b/tests/unit/shared/test_alias_dispatch.py
@@ -1,0 +1,37 @@
+"""Unit tests for shared/alias_dispatch.py — the resolution-order table.
+
+This order is a public contract shared by the redirect and the public
+preview endpoint; the table below is the single place it is spelled out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from schemas.models.url import SchemaVersion
+from shared.alias_dispatch import resolution_order
+
+
+@pytest.mark.parametrize(
+    ("short_code", "expected"),
+    [
+        # emoji aliases → emojis collection only
+        ("🚀", (SchemaVersion.EMOJI,)),
+        ("🚀✨", (SchemaVersion.EMOJI,)),
+        # percent-encoded emoji still detected (is_emoji_alias unquotes)
+        ("%F0%9F%9A%80", (SchemaVersion.EMOJI,)),
+        # 6 chars → v1 first (v1 codes were generated at this length)
+        ("abc123", (SchemaVersion.V1, SchemaVersion.V2)),
+        ("Docs12", (SchemaVersion.V1, SchemaVersion.V2)),
+        # 7 chars → v2 first (historically an explicit branch, same order
+        # as the default)
+        ("abcd123", (SchemaVersion.V2, SchemaVersion.V1)),
+        # anything else → v2 first
+        ("ab", (SchemaVersion.V2, SchemaVersion.V1)),
+        ("short", (SchemaVersion.V2, SchemaVersion.V1)),
+        ("a-much-longer-alias", (SchemaVersion.V2, SchemaVersion.V1)),
+        ("", (SchemaVersion.V2, SchemaVersion.V1)),
+    ],
+)
+def test_resolution_order_table(short_code, expected):
+    assert resolution_order(short_code) == expected


### PR DESCRIPTION
## Summary

Implements `GET /api/v1/public/preview/{short_code}` — the backend wire for the already-built link preview page (`/{code}+`, spoo-landing PR #2). The frontend contract is frozen: the spoo-landing mock (`app/api/mock/[...path]/public-preview.ts`) IS the contract, consumed via `lib/api/public-preview.ts`, and this endpoint matches it byte-for-byte.

Core safety semantics:

- **Status-agnostic resolution** — expired / inactive / blocked links still answer 200 with their status stated; only truly missing codes 404. Resolution mirrors the redirect's dispatch heuristic (emoji → v1; 6 chars → v1 then v2; otherwise v2 then v1), scoped to the system default domain, exact-match (case-sensitive), read-only.
- **Destination-only-while-active** — `destination` and `geo_destinations` ride the wire only while the link is active AND not password-protected. Password, expiry (including derived expiry the click path hasn't persisted yet), pause and block all withhold them: the preview never reveals more than the redirect would. There is no password unlock on this wire.
- **Anti-cloaking transparency** — geo-targeted links list EVERY rule, grouped by destination URL with countries sorted; `destination` stays the unmatched-country fallback.
- **Owner-set `meta_tags` never appear** — the preview shows our resolved facts only; sender-controlled content stays off the safety surface. No stats payload; `private_stats` plays no role here (preview ≠ stats).

The endpoint ships dark: nothing serves it until the frontend page + Caddy `/{code}+` matcher are wired (gated on the handle_response spike).

## Changes

- `routes/api_v1/public_preview.py` — new route, no auth dependency (the response is identical for everyone, owners included), own rate limit.
- `services/public_preview_service.py` — resolution + derivation. Deliberately does NOT use `UrlService.resolve` (it raises on non-active statuses and its cache shape lacks `created_at`); resolves raw docs per generation instead. v1/emoji docs are fetched as raw dicts (typed `LegacyUrlDoc` drops `creation-date`/`creation-time`, which `created_at` needs). `_split_destination` is lifted from the legacy Jinja preview with a pointer comment.
- `schemas/dto/responses/public_preview.py` — `PreviewDestination`, `PreviewGeoDestination`, `PublicPreviewResponse` (serialize only).
- `middleware/rate_limiter.py` — new `Limits.PUBLIC_PREVIEW = "30 per minute; 2000 per day"`: like the redirect, this endpoint is an existence oracle by design, so it gets its own bounded budget instead of the anon API tier.
- `routes/api_v1/__init__.py`, `dependencies/wiring.py`, `dependencies/services.py` — one-line include + standard singleton wiring/getter.

## Tests

- New `tests/integration/api_v1/test_public_preview.py` (22 tests, all mocked): 404 body; full-body v2 active assertion; destination splitting (bare host → empty path, querystring/fragment preserved, http vs https); geo grouping/sorting; password withholding (v2 hash + v1 plaintext, secrets never leak); persisted EXPIRED/INACTIVE/BLOCKED lowercased + withheld; derived expiry (past `expire_after`, max-clicks reached) for both generations; naive v1 expiration never expires (legacy parity); v1 `created_at` combination + null for ancient rows; percent-encoded emoji alias; `private_stats` irrelevance; `meta_tags` absent from the wire; case-sensitive lookups; v1-vs-v2 resolution order for 6- and 7-char codes.
- Targeted run: 22 passed. Full sweep: 2114 passed.

## Summary by Sourcery

Implement a read-only public link preview surface that resolves short codes across generations and returns a sanitized, rate-limited preview payload suitable for the /{code}+ frontend page.

New Features:
- Add a public link preview API endpoint that exposes status and sanitized destination details for short codes across v1, v2, and emoji aliases.

Enhancements:
- Introduce a dedicated PublicPreviewService and response DTOs to derive preview-safe link metadata without affecting existing redirect logic.
- Configure a specific rate limit bucket for public link preview requests and wire the new service into the FastAPI dependency system.

Tests:
- Add comprehensive integration tests covering status-agnostic resolution, password and expiry-based withholding, geo-targeted destinations, and v1/v2 resolution order for the public preview endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public link preview endpoint that works without authentication.
  * Preview responses include link status, creation details, destination information, and geographic routing when applicable.
  * Expired, inactive, and blocked links return preview information while protecting destination details when needed.
  * Added support for both legacy and current short-link formats, including emoji aliases.

* **Security & Reliability**
  * Added dedicated rate limits for public preview requests.
  * Missing short codes return a not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->