### PR TITLE
feat: public per-link stats endpoint

### DIFF
--- a/dependencies/services.py
+++ b/dependencies/services.py
@@ -32,6 +32,7 @@ from services.oauth_service import OAuthService
 from services.page_layout_service import PageLayoutService
 from services.profile_picture_service import ProfilePictureService
 from services.public_preview_service import PublicPreviewService
+from services.public_stats_service import PublicStatsService
 from services.stats_service import StatsService
 from services.url_service import UrlService
 
@@ -42,6 +43,10 @@ def get_url_service(request: Request) -> UrlService:
 
 def get_stats_service(request: Request) -> StatsService:
     return request.app.state.stats_service
+
+
+def get_public_stats_service(request: Request) -> PublicStatsService:
+    return request.app.state.public_stats_service
 
 
 def get_export_service(request: Request) -> ExportService:
@@ -128,6 +133,7 @@ def get_public_preview_service(request: Request) -> PublicPreviewService:
 
 UrlSvc = Annotated[UrlService, Depends(get_url_service)]
 StatsSvc = Annotated[StatsService, Depends(get_stats_service)]
+PublicStatsSvc = Annotated[PublicStatsService, Depends(get_public_stats_service)]
 ExportSvc = Annotated[ExportService, Depends(get_export_service)]
 ApiKeySvc = Annotated[ApiKeyService, Depends(get_api_key_service)]
 PageLayoutSvc = Annotated[PageLayoutService, Depends(get_page_layout_service)]

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -56,6 +56,7 @@ from services.mock_dcv_backend import MockDcvBackend
 from services.oauth_service import OAuthService
 from services.page_layout_service import PageLayoutService
 from services.profile_picture_service import ProfilePictureService
+from services.public_link_resolver import PublicLinkResolver
 from services.public_preview_service import PublicPreviewService
 from services.public_stats_service import PublicStatsService
 from services.stats_service import StatsService
@@ -208,18 +209,19 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         url_repo,
         max_date_range_days=settings.max_date_range_days,
     )
-    app.state.public_preview_service = PublicPreviewService(
+    # One resolver serves BOTH public read-only surfaces (preview + stats)
+    # so they can never disagree about which link a code names or what
+    # state it is in.
+    public_link_resolver = PublicLinkResolver(
         url_repo,
         legacy_repo,
         emoji_repo,
         system_default_domain=settings.system_default_domain,
     )
+    app.state.public_preview_service = PublicPreviewService(public_link_resolver)
     app.state.public_stats_service = PublicStatsService(
-        url_repo,
-        legacy_repo,
-        emoji_repo,
+        public_link_resolver,
         app.state.stats_service,
-        system_default_domain=settings.system_default_domain,
         max_date_range_days=settings.max_date_range_days,
     )
     app.state.export_service = ExportService(

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -57,6 +57,7 @@ from services.oauth_service import OAuthService
 from services.page_layout_service import PageLayoutService
 from services.profile_picture_service import ProfilePictureService
 from services.public_preview_service import PublicPreviewService
+from services.public_stats_service import PublicStatsService
 from services.stats_service import StatsService
 from services.tenant_resolver import CachedMongoTenantResolver
 from services.token_factory import TokenFactory
@@ -212,6 +213,14 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         legacy_repo,
         emoji_repo,
         system_default_domain=settings.system_default_domain,
+    )
+    app.state.public_stats_service = PublicStatsService(
+        url_repo,
+        legacy_repo,
+        emoji_repo,
+        app.state.stats_service,
+        system_default_domain=settings.system_default_domain,
+        max_date_range_days=settings.max_date_range_days,
     )
     app.state.export_service = ExportService(
         app.state.stats_service,

--- a/errors.py
+++ b/errors.py
@@ -46,6 +46,18 @@ class AuthenticationError(AppError):
     error_code = "authentication_error"
 
 
+class PasswordRequiredError(AuthenticationError):
+    """A password-protected resource was requested without a password."""
+
+    error_code = "password_required"
+
+
+class InvalidPasswordError(AuthenticationError):
+    """A password-protected resource was requested with the wrong password."""
+
+    error_code = "invalid_password"
+
+
 class ForbiddenError(AppError):
     status_code = 403
     error_code = "forbidden"

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -118,6 +118,17 @@ class Limits:
     # gets its own bounded budget instead of riding the anon API tier.
     PUBLIC_PREVIEW = "30 per minute; 2000 per day"
 
+    # Public per-link stats (the /stats/{code} wire). Two reasons this
+    # gets its own budget instead of riding the generic API tier: every
+    # anonymous hit can run a 90-day $facet aggregation over a hot link's
+    # clicks — far heavier than a typical API read — and the same bucket
+    # is the password-guess budget (401s are billed like any request, and
+    # v1 passwords compare server-side for cheap, so the limiter is the
+    # only real brake on guessing). Authed keeps headroom: owners
+    # re-checking their own private/password link ride this endpoint too.
+    PUBLIC_STATS_AUTHED = "60 per minute; 2000 per day"
+    PUBLIC_STATS_ANON = "20 per minute; 500 per day"
+
 
 # ── Key resolution ───────────────────────────────────────────────────────────
 

--- a/routes/api_v1/__init__.py
+++ b/routes/api_v1/__init__.py
@@ -10,6 +10,7 @@ from routes.api_v1 import (
     me,
     metadata,
     public_preview,
+    public_stats,
     shorten,
     stats,
     urls,
@@ -20,6 +21,7 @@ router.include_router(shorten.router)
 router.include_router(urls.router)
 router.include_router(management.router)
 router.include_router(stats.router)
+router.include_router(public_stats.router)
 router.include_router(exports.router)
 router.include_router(keys.router)
 router.include_router(custom_domains.router)

--- a/routes/api_v1/public_stats.py
+++ b/routes/api_v1/public_stats.py
@@ -25,8 +25,11 @@ from services.public_stats_service import PublicStatsService
 
 router = APIRouter(tags=["Public"])
 
+# Dedicated pair — NOT the generic API tier. Reasoning lives on
+# Limits.PUBLIC_STATS_*: anon hits can run 90-day $facet aggregations,
+# and this bucket doubles as the password-guess budget.
 _public_stats_limit, _public_stats_key = dynamic_limit(
-    Limits.API_AUTHED, Limits.API_ANON
+    Limits.PUBLIC_STATS_AUTHED, Limits.PUBLIC_STATS_ANON
 )
 
 _PATH = "/public/stats/{short_code}"
@@ -104,8 +107,8 @@ async def public_stats_get(
 
     **Rate Limits**:
 
-    - Authenticated: 60/min, 5,000/day
-    - Anonymous: 20/min, 1,000/day
+    - Authenticated: 60/min, 2,000/day
+    - Anonymous: 20/min, 500/day
     """
     return await _serve_public_stats(
         public_stats_service,

--- a/routes/api_v1/public_stats.py
+++ b/routes/api_v1/public_stats.py
@@ -1,0 +1,154 @@
+"""
+GET|POST /api/v1/public/stats/{short_code} — public per-link statistics.
+
+Serves the public stats page (/stats/{code}) for BOTH URL generations on
+the system default domain. No auth required; an authenticated owner
+session bypasses the privacy and password gates.
+
+GET never accepts a password — not as a query param, not as a header
+(an undeclared ``?password=`` is simply ignored). POST exists solely to
+carry ``{"password"}`` in a JSON body; it accepts the same query params.
+"""
+
+from __future__ import annotations
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, Query, Request
+
+from dependencies import STATS_SCOPES, CurrentUser, optional_scopes
+from dependencies.services import PublicStatsSvc
+from middleware.openapi import ERROR_RESPONSES, OPTIONAL_AUTH_SECURITY
+from middleware.rate_limiter import Limits, dynamic_limit, limiter
+from schemas.dto.requests.public_stats import PublicStatsBody
+from schemas.dto.responses.public_stats import PublicStatsResponse
+from services.public_stats_service import PublicStatsService
+
+router = APIRouter(tags=["Public"])
+
+_public_stats_limit, _public_stats_key = dynamic_limit(
+    Limits.API_AUTHED, Limits.API_ANON
+)
+
+_PATH = "/public/stats/{short_code}"
+
+_START_DATE_QUERY = Query(
+    default=None,
+    max_length=50,
+    description="Range start (ISO 8601). Defaults to 7 days before end_date.",
+    examples=["2025-01-01T00:00:00Z"],
+)
+_END_DATE_QUERY = Query(
+    default=None,
+    max_length=50,
+    description="Range end (ISO 8601). Defaults to now.",
+    examples=["2025-12-31T23:59:59Z"],
+)
+_TIMEZONE_QUERY = Query(
+    default="UTC",
+    max_length=50,
+    description="IANA timezone for time bucketing and formatting.",
+    examples=["UTC", "America/New_York"],
+)
+
+
+async def _serve_public_stats(
+    public_stats_service: PublicStatsService,
+    short_code: str,
+    *,
+    start_date: str | None,
+    end_date: str | None,
+    timezone: str,
+    password: str | None,
+    user: CurrentUser | None,
+) -> PublicStatsResponse:
+    user_id: ObjectId | None = user.user_id if user is not None else None
+    result = await public_stats_service.get_public_stats(
+        short_code,
+        start_date=start_date,
+        end_date=end_date,
+        tz_name=timezone,
+        password=password,
+        user_id=user_id,
+    )
+    return PublicStatsResponse.model_validate(result)
+
+
+@router.get(
+    _PATH,
+    responses=ERROR_RESPONSES,
+    openapi_extra=OPTIONAL_AUTH_SECURITY,
+    operation_id="getPublicStats",
+    summary="Public URL Statistics",
+)
+@limiter.limit(_public_stats_limit, key_func=_public_stats_key)
+async def public_stats_get(
+    request: Request,
+    short_code: str,
+    public_stats_service: PublicStatsSvc,
+    start_date: str | None = _START_DATE_QUERY,
+    end_date: str | None = _END_DATE_QUERY,
+    timezone: str = _TIMEZONE_QUERY,
+    user: CurrentUser | None = Depends(optional_scopes(STATS_SCOPES)),  # noqa: B008
+) -> PublicStatsResponse:
+    """Get public click statistics for a single short link.
+
+    Resolves both URL generations (plus emoji aliases) on the system
+    default domain and returns link facts plus the standard stats wire.
+
+    **Authentication**: Optional — an owner session additionally sees
+    private-stats links and skips the password gate.
+
+    **Privacy**: A link with private stats answers exactly like a missing
+    code (404, byte-identical). Password-protected links answer 401
+    `password_required`; send the password via POST — never in the URL.
+
+    **Rate Limits**:
+
+    - Authenticated: 60/min, 5,000/day
+    - Anonymous: 20/min, 1,000/day
+    """
+    return await _serve_public_stats(
+        public_stats_service,
+        short_code,
+        start_date=start_date,
+        end_date=end_date,
+        timezone=timezone,
+        password=None,
+        user=user,
+    )
+
+
+@router.post(
+    _PATH,
+    responses=ERROR_RESPONSES,
+    openapi_extra=OPTIONAL_AUTH_SECURITY,
+    operation_id="getPublicStatsWithPassword",
+    summary="Public URL Statistics (password unlock)",
+)
+@limiter.limit(_public_stats_limit, key_func=_public_stats_key)
+async def public_stats_post(
+    request: Request,
+    short_code: str,
+    public_stats_service: PublicStatsSvc,
+    body: PublicStatsBody | None = None,
+    start_date: str | None = _START_DATE_QUERY,
+    end_date: str | None = _END_DATE_QUERY,
+    timezone: str = _TIMEZONE_QUERY,
+    user: CurrentUser | None = Depends(optional_scopes(STATS_SCOPES)),  # noqa: B008
+) -> PublicStatsResponse:
+    """Same as the GET variant, carrying a password in the JSON body.
+
+    The body is the ONLY way a password travels to this endpoint —
+    query-string passwords are ignored so they can't land in URLs, logs,
+    or referrers. Wrong passwords answer 401 `invalid_password`
+    (retryable). The body may be absent or empty.
+    """
+    return await _serve_public_stats(
+        public_stats_service,
+        short_code,
+        start_date=start_date,
+        end_date=end_date,
+        timezone=timezone,
+        password=body.password if body is not None else None,
+        user=user,
+    )

--- a/schemas/dto/requests/public_stats.py
+++ b/schemas/dto/requests/public_stats.py
@@ -1,0 +1,26 @@
+"""
+Request DTO for the public per-link stats endpoint.
+
+PublicStatsBody — POST /api/v1/public/stats/{short_code} (JSON body)
+
+The POST body is the ONLY way a password travels to this endpoint — never
+a query param or header, so passwords can't leak into URLs, logs, or
+referrers. The body is optional; an absent or empty body means "no
+password supplied".
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from schemas.dto.base import RequestBase
+
+
+class PublicStatsBody(RequestBase):
+    """Optional JSON body carrying the stats-page password."""
+
+    password: str | None = Field(
+        default=None,
+        max_length=200,
+        description="Password for a password-protected link's stats.",
+    )

--- a/schemas/dto/responses/public_stats.py
+++ b/schemas/dto/responses/public_stats.py
@@ -1,0 +1,54 @@
+"""
+Response DTOs for the public per-link stats endpoint.
+
+PublicStatsResponse — GET|POST /api/v1/public/stats/{short_code} (200)
+
+The wire contract is frozen by the spoo-landing public stats page
+(consumed via ``lib/api/public-stats.ts``, mirrored byte-for-byte by its
+mock API). ``stats`` carries the same shape as GET /api/v1/stats — the
+dynamic ``{metric}_by_{dimension}`` metric keys make it a flexible dict.
+DTOs serialize only; all derivation (effective status, long_url
+withholding, v1 synthesis) lives in PublicStatsService.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import Field
+
+from schemas.dto.base import ResponseBase
+
+
+class PublicLinkFacts(ResponseBase):
+    """Public facts about the link shown above the charts."""
+
+    alias: str
+    short_url: str
+    # Destination-only-while-active (same rule as the preview page):
+    # null unless the effective status is "active"; owner sessions
+    # always get it.
+    long_url: str | None = None
+    created_at: datetime | None = None
+    status: Literal["active", "inactive", "expired", "blocked"]
+    max_clicks: int | None = None
+    block_bots: bool
+    password_protected: bool
+
+
+class PublicStatsResponse(ResponseBase):
+    """Response body for GET|POST /api/v1/public/stats/{short_code}."""
+
+    # Which URL generation served the analytics. Emoji aliases collapse to
+    # "v1" — they carry v1-shaped (lifetime-dimension) analytics.
+    generation: Literal["v1", "v2"]
+    link: PublicLinkFacts
+    stats: dict[str, Any] = Field(
+        description=(
+            "The modern stats wire shape (same as GET /api/v1/stats): "
+            "summary, metrics keyed '{metric}_by_{dimension}', time_range, "
+            "time_bucket_info, computed_metrics. v1 links carry a "
+            "'clicks_by_bots' dimension and no 'city'; v2 the reverse."
+        ),
+    )

--- a/services/public_link_resolver.py
+++ b/services/public_link_resolver.py
@@ -1,0 +1,244 @@
+"""
+Shared resolver for the public read-only link surfaces.
+
+Both public endpoints — the link preview (``/{code}+``) and the public
+stats page (``/stats/{code}``) — must answer a given short code from the
+SAME generation, derive the SAME effective status, and surface the SAME
+``created_at``, or the two pages could describe two different links under
+one code. This module is that single source of truth; neither service
+keeps a private copy of any piece of it.
+
+Invariants (load-bearing — preserved from the preview endpoint):
+  - Resolution follows ``shared.alias_dispatch.resolution_order`` (the
+    same single source of truth the redirect dispatches on) and is
+    scoped to the system default domain. Custom-domain aliases resolve
+    only via the redirect; the public surfaces are system-domain-only.
+  - v1/emoji documents are fetched RAW — the typed ``LegacyUrlDoc``
+    silently drops ``creation-date`` / ``creation-time``.
+  - Derived expiry is DELIBERATELY STRICTER than the expiry-blind
+    redirect: a public surface must never reveal a destination the
+    redirect would refuse, so status may err toward "expired", never
+    away from it.
+  - Everything is derived READ-ONLY — nothing here writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+from urllib.parse import unquote
+
+from repositories.legacy.emoji_url_repository import EmojiUrlRepository
+from repositories.legacy.legacy_url_repository import LegacyUrlRepository
+from repositories.url_repository import UrlRepository
+from schemas.models.url import SchemaVersion, UrlStatus, UrlV2Doc
+from shared.alias_dispatch import resolution_order
+from shared.datetime_utils import convert_to_gmt, parse_datetime
+
+# ── Derivation helpers (generation-specific primitives) ──────────────────────
+
+
+def as_aware_utc(dt: Any) -> datetime | None:
+    """Normalize a stored datetime for comparison — Mongo returns naive
+    UTC datetimes by default (the client is not ``tz_aware``)."""
+    if not isinstance(dt, datetime):
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def v2_effective_status(doc: UrlV2Doc) -> str:
+    """Lowercase wire status, folding derived expiry into ``expired``.
+
+    The persisted status flip happens on the click path
+    (``UrlRepository.expire_if_max_clicks``); a time-based flip has no
+    writer at all — the redirect never compares ``expire_after`` to
+    now. The invariant the public surfaces hold is one-directional:
+    they never reveal a destination the redirect would refuse.
+    Deriving time-based expiry here is therefore DELIBERATELY STRICTER
+    than the expiry-blind redirect (a lapsed-but-still-ACTIVE link
+    reads ``expired`` and withholds its destination even though the
+    redirect would still serve it). Do not "fix" that divergence by
+    deleting the check — it errs in the safe direction. Derived here,
+    never written back.
+    """
+    if doc.status == UrlStatus.ACTIVE:
+        expire_after = as_aware_utc(doc.expire_after)
+        if expire_after is not None and expire_after <= datetime.now(timezone.utc):
+            return "expired"
+        if doc.max_clicks is not None and doc.total_clicks >= doc.max_clicks:
+            return "expired"
+    return doc.status.value.lower()
+
+
+def v1_is_expired(data: dict) -> bool:
+    """Mirror the legacy stats page's expired logic (routes/legacy/
+    stats.py): max-clicks reached or ``expiration-time`` passed.
+
+    Like ``convert_to_gmt``, a timezone-naive expiration is ambiguous
+    and never counts as expired; unparseable ancient values are
+    treated the same rather than 500-ing a public page.
+    """
+    max_clicks = data.get("max-clicks")
+    if max_clicks is not None:
+        try:
+            if int(data.get("total-clicks") or 0) >= int(max_clicks):
+                return True
+        except (TypeError, ValueError):
+            pass
+
+    raw_expiration = data.get("expiration-time")
+    if raw_expiration is None:
+        return False
+    if isinstance(raw_expiration, datetime):
+        expires_at = raw_expiration if raw_expiration.tzinfo else None
+    else:
+        try:
+            expires_at = convert_to_gmt(str(raw_expiration))
+        except (TypeError, ValueError):
+            expires_at = None
+    return expires_at is not None and expires_at.astimezone(
+        timezone.utc
+    ) <= datetime.now(timezone.utc)
+
+
+def v1_created_at(data: dict) -> datetime | None:
+    """Combine v1 ``creation-date`` + ``creation-time`` (both set at
+    shorten time) into an aware datetime; either missing or unparseable
+    → ``None`` — ancient rows lack them and the pages omit the line.
+    """
+    date = data.get("creation-date")
+    time_of_day = data.get("creation-time")
+    if not date or not time_of_day:
+        return None
+    return parse_datetime(f"{date}T{time_of_day}")
+
+
+# ── The resolved link ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class ResolvedPublicLink:
+    """A short code resolved for a public read-only surface.
+
+    Exactly one of ``v2_doc`` / ``raw_v1`` is set, matching ``schema``.
+    ``raw_v1`` stays RAW so legacy-only fields survive; validate it into
+    ``LegacyUrlDoc`` where typed access is needed.
+    """
+
+    schema: SchemaVersion
+    alias: str
+    short_url: str
+    v2_doc: UrlV2Doc | None = None
+    raw_v1: dict[str, Any] | None = None
+
+    @property
+    def is_v2(self) -> bool:
+        return self.schema is SchemaVersion.V2
+
+    @property
+    def generation(self) -> Literal["v1", "v2"]:
+        """Public wire generation — emoji collapses to ``"v1"`` (emoji
+        links carry v1-shaped analytics; the wire only knows v1|v2)."""
+        return "v2" if self.is_v2 else "v1"
+
+    def effective_status(self) -> str:
+        """Derived wire status (lowercase) — see ``v2_effective_status``.
+
+        v1/emoji docs have no status field and can never be inactive or
+        blocked — only "active" or (derived) "expired".
+        """
+        if self.is_v2:
+            return v2_effective_status(self.v2_doc)
+        return "expired" if v1_is_expired(self.raw_v1) else "active"
+
+    def created_at(self) -> datetime | None:
+        """Aware-UTC creation time; ``None`` when the doc never stored one."""
+        if self.is_v2:
+            return as_aware_utc(self.v2_doc.created_at)
+        return v1_created_at(self.raw_v1)
+
+
+# ── The resolver ──────────────────────────────────────────────────────────────
+
+
+class PublicLinkResolver:
+    """Domain-scoped, status-agnostic resolution for public surfaces.
+
+    Status-agnostic on purpose: expired / inactive / blocked links still
+    resolve (the surfaces describe them without serving them) — which is
+    why this deliberately does NOT use ``UrlService.resolve`` (it raises
+    on non-active statuses and its cache shape lacks ``created_at``).
+    """
+
+    def __init__(
+        self,
+        url_repo: UrlRepository,
+        legacy_repo: LegacyUrlRepository,
+        emoji_repo: EmojiUrlRepository,
+        *,
+        system_default_domain: str,
+    ) -> None:
+        self._url_repo = url_repo
+        self._legacy_repo = legacy_repo
+        self._emoji_repo = emoji_repo
+        self._system_default_domain = system_default_domain
+
+    async def resolve(self, short_code: str) -> ResolvedPublicLink | None:
+        """Resolve *short_code*; ``None`` when it misses every generation.
+
+        The code is percent-decoded here (emoji aliases arrive encoded,
+        same as the redirect path). Generation lookup order comes from
+        ``resolution_order`` — shared with the redirect so all surfaces
+        answer a given code from the same generation; emoji misses never
+        fall through to urls/urlsV2. Lookups are exact matches; case is
+        never normalized ("/Docs" and "/docs" are different links).
+        """
+        code = unquote(short_code)
+        for generation in resolution_order(code):
+            if generation is SchemaVersion.V2:
+                v2_doc = await self._url_repo.find_by_alias(
+                    code, self._system_default_domain
+                )
+                if v2_doc is not None:
+                    return ResolvedPublicLink(
+                        schema=SchemaVersion.V2,
+                        alias=v2_doc.alias,
+                        short_url=self._short_url(v2_doc.alias),
+                        v2_doc=v2_doc,
+                    )
+            else:
+                repo = (
+                    self._emoji_repo
+                    if generation is SchemaVersion.EMOJI
+                    else self._legacy_repo
+                )
+                raw = await self._find_v1_raw(repo, code)
+                if raw is not None:
+                    return ResolvedPublicLink(
+                        schema=generation,
+                        alias=code,
+                        short_url=self._short_url(code),
+                        raw_v1=raw,
+                    )
+        return None
+
+    def _short_url(self, alias: str) -> str:
+        return f"https://{self._system_default_domain}/{alias}"
+
+    @staticmethod
+    async def _find_v1_raw(
+        repo: LegacyUrlRepository | EmojiUrlRepository, short_code: str
+    ) -> dict | None:
+        """Fetch a v1/emoji document as a RAW dict by exact ``_id`` match.
+
+        Not ``find_by_id``: that returns a typed ``LegacyUrlDoc``, which
+        silently drops ``creation-date`` / ``creation-time`` (the model
+        doesn't declare them and pydantic ignores extras) — and both
+        public surfaces need them for ``created_at``. The public
+        ``aggregate`` helper is how the legacy stats page reads raw v1
+        docs too.
+        """
+        return await repo.aggregate([{"$match": {"_id": short_code}}])

--- a/services/public_preview_service.py
+++ b/services/public_preview_service.py
@@ -11,112 +11,56 @@ that means enumerating the full country→destination map while a single
 redirect follows only one rule: deliberate anti-cloaking transparency,
 not a leak.
 
-Deliberately does NOT use ``UrlService.resolve`` — it raises on non-active
-statuses and its cache shape lacks ``created_at``. Raw docs are resolved
-here instead, in the order ``shared.alias_dispatch.resolution_order``
-prescribes (the same single source of truth the redirect dispatches on).
-Lookups are scoped to the system default domain: custom-domain aliases
-resolve only via the redirect; this endpoint is system-domain-only.
+Resolution, raw v1/emoji reads, derived effective status, and created_at
+all come from ``services.public_link_resolver`` — the single source of
+truth shared with the public stats endpoint, so the two public surfaces
+can never disagree about which link a code names or what state it is in.
 
 Everything is derived READ-ONLY — this endpoint never writes.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
-from urllib.parse import unquote
-
 from errors import NotFoundError
 from infrastructure.logging import get_logger
-from repositories.legacy.emoji_url_repository import EmojiUrlRepository
-from repositories.legacy.legacy_url_repository import LegacyUrlRepository
-from repositories.url_repository import UrlRepository
 from schemas.dto.responses.public_preview import (
     PreviewDestination,
     PreviewGeoDestination,
     PublicPreviewResponse,
 )
-from schemas.models.url import SchemaVersion, UrlStatus, UrlV2Doc
-from shared.alias_dispatch import resolution_order
-from shared.datetime_utils import convert_to_gmt, parse_datetime
+from services.public_link_resolver import PublicLinkResolver, ResolvedPublicLink
 from shared.url_utils import split_destination
 
 log = get_logger(__name__)
 
 
 class PublicPreviewService:
-    """Resolution + derivation for the public link preview wire."""
+    """Derivation of the public link preview wire over the shared resolver."""
 
-    def __init__(
-        self,
-        url_repo: UrlRepository,
-        legacy_repo: LegacyUrlRepository,
-        emoji_repo: EmojiUrlRepository,
-        *,
-        system_default_domain: str,
-    ) -> None:
-        self._url_repo = url_repo
-        self._legacy_repo = legacy_repo
-        self._emoji_repo = emoji_repo
-        self._system_default_domain = system_default_domain
+    def __init__(self, resolver: PublicLinkResolver) -> None:
+        self._resolver = resolver
 
     # ── Public API ────────────────────────────────────────────────────────
 
     async def get_preview(self, short_code: str) -> PublicPreviewResponse:
         """Resolve *short_code* (status-agnostic) and build the preview.
 
-        Generation lookup order comes from ``resolution_order`` — shared
-        with the redirect so both surfaces always answer a given code from
-        the same generation. Lookups are exact matches; case is never
-        normalized ("/Docs" and "/docs" are different links).
-
         Raises:
             NotFoundError: the code exists in neither generation.
         """
-        # Emoji aliases arrive percent-encoded — same as the redirect path.
-        short_code = unquote(short_code)
-
-        for generation in resolution_order(short_code):
-            if generation is SchemaVersion.V2:
-                v2_doc = await self._url_repo.find_by_alias(
-                    short_code, self._system_default_domain
-                )
-                if v2_doc is not None:
-                    return self._v2_preview(v2_doc)
-            else:
-                repo = (
-                    self._emoji_repo
-                    if generation is SchemaVersion.EMOJI
-                    else self._legacy_repo
-                )
-                v1_doc = await self._find_v1_raw(repo, short_code)
-                if v1_doc is not None:
-                    return self._v1_preview(short_code, v1_doc)
-
-        log.info("public_preview_not_found", short_code=short_code)
-        raise NotFoundError("short_code not found")
-
-    # ── Resolution helpers ────────────────────────────────────────────────
-
-    @staticmethod
-    async def _find_v1_raw(
-        repo: LegacyUrlRepository | EmojiUrlRepository, short_code: str
-    ) -> dict | None:
-        """Fetch a v1/emoji document as a RAW dict by exact ``_id`` match.
-
-        Not ``find_by_id``: that returns a typed ``LegacyUrlDoc``, which
-        silently drops ``creation-date`` / ``creation-time`` (the model
-        doesn't declare them and pydantic ignores extras) — and the preview
-        needs them for ``created_at``. The public ``aggregate`` helper is
-        how the legacy stats page reads raw v1 docs too.
-        """
-        return await repo.aggregate([{"$match": {"_id": short_code}}])
+        link = await self._resolver.resolve(short_code)
+        if link is None:
+            log.info("public_preview_not_found", short_code=short_code)
+            raise NotFoundError("short_code not found")
+        if link.is_v2:
+            return self._v2_preview(link)
+        return self._v1_preview(link)
 
     # ── v2 derivation ─────────────────────────────────────────────────────
 
-    def _v2_preview(self, doc: UrlV2Doc) -> PublicPreviewResponse:
-        status = self._v2_effective_status(doc)
+    def _v2_preview(self, link: ResolvedPublicLink) -> PublicPreviewResponse:
+        doc = link.v2_doc
+        status = link.effective_status()
         password_protected = bool(doc.password)
 
         # Destination-only-while-active: password, expiry, pause and block
@@ -128,40 +72,17 @@ class PublicPreviewService:
             destination = PreviewDestination(**split_destination(doc.long_url))
             geo_destinations = self._group_geo_rules(doc.geo_rules)
 
-        created_at = parse_datetime(doc.created_at)
+        created_at = link.created_at()
         return PublicPreviewResponse(
-            generation="v2",
-            alias=doc.alias,
-            short_url=f"https://{self._system_default_domain}/{doc.alias}",
+            generation=link.generation,
+            alias=link.alias,
+            short_url=link.short_url,
             status=status,
             created_at=created_at.isoformat() if created_at else None,
             password_protected=password_protected,
             destination=destination,
             geo_destinations=geo_destinations,
         )
-
-    def _v2_effective_status(self, doc: UrlV2Doc) -> str:
-        """Lowercase wire status, folding derived expiry into ``expired``.
-
-        The persisted status flip happens on the click path
-        (``UrlRepository.expire_if_max_clicks``); a time-based flip has no
-        writer at all — the redirect never compares ``expire_after`` to
-        now. The invariant this endpoint holds is one-directional: the
-        preview never reveals a destination the redirect would refuse.
-        Deriving time-based expiry here is therefore DELIBERATELY STRICTER
-        than the expiry-blind redirect (a lapsed-but-still-ACTIVE link
-        reads ``expired`` and withholds its destination even though the
-        redirect would still serve it). Do not "fix" that divergence by
-        deleting the check — it errs in the safe direction. Derived here,
-        never written back.
-        """
-        if doc.status == UrlStatus.ACTIVE:
-            expire_after = self._as_aware_utc(doc.expire_after)
-            if expire_after is not None and expire_after <= datetime.now(timezone.utc):
-                return "expired"
-            if doc.max_clicks is not None and doc.total_clicks >= doc.max_clicks:
-                return "expired"
-        return doc.status.value.lower()
 
     @staticmethod
     def _group_geo_rules(
@@ -185,78 +106,24 @@ class PublicPreviewService:
 
     # ── v1 / emoji derivation ─────────────────────────────────────────────
 
-    def _v1_preview(self, alias: str, data: dict) -> PublicPreviewResponse:
+    def _v1_preview(self, link: ResolvedPublicLink) -> PublicPreviewResponse:
+        data = link.raw_v1
         # v1 has no status field and can never be inactive or blocked.
-        status = "expired" if self._v1_is_expired(data) else "active"
+        status = link.effective_status()
         password_protected = bool(data.get("password"))
 
         destination: PreviewDestination | None = None
         if status == "active" and not password_protected:
             destination = PreviewDestination(**split_destination(data.get("url") or ""))
 
+        created_at = link.created_at()
         return PublicPreviewResponse(
-            generation="v1",
-            alias=alias,
-            short_url=f"https://{self._system_default_domain}/{alias}",
+            generation=link.generation,
+            alias=link.alias,
+            short_url=link.short_url,
             status=status,
-            created_at=self._v1_created_at(data),
+            created_at=created_at.isoformat() if created_at else None,
             password_protected=password_protected,
             destination=destination,
             geo_destinations=None,  # geo targeting is v2-only
         )
-
-    @staticmethod
-    def _v1_is_expired(data: dict) -> bool:
-        """Mirror the legacy stats page's expired logic (routes/legacy/
-        stats.py): max-clicks reached or ``expiration-time`` passed.
-
-        Like ``convert_to_gmt``, a timezone-naive expiration is ambiguous
-        and never counts as expired; unparseable ancient values are
-        treated the same rather than 500-ing a public page.
-        """
-        max_clicks = data.get("max-clicks")
-        if max_clicks is not None:
-            try:
-                if int(data.get("total-clicks") or 0) >= int(max_clicks):
-                    return True
-            except (TypeError, ValueError):
-                pass
-
-        raw_expiration = data.get("expiration-time")
-        if raw_expiration is None:
-            return False
-        if isinstance(raw_expiration, datetime):
-            expires_at = raw_expiration if raw_expiration.tzinfo else None
-        else:
-            try:
-                expires_at = convert_to_gmt(str(raw_expiration))
-            except (TypeError, ValueError):
-                expires_at = None
-        return expires_at is not None and expires_at.astimezone(
-            timezone.utc
-        ) <= datetime.now(timezone.utc)
-
-    @staticmethod
-    def _v1_created_at(data: dict) -> str | None:
-        """Combine v1 ``creation-date`` + ``creation-time`` (both set at
-        shorten time) into an ISO string; either missing or unparseable →
-        ``None`` — ancient rows lack them and the frontend omits the line.
-        """
-        date = data.get("creation-date")
-        time = data.get("creation-time")
-        if not date or not time:
-            return None
-        created_at = parse_datetime(f"{date}T{time}")
-        return created_at.isoformat() if created_at else None
-
-    # ── Shared helpers ────────────────────────────────────────────────────
-
-    @staticmethod
-    def _as_aware_utc(dt: Any) -> datetime | None:
-        """Normalize a stored datetime for comparison — Mongo returns naive
-        UTC datetimes by default (the client is not ``tz_aware``)."""
-        if not isinstance(dt, datetime):
-            return None
-        if dt.tzinfo is None:
-            return dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc)

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -147,7 +147,7 @@ class PublicStatsService:
         started = time.perf_counter()
         code = unquote(short_code)
 
-        doc, schema = await self._resolve(code)
+        doc, schema, raw_v1 = await self._resolve(code)
         if doc is None:
             raise NotFoundError("short_code not found")
 
@@ -188,7 +188,9 @@ class PublicStatsService:
         alias = doc.alias if is_v2 else code
         now = datetime.now(timezone.utc)
         status = self._effective_status(doc, is_v2, now)
-        link = self._link_facts(doc, alias, status, is_v2=is_v2, is_owner=is_owner)
+        link = self._link_facts(
+            doc, alias, status, is_v2=is_v2, is_owner=is_owner, raw_v1=raw_v1
+        )
 
         if is_v2:
             stats = await self._query_v2_stats(doc, window_start, window_end, tz_name)
@@ -214,30 +216,52 @@ class PublicStatsService:
 
     # ── Private: resolution ───────────────────────────────────────────────────
 
-    async def _resolve(self, code: str) -> tuple[_PublicDoc | None, SchemaVersion]:
+    async def _resolve(
+        self, code: str
+    ) -> tuple[_PublicDoc | None, SchemaVersion, dict | None]:
         """Domain-scoped dispatch, mirroring UrlService._dispatch.
 
         emoji → emojis only; 7 chars → urlsV2 then urls; 6 chars → urls
         then urlsV2; anything else → urlsV2 then urls. v2 lookups are
         scoped to the system default domain; v1/emoji only exist there —
         custom-tenant aliases never resolve on this endpoint.
+
+        Returns ``(typed doc, schema, raw v1 dict)`` — the raw dict (None
+        for v2) carries fields the typed model drops (``creation-date`` /
+        ``creation-time``); one DB read serves both views.
         """
         if is_emoji_alias(code):
-            return await self._emoji_repo.find_by_id(code), SchemaVersion.EMOJI
+            raw = await self._find_v1_raw(self._emoji_repo, code)
+            return EmojiUrlDoc.from_mongo(raw), SchemaVersion.EMOJI, raw
 
         if len(code) == 6:
-            v1_doc = await self._legacy_repo.find_by_id(code)
-            if v1_doc is not None:
-                return v1_doc, SchemaVersion.V1
+            raw = await self._find_v1_raw(self._legacy_repo, code)
+            if raw is not None:
+                return LegacyUrlDoc.from_mongo(raw), SchemaVersion.V1, raw
             v2_doc = await self._url_repo.find_by_alias(
                 code, self._system_default_domain
             )
-            return v2_doc, SchemaVersion.V2
+            return v2_doc, SchemaVersion.V2, None
 
         v2_doc = await self._url_repo.find_by_alias(code, self._system_default_domain)
         if v2_doc is not None:
-            return v2_doc, SchemaVersion.V2
-        return await self._legacy_repo.find_by_id(code), SchemaVersion.V1
+            return v2_doc, SchemaVersion.V2, None
+        raw = await self._find_v1_raw(self._legacy_repo, code)
+        return LegacyUrlDoc.from_mongo(raw), SchemaVersion.V1, raw
+
+    @staticmethod
+    async def _find_v1_raw(
+        repo: LegacyUrlRepository | EmojiUrlRepository, code: str
+    ) -> dict | None:
+        """Fetch a v1/emoji document as a RAW dict by exact ``_id`` match.
+
+        Not ``find_by_id``: that returns a typed ``LegacyUrlDoc``, which
+        silently drops ``creation-date`` / ``creation-time`` (the model
+        doesn't declare them and pydantic ignores extras) — and the link
+        facts need them for ``created_at``. Same pattern as the public
+        preview endpoint, so /stats/{code} and /{code}+ agree.
+        """
+        return await repo.aggregate([{"$match": {"_id": code}}])
 
     # ── Private: gates and derived facts ──────────────────────────────────────
 
@@ -288,6 +312,7 @@ class PublicStatsService:
         *,
         is_v2: bool,
         is_owner: bool,
+        raw_v1: dict | None = None,
     ) -> dict[str, Any]:
         long_url = doc.long_url if is_v2 else doc.url
         return {
@@ -297,13 +322,29 @@ class PublicStatsService:
             # expired, paused, or blocked link's stats page must not out
             # the destination. Owner sessions always get it.
             "long_url": long_url if (status == "active" or is_owner) else None,
-            # v1/emoji docs never stored a creation timestamp.
-            "created_at": _as_utc(doc.created_at) if is_v2 else None,
+            "created_at": (
+                _as_utc(doc.created_at) if is_v2 else self._v1_created_at(raw_v1)
+            ),
             "status": status,
             "max_clicks": doc.max_clicks,
             "block_bots": bool(doc.block_bots),
             "password_protected": bool(doc.password),
         }
+
+    @staticmethod
+    def _v1_created_at(raw_v1: dict | None) -> datetime | None:
+        """Combine v1 ``creation-date`` + ``creation-time`` (both set at
+        shorten time) into a datetime; either missing or unparseable →
+        ``None`` — ancient rows lack them and the page omits the line.
+        Same rule as the public preview endpoint.
+        """
+        if not raw_v1:
+            return None
+        date = raw_v1.get("creation-date")
+        time_of_day = raw_v1.get("creation-time")
+        if not date or not time_of_day:
+            return None
+        return parse_datetime(f"{date}T{time_of_day}")
 
     # ── Private: date window ──────────────────────────────────────────────────
 

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -1,10 +1,13 @@
 """
 PublicStatsService — public per-link statistics for the /stats/{code} page.
 
-Resolves a short code across BOTH URL generations (``urlsV2``, legacy
-``urls``, ``emojis``) scoped to the system default domain, enforces the
-public-page privacy rules, and returns link facts plus the modern stats
-wire shape (identical keys to GET /api/v1/stats).
+Resolves a short code across BOTH URL generations and returns link facts
+plus the modern stats wire shape (identical keys to GET /api/v1/stats).
+
+Resolution, raw v1/emoji reads, derived effective status, and created_at
+all come from ``services.public_link_resolver`` — the single source of
+truth shared with the public preview endpoint, so the two public surfaces
+can never disagree about which link a code names or what state it is in.
 
 Privacy semantics (frozen contract):
   - a v2 link with private stats answers BYTE-IDENTICALLY to a missing
@@ -30,7 +33,6 @@ from __future__ import annotations
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from urllib.parse import unquote
 
 from bson import ObjectId
 
@@ -42,25 +44,16 @@ from errors import (
 )
 from infrastructure.crypto import verify_password
 from infrastructure.logging import get_logger
-from repositories.legacy.emoji_url_repository import EmojiUrlRepository
-from repositories.legacy.legacy_url_repository import LegacyUrlRepository
-from repositories.url_repository import UrlRepository
 from schemas.enums.stats import StatsScope
-from schemas.models.url import (
-    EmojiUrlDoc,
-    LegacyUrlDoc,
-    SchemaVersion,
-    UrlStatus,
-    UrlV2Doc,
-)
+from schemas.models.url import LegacyUrlDoc, UrlV2Doc
+from services.public_link_resolver import PublicLinkResolver, ResolvedPublicLink
 from services.stats_service import StatsService
 from shared.aggregation_strategies import convert_country_name
 from shared.datetime_utils import parse_datetime
-from shared.validators import is_emoji_alias
 
 log = get_logger(__name__)
 
-_PublicDoc = UrlV2Doc | LegacyUrlDoc | EmojiUrlDoc
+_PublicDoc = UrlV2Doc | LegacyUrlDoc
 
 # Dimensions are FIXED per generation (no group_by on the wire). v1 never
 # emits city (not stored); v2 never emits bots (tracked per-click, not as
@@ -72,43 +65,25 @@ _METRICS = ["clicks", "unique_clicks"]
 _V1_LAST_CLICK_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-def _as_utc(dt: datetime | None) -> datetime | None:
-    """Make a stored datetime timezone-aware (BSON datetimes are naive UTC)."""
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
-
-
 class PublicStatsService:
     """Public stats query service.
 
     Args:
-        url_repo:              Repository for the ``urlsV2`` collection.
-        legacy_repo:           Repository for the legacy ``urls`` collection.
-        emoji_repo:            Repository for the ``emojis`` collection.
-        stats_service:         The shared StatsService (v2 aggregation reuse).
-        system_default_domain: Canonical fqdn — resolution is scoped to it;
-                               custom-tenant aliases never resolve here.
-        max_date_range_days:   Maximum allowed date range in days.
+        resolver:            The shared public-link resolver (resolution,
+                             raw v1 reads, derived status, created_at).
+        stats_service:       The shared StatsService (v2 aggregation reuse).
+        max_date_range_days: Maximum allowed date range in days.
     """
 
     def __init__(
         self,
-        url_repo: UrlRepository,
-        legacy_repo: LegacyUrlRepository,
-        emoji_repo: EmojiUrlRepository,
+        resolver: PublicLinkResolver,
         stats_service: StatsService,
         *,
-        system_default_domain: str,
         max_date_range_days: int = 90,
     ) -> None:
-        self._url_repo = url_repo
-        self._legacy_repo = legacy_repo
-        self._emoji_repo = emoji_repo
+        self._resolver = resolver
         self._stats = stats_service
-        self._system_default_domain = system_default_domain
         self._max_date_range_days = max_date_range_days
 
     # ── Public API ────────────────────────────────────────────────────────────
@@ -149,14 +124,16 @@ class PublicStatsService:
         legacy /stats page.
         """
         started = time.perf_counter()
-        code = unquote(short_code)
 
-        doc, schema, raw_v1 = await self._resolve(code)
-        if doc is None:
+        link = await self._resolver.resolve(short_code)
+        if link is None:
             raise NotFoundError("short_code not found")
 
-        is_v2 = schema == SchemaVersion.V2
-        generation = "v2" if is_v2 else "v1"
+        is_v2 = link.is_v2
+        # The resolver keeps v1 docs RAW (legacy-only fields survive for
+        # created_at); typed access (parsed datetimes, int coercion, map
+        # defaults) drives the gates and the synthesis.
+        doc: _PublicDoc = link.v2_doc if is_v2 else LegacyUrlDoc.from_mongo(link.raw_v1)
 
         # Owner bypass rides the same request. The anonymous sentinel
         # owner_id can never equal a real user id, so no special-casing.
@@ -168,7 +145,9 @@ class PublicStatsService:
         # legacy schema never grew a private_stats field) — public by
         # design, mirroring the shipped legacy /stats page.
         if is_v2 and doc.private_stats and not is_owner:
-            log.info("public_stats_denied", reason="private_stats", short_code=code)
+            log.info(
+                "public_stats_denied", reason="private_stats", short_code=link.alias
+            )
             raise NotFoundError("short_code not found")
 
         if not is_owner and doc.password:
@@ -176,14 +155,14 @@ class PublicStatsService:
                 log.info(
                     "public_stats_denied",
                     reason="password_required",
-                    short_code=code,
+                    short_code=link.alias,
                 )
                 raise PasswordRequiredError("this link's stats are password protected")
             if not self._password_matches(doc, is_v2, password):
                 log.info(
                     "public_stats_denied",
                     reason="invalid_password",
-                    short_code=code,
+                    short_code=link.alias,
                 )
                 raise InvalidPasswordError("incorrect password")
 
@@ -191,25 +170,21 @@ class PublicStatsService:
             start_date, end_date, tz_name
         )
 
-        alias = doc.alias if is_v2 else code
-        now = datetime.now(timezone.utc)
-        status = self._effective_status(doc, is_v2, now)
-        link = self._link_facts(
-            doc, alias, status, is_v2=is_v2, is_owner=is_owner, raw_v1=raw_v1
-        )
+        status = link.effective_status()
+        facts = self._link_facts(link, doc, status, is_owner=is_owner)
 
         if is_v2:
             stats = await self._query_v2_stats(doc, window_start, window_end, tz_name)
         else:
             stats = self._synthesize_v1_stats(
-                doc, alias, window_start, window_end, tz_name
+                doc, link.alias, window_start, window_end, tz_name
             )
 
         duration_ms = int((time.perf_counter() - started) * 1000)
         log.info(
             "public_stats_query",
-            short_code=alias,
-            generation=generation,
+            short_code=link.alias,
+            generation=link.generation,
             status=status,
             owner_bypass=is_owner,
             start_date=window_start.isoformat(),
@@ -218,60 +193,7 @@ class PublicStatsService:
             duration_ms=duration_ms,
         )
 
-        return {"generation": generation, "link": link, "stats": stats}
-
-    # ── Private: resolution ───────────────────────────────────────────────────
-
-    async def _resolve(
-        self, code: str
-    ) -> tuple[_PublicDoc | None, SchemaVersion, dict | None]:
-        """Domain-scoped dispatch, mirroring UrlService._dispatch.
-
-        emoji → emojis only; 7 chars → urlsV2 then urls; 6 chars → urls
-        then urlsV2; anything else → urlsV2 then urls. v2 lookups are
-        scoped to the system default domain; v1/emoji only exist there —
-        custom-tenant aliases never resolve on this endpoint.
-
-        Returns ``(typed doc, schema, raw v1 dict)`` — the raw dict (None
-        for v2) carries fields the typed model drops (``creation-date`` /
-        ``creation-time``); one DB read serves both views.
-        """
-        if is_emoji_alias(code):
-            raw = await self._find_v1_raw(self._emoji_repo, code)
-            if raw is None:  # emoji misses never fall through to urls/urlsV2
-                return None, SchemaVersion.EMOJI, None
-            return EmojiUrlDoc.from_mongo(raw), SchemaVersion.EMOJI, raw
-
-        if len(code) == 6:
-            raw = await self._find_v1_raw(self._legacy_repo, code)
-            if raw is not None:
-                return LegacyUrlDoc.from_mongo(raw), SchemaVersion.V1, raw
-            v2_doc = await self._url_repo.find_by_alias(
-                code, self._system_default_domain
-            )
-            return v2_doc, SchemaVersion.V2, None
-
-        v2_doc = await self._url_repo.find_by_alias(code, self._system_default_domain)
-        if v2_doc is not None:
-            return v2_doc, SchemaVersion.V2, None
-        raw = await self._find_v1_raw(self._legacy_repo, code)
-        if raw is None:  # missed both generations
-            return None, SchemaVersion.V1, None
-        return LegacyUrlDoc.from_mongo(raw), SchemaVersion.V1, raw
-
-    @staticmethod
-    async def _find_v1_raw(
-        repo: LegacyUrlRepository | EmojiUrlRepository, code: str
-    ) -> dict | None:
-        """Fetch a v1/emoji document as a RAW dict by exact ``_id`` match.
-
-        Not ``find_by_id``: that returns a typed ``LegacyUrlDoc``, which
-        silently drops ``creation-date`` / ``creation-time`` (the model
-        doesn't declare them and pydantic ignores extras) — and the link
-        facts need them for ``created_at``. Same pattern as the public
-        preview endpoint, so /stats/{code} and /{code}+ agree.
-        """
-        return await repo.aggregate([{"$match": {"_id": code}}])
+        return {"generation": link.generation, "link": facts, "stats": stats}
 
     # ── Private: gates and derived facts ──────────────────────────────────────
 
@@ -282,79 +204,28 @@ class PublicStatsService:
             return verify_password(password, doc.password)
         return password == doc.password
 
-    def _effective_status(self, doc: _PublicDoc, is_v2: bool, now: datetime) -> str:
-        """Derive the wire status (lowercase) — READ-ONLY, no writes.
-
-        The persisted EXPIRED flip happens on the click path; this endpoint
-        must never report "active" for a link the redirect would refuse.
-        """
-        if is_v2:
-            if doc.status == UrlStatus.ACTIVE and self._expiry_reached(
-                doc.expire_after, doc.max_clicks, doc.total_clicks, now
-            ):
-                return "expired"
-            return doc.status.value.lower()
-        # v1/emoji docs have no status field — mirror the legacy stats
-        # page's inline rule: expiration-time passed or max-clicks reached.
-        if self._expiry_reached(
-            doc.expiration_time, doc.max_clicks, doc.total_clicks, now
-        ):
-            return "expired"
-        return "active"
-
     @staticmethod
-    def _expiry_reached(
-        expire_at: datetime | None,
-        max_clicks: int | None,
-        total_clicks: int,
-        now: datetime,
-    ) -> bool:
-        if max_clicks is not None and total_clicks >= max_clicks:
-            return True
-        expire_at = _as_utc(expire_at)
-        return expire_at is not None and expire_at <= now
-
     def _link_facts(
-        self,
+        link: ResolvedPublicLink,
         doc: _PublicDoc,
-        alias: str,
         status: str,
         *,
-        is_v2: bool,
         is_owner: bool,
-        raw_v1: dict | None = None,
     ) -> dict[str, Any]:
-        long_url = doc.long_url if is_v2 else doc.url
+        long_url = doc.long_url if link.is_v2 else doc.url
         return {
-            "alias": alias,
-            "short_url": f"https://{self._system_default_domain}/{alias}",
+            "alias": link.alias,
+            "short_url": link.short_url,
             # Destination-only-while-active, like the preview page: an
             # expired, paused, or blocked link's stats page must not out
             # the destination. Owner sessions always get it.
             "long_url": long_url if (status == "active" or is_owner) else None,
-            "created_at": (
-                _as_utc(doc.created_at) if is_v2 else self._v1_created_at(raw_v1)
-            ),
+            "created_at": link.created_at(),
             "status": status,
             "max_clicks": doc.max_clicks,
             "block_bots": bool(doc.block_bots),
             "password_protected": bool(doc.password),
         }
-
-    @staticmethod
-    def _v1_created_at(raw_v1: dict | None) -> datetime | None:
-        """Combine v1 ``creation-date`` + ``creation-time`` (both set at
-        shorten time) into a datetime; either missing or unparseable →
-        ``None`` — ancient rows lack them and the page omits the line.
-        Same rule as the public preview endpoint.
-        """
-        if not raw_v1:
-            return None
-        date = raw_v1.get("creation-date")
-        time_of_day = raw_v1.get("creation-time")
-        if not date or not time_of_day:
-            return None
-        return parse_datetime(f"{date}T{time_of_day}")
 
     # ── Private: date window ──────────────────────────────────────────────────
 
@@ -428,7 +299,7 @@ class PublicStatsService:
 
     def _synthesize_v1_stats(
         self,
-        doc: LegacyUrlDoc | EmojiUrlDoc,
+        doc: LegacyUrlDoc,
         alias: str,
         start_date: datetime,
         end_date: datetime,

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -31,7 +31,6 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import unquote
-from zoneinfo import available_timezones
 
 from bson import ObjectId
 
@@ -54,7 +53,7 @@ from schemas.models.url import (
     UrlStatus,
     UrlV2Doc,
 )
-from services.stats_service import _TIMEZONE_ALIASES, StatsService
+from services.stats_service import StatsService
 from shared.aggregation_strategies import convert_country_name
 from shared.datetime_utils import parse_datetime
 from shared.validators import is_emoji_alias
@@ -143,6 +142,11 @@ class PublicStatsService:
             PasswordRequiredError: Password set, none supplied (401).
             InvalidPasswordError:  Password set, wrong one supplied (401).
             ValidationError:       Bad dates / range too large.
+
+        Note: the privacy gate only applies to v2 — legacy docs have no
+        privacy concept (no ``private_stats`` field exists), so v1/emoji
+        stats are public BY DESIGN, intentional parity with the shipped
+        legacy /stats page.
         """
         started = time.perf_counter()
         code = unquote(short_code)
@@ -160,7 +164,9 @@ class PublicStatsService:
 
         # Private stats answer exactly like a missing code. Semantics:
         # True = private (owned default), None = anonymous/unowned = public,
-        # False = explicitly public. v1/emoji have no flag — always public.
+        # False = explicitly public. v1/emoji have NO privacy concept (the
+        # legacy schema never grew a private_stats field) — public by
+        # design, mirroring the shipped legacy /stats page.
         if is_v2 and doc.private_stats and not is_owner:
             log.info("public_stats_denied", reason="private_stats", short_code=code)
             raise NotFoundError("short_code not found")
@@ -232,6 +238,8 @@ class PublicStatsService:
         """
         if is_emoji_alias(code):
             raw = await self._find_v1_raw(self._emoji_repo, code)
+            if raw is None:  # emoji misses never fall through to urls/urlsV2
+                return None, SchemaVersion.EMOJI, None
             return EmojiUrlDoc.from_mongo(raw), SchemaVersion.EMOJI, raw
 
         if len(code) == 6:
@@ -247,6 +255,8 @@ class PublicStatsService:
         if v2_doc is not None:
             return v2_doc, SchemaVersion.V2, None
         raw = await self._find_v1_raw(self._legacy_repo, code)
+        if raw is None:  # missed both generations
+            return None, SchemaVersion.V1, None
         return LegacyUrlDoc.from_mongo(raw), SchemaVersion.V1, raw
 
     @staticmethod
@@ -383,12 +393,7 @@ class PublicStatsService:
                 f"date range cannot exceed {self._max_date_range_days} days"
             )
 
-        tz_name = _TIMEZONE_ALIASES.get(tz_name, tz_name)
-        if tz_name not in available_timezones():
-            log.info("invalid_timezone_provided", timezone=tz_name, fallback="UTC")
-            tz_name = "UTC"
-
-        return start, end, tz_name
+        return start, end, self._stats.normalize_timezone(tz_name)
 
     # ── Private: v2 stats (StatsService reuse, scoped by url_id) ─────────────
 
@@ -408,22 +413,16 @@ class PublicStatsService:
             "meta.url_id": doc.id,
             "clicked_at": {"$gte": start_date, "$lte": end_date},
         }
-        summary, aggregation_results = await self._stats._execute_all_stats(
-            click_query, _V2_GROUP_BY, start_date, end_date, tz_name
+        return await self._stats.compute(
+            click_query,
+            scope=StatsScope.ANON,
+            short_code=doc.alias,
+            start_date=start_date,
+            end_date=end_date,
+            group_by=_V2_GROUP_BY,
+            metrics=_METRICS,
+            tz_name=tz_name,
         )
-        response = self._stats._format_results(
-            StatsScope.ANON,
-            doc.alias,
-            start_date,
-            end_date,
-            {},
-            _V2_GROUP_BY,
-            _METRICS,
-            tz_name,
-            aggregation_results,
-        )
-        response["summary"] = summary
-        return self._stats._add_metadata(response)
 
     # ── Private: v1/emoji stats (synthesized from the embedded doc) ──────────
 
@@ -493,7 +492,7 @@ class PublicStatsService:
             "total_clicks": doc.total_clicks,
             "unique_clicks": len(doc.ips or []),
             "first_click": None,  # not stored on v1 docs
-            "last_click": self._stats._to_user_tz(last_click, tz_name),
+            "last_click": self._stats.to_user_tz(last_click, tz_name),
             "avg_redirection_time": round(doc.average_redirection_time or 0, 2),
         }
 
@@ -504,8 +503,8 @@ class PublicStatsService:
             "timezone": tz_name,
             "short_code": alias,
             "time_range": {
-                "start_date": self._stats._to_user_tz(start_date, tz_name),
-                "end_date": self._stats._to_user_tz(end_date, tz_name),
+                "start_date": self._stats.to_user_tz(start_date, tz_name),
+                "end_date": self._stats.to_user_tz(end_date, tz_name),
             },
             # The frontend adapter picks bucket size and zero-fills from
             # this — v1 counters are daily, full stop.
@@ -519,7 +518,7 @@ class PublicStatsService:
             "metrics": metrics,
             "summary": summary,
         }
-        return self._stats._add_metadata(response)
+        return self._stats.add_metadata(response)
 
     @staticmethod
     def _v1_dimension_rows(

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -1,0 +1,514 @@
+"""
+PublicStatsService — public per-link statistics for the /stats/{code} page.
+
+Resolves a short code across BOTH URL generations (``urlsV2``, legacy
+``urls``, ``emojis``) scoped to the system default domain, enforces the
+public-page privacy rules, and returns link facts plus the modern stats
+wire shape (identical keys to GET /api/v1/stats).
+
+Privacy semantics (frozen contract):
+  - a v2 link with private stats answers BYTE-IDENTICALLY to a missing
+    code (no oracle distinguishing "private" from "absent");
+  - password-protected links answer 401 ``password_required`` until the
+    password arrives in a POST body; a wrong password is 401
+    ``invalid_password``; a password never rides a URL;
+  - an authenticated owner bypasses both the privacy and password gates.
+
+v2 analytics reuse StatsService's aggregation machinery scoped by
+``meta.url_id`` (never ``meta.short_code`` — a same-alias link on a custom
+domain must not bleed in). v1/emoji analytics are synthesized into the
+same wire shape from the embedded document counters: dimensions are
+LIFETIME totals (that's all v1 stores), only the daily time series is
+windowed.
+
+Framework-agnostic: no FastAPI imports. Status is derived READ-ONLY —
+this service never writes.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import unquote
+from zoneinfo import available_timezones
+
+from bson import ObjectId
+
+from errors import (
+    InvalidPasswordError,
+    NotFoundError,
+    PasswordRequiredError,
+    ValidationError,
+)
+from infrastructure.crypto import verify_password
+from infrastructure.logging import get_logger
+from repositories.legacy.emoji_url_repository import EmojiUrlRepository
+from repositories.legacy.legacy_url_repository import LegacyUrlRepository
+from repositories.url_repository import UrlRepository
+from schemas.enums.stats import StatsScope
+from schemas.models.url import (
+    EmojiUrlDoc,
+    LegacyUrlDoc,
+    SchemaVersion,
+    UrlStatus,
+    UrlV2Doc,
+)
+from services.stats_service import _TIMEZONE_ALIASES, StatsService
+from shared.aggregation_strategies import convert_country_name
+from shared.datetime_utils import parse_datetime
+from shared.validators import is_emoji_alias
+
+log = get_logger(__name__)
+
+_PublicDoc = UrlV2Doc | LegacyUrlDoc | EmojiUrlDoc
+
+# Dimensions are FIXED per generation (no group_by on the wire). v1 never
+# emits city (not stored); v2 never emits bots (tracked per-click, not as
+# a dimension the public page shows).
+_V2_GROUP_BY = ["time", "browser", "os", "country", "city", "referrer"]
+_V1_GROUP_BY = ["time", "browser", "os", "country", "referrer"]
+_METRICS = ["clicks", "unique_clicks"]
+
+_V1_LAST_CLICK_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    """Make a stored datetime timezone-aware (BSON datetimes are naive UTC)."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+class PublicStatsService:
+    """Public stats query service.
+
+    Args:
+        url_repo:              Repository for the ``urlsV2`` collection.
+        legacy_repo:           Repository for the legacy ``urls`` collection.
+        emoji_repo:            Repository for the ``emojis`` collection.
+        stats_service:         The shared StatsService (v2 aggregation reuse).
+        system_default_domain: Canonical fqdn — resolution is scoped to it;
+                               custom-tenant aliases never resolve here.
+        max_date_range_days:   Maximum allowed date range in days.
+    """
+
+    def __init__(
+        self,
+        url_repo: UrlRepository,
+        legacy_repo: LegacyUrlRepository,
+        emoji_repo: EmojiUrlRepository,
+        stats_service: StatsService,
+        *,
+        system_default_domain: str,
+        max_date_range_days: int = 90,
+    ) -> None:
+        self._url_repo = url_repo
+        self._legacy_repo = legacy_repo
+        self._emoji_repo = emoji_repo
+        self._stats = stats_service
+        self._system_default_domain = system_default_domain
+        self._max_date_range_days = max_date_range_days
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    async def get_public_stats(
+        self,
+        short_code: str,
+        *,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        tz_name: str = "UTC",
+        password: str | None = None,
+        user_id: ObjectId | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a short code and return its public stats payload.
+
+        Args:
+            short_code: Path alias (may arrive percent-encoded — emoji).
+            start_date: ISO datetime string; defaults to end_date - 7 days.
+            end_date:   ISO datetime string; defaults to now.
+            tz_name:    IANA timezone for bucketing/formatting.
+            password:   Password from a POST body (never from a URL).
+            user_id:    Authenticated user id, if any (owner bypass).
+
+        Returns:
+            ``{"generation", "link", "stats"}`` ready for the response DTO.
+
+        Raises:
+            NotFoundError:         Unknown code — or private stats
+                                   (byte-identical body, no oracle).
+            PasswordRequiredError: Password set, none supplied (401).
+            InvalidPasswordError:  Password set, wrong one supplied (401).
+            ValidationError:       Bad dates / range too large.
+        """
+        started = time.perf_counter()
+        code = unquote(short_code)
+
+        doc, schema = await self._resolve(code)
+        if doc is None:
+            raise NotFoundError("short_code not found")
+
+        is_v2 = schema == SchemaVersion.V2
+        generation = "v2" if is_v2 else "v1"
+
+        # Owner bypass rides the same request. The anonymous sentinel
+        # owner_id can never equal a real user id, so no special-casing.
+        is_owner = bool(is_v2 and user_id is not None and doc.owner_id == user_id)
+
+        # Private stats answer exactly like a missing code. Semantics:
+        # True = private (owned default), None = anonymous/unowned = public,
+        # False = explicitly public. v1/emoji have no flag — always public.
+        if is_v2 and doc.private_stats and not is_owner:
+            log.info("public_stats_denied", reason="private_stats", short_code=code)
+            raise NotFoundError("short_code not found")
+
+        if not is_owner and doc.password:
+            if not password:
+                log.info(
+                    "public_stats_denied",
+                    reason="password_required",
+                    short_code=code,
+                )
+                raise PasswordRequiredError("this link's stats are password protected")
+            if not self._password_matches(doc, is_v2, password):
+                log.info(
+                    "public_stats_denied",
+                    reason="invalid_password",
+                    short_code=code,
+                )
+                raise InvalidPasswordError("incorrect password")
+
+        window_start, window_end, tz_name = self._resolve_window(
+            start_date, end_date, tz_name
+        )
+
+        alias = doc.alias if is_v2 else code
+        now = datetime.now(timezone.utc)
+        status = self._effective_status(doc, is_v2, now)
+        link = self._link_facts(doc, alias, status, is_v2=is_v2, is_owner=is_owner)
+
+        if is_v2:
+            stats = await self._query_v2_stats(doc, window_start, window_end, tz_name)
+        else:
+            stats = self._synthesize_v1_stats(
+                doc, alias, window_start, window_end, tz_name
+            )
+
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        log.info(
+            "public_stats_query",
+            short_code=alias,
+            generation=generation,
+            status=status,
+            owner_bypass=is_owner,
+            start_date=window_start.isoformat(),
+            end_date=window_end.isoformat(),
+            total_clicks=stats.get("summary", {}).get("total_clicks", 0),
+            duration_ms=duration_ms,
+        )
+
+        return {"generation": generation, "link": link, "stats": stats}
+
+    # ── Private: resolution ───────────────────────────────────────────────────
+
+    async def _resolve(self, code: str) -> tuple[_PublicDoc | None, SchemaVersion]:
+        """Domain-scoped dispatch, mirroring UrlService._dispatch.
+
+        emoji → emojis only; 7 chars → urlsV2 then urls; 6 chars → urls
+        then urlsV2; anything else → urlsV2 then urls. v2 lookups are
+        scoped to the system default domain; v1/emoji only exist there —
+        custom-tenant aliases never resolve on this endpoint.
+        """
+        if is_emoji_alias(code):
+            return await self._emoji_repo.find_by_id(code), SchemaVersion.EMOJI
+
+        if len(code) == 6:
+            v1_doc = await self._legacy_repo.find_by_id(code)
+            if v1_doc is not None:
+                return v1_doc, SchemaVersion.V1
+            v2_doc = await self._url_repo.find_by_alias(
+                code, self._system_default_domain
+            )
+            return v2_doc, SchemaVersion.V2
+
+        v2_doc = await self._url_repo.find_by_alias(code, self._system_default_domain)
+        if v2_doc is not None:
+            return v2_doc, SchemaVersion.V2
+        return await self._legacy_repo.find_by_id(code), SchemaVersion.V1
+
+    # ── Private: gates and derived facts ──────────────────────────────────────
+
+    @staticmethod
+    def _password_matches(doc: _PublicDoc, is_v2: bool, password: str) -> bool:
+        """v2 stores an argon2 hash; v1/emoji store plaintext."""
+        if is_v2:
+            return verify_password(password, doc.password)
+        return password == doc.password
+
+    def _effective_status(self, doc: _PublicDoc, is_v2: bool, now: datetime) -> str:
+        """Derive the wire status (lowercase) — READ-ONLY, no writes.
+
+        The persisted EXPIRED flip happens on the click path; this endpoint
+        must never report "active" for a link the redirect would refuse.
+        """
+        if is_v2:
+            if doc.status == UrlStatus.ACTIVE and self._expiry_reached(
+                doc.expire_after, doc.max_clicks, doc.total_clicks, now
+            ):
+                return "expired"
+            return doc.status.value.lower()
+        # v1/emoji docs have no status field — mirror the legacy stats
+        # page's inline rule: expiration-time passed or max-clicks reached.
+        if self._expiry_reached(
+            doc.expiration_time, doc.max_clicks, doc.total_clicks, now
+        ):
+            return "expired"
+        return "active"
+
+    @staticmethod
+    def _expiry_reached(
+        expire_at: datetime | None,
+        max_clicks: int | None,
+        total_clicks: int,
+        now: datetime,
+    ) -> bool:
+        if max_clicks is not None and total_clicks >= max_clicks:
+            return True
+        expire_at = _as_utc(expire_at)
+        return expire_at is not None and expire_at <= now
+
+    def _link_facts(
+        self,
+        doc: _PublicDoc,
+        alias: str,
+        status: str,
+        *,
+        is_v2: bool,
+        is_owner: bool,
+    ) -> dict[str, Any]:
+        long_url = doc.long_url if is_v2 else doc.url
+        return {
+            "alias": alias,
+            "short_url": f"https://{self._system_default_domain}/{alias}",
+            # Destination-only-while-active, like the preview page: an
+            # expired, paused, or blocked link's stats page must not out
+            # the destination. Owner sessions always get it.
+            "long_url": long_url if (status == "active" or is_owner) else None,
+            # v1/emoji docs never stored a creation timestamp.
+            "created_at": _as_utc(doc.created_at) if is_v2 else None,
+            "status": status,
+            "max_clicks": doc.max_clicks,
+            "block_bots": bool(doc.block_bots),
+            "password_protected": bool(doc.password),
+        }
+
+    # ── Private: date window ──────────────────────────────────────────────────
+
+    def _resolve_window(
+        self,
+        start_raw: str | None,
+        end_raw: str | None,
+        tz_name: str,
+    ) -> tuple[datetime, datetime, str]:
+        """Defaults and validation mirroring StatsService.query."""
+        start = parse_datetime(start_raw) if start_raw else None
+        if start_raw and start is None:
+            raise ValidationError("invalid start_date format")
+        end = parse_datetime(end_raw) if end_raw else None
+        if end_raw and end is None:
+            raise ValidationError("invalid end_date format")
+
+        now = datetime.now(timezone.utc)
+        if start is None and end is None:
+            end = now
+            start = now - timedelta(days=7)
+        elif start is None:
+            start = end - timedelta(days=7)
+        elif end is None:
+            end = now
+
+        if start > now:
+            start = now
+        if end > now:
+            end = now
+
+        if start > end:
+            raise ValidationError("start_date must be before end_date")
+        if (end - start).days > self._max_date_range_days:
+            raise ValidationError(
+                f"date range cannot exceed {self._max_date_range_days} days"
+            )
+
+        tz_name = _TIMEZONE_ALIASES.get(tz_name, tz_name)
+        if tz_name not in available_timezones():
+            log.info("invalid_timezone_provided", timezone=tz_name, fallback="UTC")
+            tz_name = "UTC"
+
+        return start, end, tz_name
+
+    # ── Private: v2 stats (StatsService reuse, scoped by url_id) ─────────────
+
+    async def _query_v2_stats(
+        self,
+        doc: UrlV2Doc,
+        start_date: datetime,
+        end_date: datetime,
+        tz_name: str,
+    ) -> dict[str, Any]:
+        """Run the standard $facet aggregation scoped by ``meta.url_id``.
+
+        Matching on url_id — never meta.short_code — so a same-alias link
+        on a custom domain can never bleed into the public page.
+        """
+        click_query: dict[str, Any] = {
+            "meta.url_id": doc.id,
+            "clicked_at": {"$gte": start_date, "$lte": end_date},
+        }
+        summary, aggregation_results = await self._stats._execute_all_stats(
+            click_query, _V2_GROUP_BY, start_date, end_date, tz_name
+        )
+        response = self._stats._format_results(
+            StatsScope.ANON,
+            doc.alias,
+            start_date,
+            end_date,
+            {},
+            _V2_GROUP_BY,
+            _METRICS,
+            tz_name,
+            aggregation_results,
+        )
+        response["summary"] = summary
+        return self._stats._add_metadata(response)
+
+    # ── Private: v1/emoji stats (synthesized from the embedded doc) ──────────
+
+    def _synthesize_v1_stats(
+        self,
+        doc: LegacyUrlDoc | EmojiUrlDoc,
+        alias: str,
+        start_date: datetime,
+        end_date: datetime,
+        tz_name: str,
+    ) -> dict[str, Any]:
+        """Build the SAME wire shape from v1's embedded counters.
+
+        Dimension maps are lifetime totals (v1 never stored per-click
+        events); only the daily counter time series can honour the window.
+        """
+        metrics: dict[str, list[dict[str, Any]]] = {}
+
+        # counter keys are UTC day strings written by the click handler.
+        start_day = start_date.astimezone(timezone.utc).date().isoformat()
+        end_day = end_date.astimezone(timezone.utc).date().isoformat()
+        metrics["clicks_by_time"] = [
+            {"time": day, "clicks": int(count or 0)}
+            for day, count in sorted((doc.counter or {}).items())
+            if start_day <= day <= end_day
+        ]
+        metrics["unique_clicks_by_time"] = [
+            {"time": day, "unique_clicks": int(count or 0)}
+            for day, count in sorted((doc.unique_counter or {}).items())
+            if start_day <= day <= end_day
+        ]
+
+        dimensions: list[tuple[str, dict[str, Any], Any]] = [
+            ("browser", doc.browser, None),
+            # v1 stores the field as os_name; the wire key is "os".
+            ("os", doc.os_name, None),
+            # v1 stores display names (dots→spaces) — convert to ISO
+            # alpha-2 so flags render like v2 ("XX" fallback).
+            ("country", doc.country, convert_country_name),
+            ("referrer", doc.referrer, None),
+        ]
+        for key, source, transform in dimensions:
+            clicks_rows, unique_rows = self._v1_dimension_rows(source, key, transform)
+            metrics[f"clicks_by_{key}"] = clicks_rows
+            metrics[f"unique_clicks_by_{key}"] = unique_rows
+
+        # v1 tracks named-bot hits on the doc (no unique variant);
+        # v2 never emits this dimension.
+        metrics["clicks_by_bots"] = [
+            {"bots": name, "clicks": int(count or 0)}
+            for name, count in sorted(
+                (doc.bots or {}).items(), key=lambda item: item[1], reverse=True
+            )
+        ]
+
+        last_click = None
+        if doc.last_click:
+            try:
+                last_click = datetime.strptime(
+                    doc.last_click, _V1_LAST_CLICK_FORMAT
+                ).replace(tzinfo=timezone.utc)
+            except ValueError:
+                last_click = None
+
+        summary: dict[str, Any] = {
+            # Lifetime totals — matching the dimension maps.
+            "total_clicks": doc.total_clicks,
+            "unique_clicks": len(doc.ips or []),
+            "first_click": None,  # not stored on v1 docs
+            "last_click": self._stats._to_user_tz(last_click, tz_name),
+            "avg_redirection_time": round(doc.average_redirection_time or 0, 2),
+        }
+
+        response: dict[str, Any] = {
+            "scope": StatsScope.ANON,
+            "filters": {},
+            "group_by": list(_V1_GROUP_BY),
+            "timezone": tz_name,
+            "short_code": alias,
+            "time_range": {
+                "start_date": self._stats._to_user_tz(start_date, tz_name),
+                "end_date": self._stats._to_user_tz(end_date, tz_name),
+            },
+            # The frontend adapter picks bucket size and zero-fills from
+            # this — v1 counters are daily, full stop.
+            "time_bucket_info": {
+                "strategy": "daily",
+                "interval_minutes": 1440,
+                "display_format": "%Y-%m-%d",
+                "mongo_format": "%Y-%m-%d",
+                "timezone": tz_name,
+            },
+            "metrics": metrics,
+            "summary": summary,
+        }
+        return self._stats._add_metadata(response)
+
+    @staticmethod
+    def _v1_dimension_rows(
+        source: dict[str, Any] | None,
+        key: str,
+        transform: Any = None,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Turn a v1 ``{value: {"counts": n, "ips": [...]}}`` map into wire rows.
+
+        Returns (clicks_rows, unique_rows) sorted by clicks descending —
+        unique rows ride the same order so the frontend zip keeps the
+        backend's ranking. Values that transform to the same output (e.g.
+        two spellings hitting the "XX" country fallback) are merged.
+        """
+        clicks: dict[str, int] = {}
+        unique_ips: dict[str, set[str]] = {}
+        for raw_value, entry in (source or {}).items():
+            if isinstance(entry, dict):
+                count = int(entry.get("counts", 0) or 0)
+                ips = entry.get("ips") or []
+            else:  # defensively tolerate bare counters in legacy data
+                count = int(entry or 0)
+                ips = []
+            value = transform(raw_value) if transform else raw_value
+            clicks[value] = clicks.get(value, 0) + count
+            unique_ips.setdefault(value, set()).update(ips)
+
+        ordered = sorted(clicks, key=lambda value: clicks[value], reverse=True)
+        clicks_rows = [{key: value, "clicks": clicks[value]} for value in ordered]
+        unique_rows = [
+            {key: value, "unique_clicks": len(unique_ips[value])} for value in ordered
+        ]
+        return clicks_rows, unique_rows

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -57,6 +57,11 @@ _TIMEZONE_ALIASES: dict[str, str] = {
     "US/Pacific": "America/Los_Angeles",
 }
 
+# IANA name snapshot — available_timezones() rescans the tzdata files on
+# every call, far too heavy to rebuild per request. Membership checks use
+# this set instead.
+_KNOWN_TIMEZONES: frozenset[str] = frozenset(available_timezones())
+
 
 class StatsService:
     """Analytics query service.
@@ -77,10 +82,10 @@ class StatsService:
         self._click_repo = click_repo
         self._url_repo = url_repo
 
-    # ── Private: timezone helpers ─────────────────────────────────────────────
+    # ── Timezone helpers (shared with the public stats endpoint) ─────────────
 
     @staticmethod
-    def _to_user_tz(dt: datetime | None, tz_name: str) -> datetime | None:
+    def to_user_tz(dt: datetime | None, tz_name: str) -> datetime | None:
         """Convert a UTC datetime to the user's timezone."""
         if dt is None:
             return None
@@ -98,9 +103,22 @@ class StatsService:
             return dt
 
     @staticmethod
+    def normalize_timezone(tz_name: str) -> str:
+        """Map deprecated aliases to canonical IANA names; unknown → UTC.
+
+        Shared by ``query()`` and the public per-link stats endpoint so
+        both normalize identically (and neither rescans tzdata per call).
+        """
+        tz_name = _TIMEZONE_ALIASES.get(tz_name, tz_name)
+        if tz_name not in _KNOWN_TIMEZONES:
+            log.info("invalid_timezone_provided", timezone=tz_name, fallback="UTC")
+            tz_name = "UTC"
+        return tz_name
+
+    @staticmethod
     def _fmt_tz(dt: datetime | None, tz_name: str) -> datetime | None:
         """Convert a UTC datetime to the user's timezone."""
-        return StatsService._to_user_tz(dt, tz_name)
+        return StatsService.to_user_tz(dt, tz_name)
 
     # ── Private: query building ───────────────────────────────────────────────
 
@@ -283,7 +301,7 @@ class StatsService:
 
         return summary, results
 
-    # ── Private: response formatting ─────────────────────────────────────────
+    # ── Response formatting ──────────────────────────────────────────────────
 
     def _format_results(
         self,
@@ -360,10 +378,13 @@ class StatsService:
         return response
 
     @staticmethod
-    def _add_metadata(response: dict[str, Any]) -> dict[str, Any]:
+    def add_metadata(response: dict[str, Any]) -> dict[str, Any]:
         """Enhance the response with metadata and computed percentages.
 
         Preserves the exact logic from utils/stats_utils.format_stats_response_with_metadata().
+        Public: the v1 branch of the public stats endpoint decorates its
+        synthesized wire with this too, so percentages/computed_metrics
+        can never drift between generations.
         """
         response = response.copy()
 
@@ -405,6 +426,48 @@ class StatsService:
         return response
 
     # ── Public API ────────────────────────────────────────────────────────────
+
+    async def compute(
+        self,
+        click_query: dict[str, Any],
+        *,
+        scope: StatsScope,
+        short_code: str | None,
+        start_date: datetime,
+        end_date: datetime,
+        group_by: list[str],
+        metrics: list[str],
+        tz_name: str,
+        filters: dict[str, list[str]] | None = None,
+    ) -> dict[str, Any]:
+        """Run a pre-built clicks ``$match`` and format the standard wire.
+
+        The single public seam over the aggregation chain ($facet
+        execution → result formatting → summary → metadata). Both
+        ``query()`` and the public per-link stats endpoint go through
+        this, so the wire shape can never drift between the dashboard
+        and the public page.
+
+        The caller owns access control and scoping: ``click_query``
+        arrives fully built (owner-scoped, url_id-scoped, ...) with
+        already-validated dates and a normalized timezone.
+        """
+        summary, aggregation_results = await self._execute_all_stats(
+            click_query, group_by, start_date, end_date, tz_name
+        )
+        response = self._format_results(
+            scope,
+            short_code,
+            start_date,
+            end_date,
+            filters or {},
+            group_by,
+            metrics,
+            tz_name,
+            aggregation_results,
+        )
+        response["summary"] = summary
+        return self.add_metadata(response)
 
     async def query(
         self,
@@ -468,10 +531,7 @@ class StatsService:
             )
 
         # ── Validate timezone ─────────────────────────────────────────────────
-        tz_name = _TIMEZONE_ALIASES.get(tz_name, tz_name)
-        if tz_name not in available_timezones():
-            log.info("invalid_timezone_provided", timezone=tz_name, fallback="UTC")
-            tz_name = "UTC"
+        tz_name = self.normalize_timezone(tz_name)
 
         # ── Scope/target validation ───────────────────────────────────────────
         if scope == StatsScope.ANON:
@@ -510,28 +570,22 @@ class StatsService:
                 )
                 raise AuthenticationError("authentication required for scope=all")
 
-        # ── Execute ───────────────────────────────────────────────────────────
+        # ── Execute + format ──────────────────────────────────────────────────
         click_query = self._build_click_query(
             scope, owner_id, short_code, start_date, end_date, filters
         )
-        summary, aggregation_results = await self._execute_all_stats(
-            click_query, group_by, start_date, end_date, tz_name
+        response = await self.compute(
+            click_query,
+            scope=scope,
+            short_code=short_code,
+            start_date=start_date,
+            end_date=end_date,
+            group_by=group_by,
+            metrics=metrics,
+            tz_name=tz_name,
+            filters=filters,
         )
-
-        # ── Format ────────────────────────────────────────────────────────────
-        response = self._format_results(
-            scope,
-            short_code,
-            start_date,
-            end_date,
-            filters,
-            group_by,
-            metrics,
-            tz_name,
-            aggregation_results,
-        )
-        response["summary"] = summary
-        response = self._add_metadata(response)
+        summary = response.get("summary", {})
 
         duration_ms = int((time.perf_counter() - start_time) * 1000)
         log.info(

--- a/tests/integration/api_v1/test_public_preview.py
+++ b/tests/integration/api_v1/test_public_preview.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from dependencies.services import get_public_preview_service
 from schemas.models.url import UrlV2Doc
+from services.public_link_resolver import PublicLinkResolver
 from services.public_preview_service import PublicPreviewService
 
 from .conftest import _build_test_app, _make_url_doc
@@ -69,10 +70,12 @@ def _make_service(
     )
 
     return PublicPreviewService(
-        url_repo,
-        legacy_repo,
-        emoji_repo,
-        system_default_domain="spoo.me",
+        PublicLinkResolver(
+            url_repo,
+            legacy_repo,
+            emoji_repo,
+            system_default_domain="spoo.me",
+        )
     )
 
 

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -180,6 +180,28 @@ def test_explicitly_private_false_is_public():
     assert resp.json()["generation"] == "v2"
 
 
+# ── 1b. Resolver miss branches answer the same 404 explicitly ────────────────
+
+
+def test_missing_emoji_alias_answers_the_same_404():
+    # Emoji misses never fall through to the urls/urlsV2 collections.
+    service, _ = _build_service()  # emojis collection empty
+    with _client(service) as client:
+        resp = client.get(_url("🚀"))
+
+    assert resp.status_code == 404
+    assert resp.json() == _NOT_FOUND_BODY
+
+
+def test_seven_char_alias_missing_in_both_generations_is_404():
+    service, _ = _build_service()  # urlsV2 AND urls both miss
+    with _client(service) as client:
+        resp = client.get(_url("absent9"))
+
+    assert resp.status_code == 404
+    assert resp.json() == _NOT_FOUND_BODY
+
+
 # ── 2. Anonymous (private_stats=None) is public + link facts wire shape ──────
 
 
@@ -292,6 +314,25 @@ def test_v2_password_gates():
         right = client.post(_url("locked1"), json={"password": "sesame"})
         assert right.status_code == 200
         assert right.json()["link"]["password_protected"] is True
+
+
+# ── 4b. v1/emoji have no privacy gate — deliberate legacy parity ─────────────
+
+
+def test_v1_stats_are_public_by_design_legacy_parity():
+    """v1/emoji stats are PUBLIC by design — pinned as deliberate.
+
+    The legacy schema has no ``private_stats`` field (no privacy concept
+    exists to enforce), and the shipped legacy /stats/{code} page has
+    always served these stats to anyone. Intentional parity: do NOT
+    invent a v1 privacy mechanism here.
+    """
+    service, _ = _build_service(v1_docs={"legacy": _v1_data("legacy")})
+    with _client(service) as client:
+        resp = client.get(_url("legacy"))
+
+    assert resp.status_code == 200
+    assert resp.json()["generation"] == "v1"
 
 
 # ── 5. v1 password gate (plaintext) ──────────────────────────────────────────

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -1,0 +1,559 @@
+"""Tests for GET|POST /api/v1/public/stats/{short_code}.
+
+All rows of the contract matrix assert status code AND body. Repos are
+dict-backed fakes; the click repo captures aggregation pipelines so the
+url_id scoping is asserted on the real StatsService machinery.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from dependencies import get_current_user
+from dependencies.services import get_public_stats_service
+from infrastructure.crypto import hash_password
+from schemas.models.url import EmojiUrlDoc, LegacyUrlDoc, UrlV2Doc
+from services.public_stats_service import PublicStatsService
+from services.stats_service import StatsService
+
+from .conftest import _build_test_app, _make_user
+
+_DOMAIN = "spoo.me"
+_NOT_FOUND_BODY = {"error": "short_code not found", "code": "not_found"}
+
+
+# ── Document builders ─────────────────────────────────────────────────────────
+
+
+def _make_v2_doc(alias: str = "abc1234", **overrides: Any) -> UrlV2Doc:
+    data: dict[str, Any] = {
+        "_id": ObjectId(),
+        "alias": alias,
+        "owner_id": ObjectId(),
+        "domain": _DOMAIN,
+        "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "long_url": "https://example.com/long",
+        "status": "ACTIVE",
+        "private_stats": None,  # anonymous/unowned default — public
+        "total_clicks": 0,
+    }
+    data.update(overrides)
+    return UrlV2Doc(**data)
+
+
+def _v1_data(code: str, **overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "_id": code,
+        "url": "https://example.com/legacy",
+        "total-clicks": 20,
+        "ips": [f"10.0.0.{i}" for i in range(8)],
+        "counter": {},
+        "unique_counter": {},
+        "browser": {},
+        "os_name": {},
+        "country": {},
+        "referrer": {},
+        "bots": {},
+        "average_redirection_time": 14.236,
+        "last-click": "2026-01-06 10:00:00",
+    }
+    data.update(overrides)
+    return data
+
+
+def _make_v1_doc(code: str = "legacy", **overrides: Any) -> LegacyUrlDoc:
+    return LegacyUrlDoc(**_v1_data(code, **overrides))
+
+
+def _make_emoji_doc(code: str, **overrides: Any) -> EmojiUrlDoc:
+    return EmojiUrlDoc(**_v1_data(code, **overrides))
+
+
+# ── Dict-backed repo fakes ────────────────────────────────────────────────────
+
+
+class _DictUrlRepo:
+    """Stand-in for UrlRepository — (alias, domain)-keyed lookups."""
+
+    def __init__(self, docs: list[UrlV2Doc] | None = None) -> None:
+        self._docs = {(doc.alias, doc.domain): doc for doc in (docs or [])}
+
+    async def find_by_alias(self, alias: str, domain: str) -> UrlV2Doc | None:
+        return self._docs.get((alias, domain))
+
+
+class _DictLegacyRepo:
+    """Stand-in for Legacy/EmojiUrlRepository — _id-keyed lookups."""
+
+    def __init__(self, docs: dict[str, Any] | None = None) -> None:
+        self._docs = docs or {}
+
+    async def find_by_id(self, short_code: str) -> Any | None:
+        return self._docs.get(short_code)
+
+
+class _CapturingClickRepo:
+    """Records every aggregation pipeline; replays a canned $facet result."""
+
+    def __init__(self, facet_result: dict[str, Any] | None = None) -> None:
+        self.pipelines: list[list[dict[str, Any]]] = []
+        self._facet_result = facet_result
+
+    async def aggregate(self, pipeline: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        self.pipelines.append(pipeline)
+        return [self._facet_result] if self._facet_result is not None else []
+
+
+# ── App/service builders ──────────────────────────────────────────────────────
+
+
+def _build_service(
+    *,
+    v2_docs: list[UrlV2Doc] | None = None,
+    v1_docs: dict[str, LegacyUrlDoc] | None = None,
+    emoji_docs: dict[str, EmojiUrlDoc] | None = None,
+    click_repo: _CapturingClickRepo | None = None,
+) -> tuple[PublicStatsService, _CapturingClickRepo]:
+    click_repo = click_repo or _CapturingClickRepo()
+    stats_service = StatsService(click_repo, _DictUrlRepo(), max_date_range_days=90)
+    service = PublicStatsService(
+        _DictUrlRepo(v2_docs),
+        _DictLegacyRepo(v1_docs),
+        _DictLegacyRepo(emoji_docs),
+        stats_service,
+        system_default_domain=_DOMAIN,
+        max_date_range_days=90,
+    )
+    return service, click_repo
+
+
+def _client(service: PublicStatsService, user: Any = None) -> TestClient:
+    application = _build_test_app(
+        {
+            get_public_stats_service: lambda: service,
+            get_current_user: lambda: user,
+        }
+    )
+    return TestClient(application, raise_server_exceptions=True)
+
+
+def _url(code: str, query: str = "") -> str:
+    return f"/api/v1/public/stats/{code}{query}"
+
+
+_WINDOW = "?start_date=2026-01-05T00:00:00Z&end_date=2026-01-06T23:59:59Z&timezone=UTC"
+
+
+# ── 1. Missing and private answer byte-identically ────────────────────────────
+
+
+def test_missing_and_private_stats_are_byte_identical_404s():
+    service, _ = _build_service(
+        v2_docs=[_make_v2_doc(alias="hidden1", private_stats=True)]
+    )
+    with _client(service) as client:
+        missing = client.get(_url("absent9"))
+        private = client.get(_url("hidden1"))
+
+    assert missing.status_code == 404
+    assert private.status_code == 404
+    assert missing.json() == _NOT_FOUND_BODY
+    assert missing.content == private.content  # no oracle
+
+
+def test_explicitly_private_false_is_public():
+    service, _ = _build_service(
+        v2_docs=[_make_v2_doc(alias="open123", private_stats=False)]
+    )
+    with _client(service) as client:
+        resp = client.get(_url("open123"))
+
+    assert resp.status_code == 200
+    assert resp.json()["generation"] == "v2"
+
+
+# ── 2. Anonymous (private_stats=None) is public + link facts wire shape ──────
+
+
+def test_anonymous_v2_is_public_with_lowercase_status_and_system_domain():
+    service, _ = _build_service(v2_docs=[_make_v2_doc(alias="anonpub")])
+    with _client(service) as client:
+        resp = client.get(_url("anonpub"))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["generation"] == "v2"
+    link = body["link"]
+    assert link["alias"] == "anonpub"
+    assert link["status"] == "active"  # LOWERCASE on the wire
+    assert link["short_url"] == f"https://{_DOMAIN}/anonpub"
+    assert link["long_url"] == "https://example.com/long"
+    assert link["created_at"].startswith("2024-01-01")
+    assert link["max_clicks"] is None
+    assert link["block_bots"] is False
+    assert link["password_protected"] is False
+
+
+def test_blocked_status_is_lowercase_and_hides_long_url():
+    service, _ = _build_service(
+        v2_docs=[_make_v2_doc(alias="blocked1", status="BLOCKED")]
+    )
+    with _client(service) as client:
+        resp = client.get(_url("blocked1"))
+
+    assert resp.status_code == 200
+    link = resp.json()["link"]
+    assert link["status"] == "blocked"
+    assert link["long_url"] is None
+
+
+# ── 3. Owner bypass ───────────────────────────────────────────────────────────
+
+
+def test_owner_session_bypasses_private_and_password_gates():
+    owner_id = ObjectId()
+    doc = _make_v2_doc(
+        alias="mine123",
+        owner_id=owner_id,
+        private_stats=True,
+        password=hash_password("sesame"),
+    )
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service, user=_make_user(user_id=owner_id)) as client:
+        resp = client.get(_url("mine123"))
+
+    assert resp.status_code == 200
+    assert resp.json()["link"]["password_protected"] is True
+
+
+def test_owner_gets_long_url_on_non_active_link():
+    owner_id = ObjectId()
+    doc = _make_v2_doc(
+        alias="paused1",
+        owner_id=owner_id,
+        private_stats=True,
+        status="INACTIVE",
+    )
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service, user=_make_user(user_id=owner_id)) as client:
+        resp = client.get(_url("paused1"))
+
+    assert resp.status_code == 200
+    link = resp.json()["link"]
+    assert link["status"] == "inactive"
+    assert link["long_url"] == "https://example.com/long"
+
+
+def test_non_owner_session_gets_the_same_404_for_private_stats():
+    doc = _make_v2_doc(alias="hidden1", private_stats=True)
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service, user=_make_user()) as client:
+        resp = client.get(_url("hidden1"))
+
+    assert resp.status_code == 404
+    assert resp.json() == _NOT_FOUND_BODY
+
+
+# ── 4. v2 password gate (argon2) ─────────────────────────────────────────────
+
+
+def test_v2_password_gates():
+    doc = _make_v2_doc(alias="locked1", password=hash_password("sesame"))
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service) as client:
+        no_password = client.get(_url("locked1"))
+        assert no_password.status_code == 401
+        assert no_password.json()["code"] == "password_required"
+
+        # Passwords never ride URLs: a GET query-string password is IGNORED.
+        query_password = client.get(_url("locked1", "?password=sesame"))
+        assert query_password.status_code == 401
+        assert query_password.json()["code"] == "password_required"
+
+        empty_body = client.post(_url("locked1"))
+        assert empty_body.status_code == 401
+        assert empty_body.json()["code"] == "password_required"
+
+        wrong = client.post(_url("locked1"), json={"password": "wrong"})
+        assert wrong.status_code == 401
+        assert wrong.json() == {
+            "error": "incorrect password",
+            "code": "invalid_password",
+        }
+
+        right = client.post(_url("locked1"), json={"password": "sesame"})
+        assert right.status_code == 200
+        assert right.json()["link"]["password_protected"] is True
+
+
+# ── 5. v1 password gate (plaintext) ──────────────────────────────────────────
+
+
+def test_v1_password_gates():
+    doc = _make_v1_doc("legacy", password="hunter2")
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        no_password = client.get(_url("legacy"))
+        assert no_password.status_code == 401
+        assert no_password.json()["code"] == "password_required"
+
+        wrong = client.post(_url("legacy"), json={"password": "wrong"})
+        assert wrong.status_code == 401
+        assert wrong.json()["code"] == "invalid_password"
+
+        right = client.post(_url("legacy"), json={"password": "hunter2"})
+        assert right.status_code == 200
+        assert right.json()["generation"] == "v1"
+
+
+# ── 6. v1 wire synthesis ─────────────────────────────────────────────────────
+
+
+def test_v1_wire_shape():
+    doc = _make_v1_doc(
+        "legacy",
+        **{
+            "browser": {
+                "Chrome": {"counts": 12, "ips": ["1.1.1.1", "2.2.2.2", "1.1.1.1"]},
+                "Firefox": {"counts": 8, "ips": ["3.3.3.3"]},
+            },
+            "os_name": {"Windows": {"counts": 20, "ips": ["1.1.1.1"]}},
+            "country": {
+                "United States": {"counts": 15, "ips": ["1.1.1.1"]},
+                "India": {"counts": 5, "ips": ["3.3.3.3"]},
+            },
+            "referrer": {"google_com": {"counts": 9, "ips": ["1.1.1.1"]}},
+            "bots": {"Googlebot": 3, "Bingbot": 1},
+            "counter": {
+                "2026-01-04": 3,
+                "2026-01-05": 5,
+                "2026-01-06": 7,
+                "2026-01-07": 2,
+            },
+            "unique_counter": {"2026-01-05": 2, "2026-01-06": 4},
+        },
+    )
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy", _WINDOW))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["generation"] == "v1"
+    stats = body["stats"]
+    metrics = stats["metrics"]
+
+    # v1 emits bots, never city; the os wire key is "os", not "os_name".
+    assert "clicks_by_bots" in metrics
+    assert "clicks_by_city" not in metrics
+    assert "unique_clicks_by_city" not in metrics
+    assert "clicks_by_os_name" not in metrics
+
+    # Dimensions are LIFETIME (window only trims the time series).
+    assert metrics["clicks_by_browser"] == [
+        {"browser": "Chrome", "clicks": 12, "clicks_percentage": 60.0},
+        {"browser": "Firefox", "clicks": 8, "clicks_percentage": 40.0},
+    ]
+    assert metrics["unique_clicks_by_browser"] == [
+        {"browser": "Chrome", "unique_clicks": 2, "unique_clicks_percentage": 66.67},
+        {"browser": "Firefox", "unique_clicks": 1, "unique_clicks_percentage": 33.33},
+    ]
+    assert metrics["clicks_by_os"] == [
+        {"os": "Windows", "clicks": 20, "clicks_percentage": 100.0}
+    ]
+
+    # Country display names → ISO alpha-2, so flags render like v2.
+    assert metrics["clicks_by_country"] == [
+        {"country": "US", "clicks": 15, "clicks_percentage": 75.0},
+        {"country": "IN", "clicks": 5, "clicks_percentage": 25.0},
+    ]
+
+    assert metrics["clicks_by_bots"] == [
+        {"bots": "Googlebot", "clicks": 3, "clicks_percentage": 75.0},
+        {"bots": "Bingbot", "clicks": 1, "clicks_percentage": 25.0},
+    ]
+
+    # Time series IS windowed ([2026-01-05, 2026-01-06]), ascending.
+    assert metrics["clicks_by_time"] == [
+        {"time": "2026-01-05", "clicks": 5, "clicks_percentage": 41.67},
+        {"time": "2026-01-06", "clicks": 7, "clicks_percentage": 58.33},
+    ]
+    assert metrics["unique_clicks_by_time"] == [
+        {"time": "2026-01-05", "unique_clicks": 2, "unique_clicks_percentage": 33.33},
+        {"time": "2026-01-06", "unique_clicks": 4, "unique_clicks_percentage": 66.67},
+    ]
+
+    summary = stats["summary"]
+    assert summary["total_clicks"] == 20  # lifetime
+    assert summary["unique_clicks"] == 8  # len(ips)
+    assert summary["first_click"] is None  # not stored on v1
+    assert summary["last_click"].startswith("2026-01-06T10:00:00")
+    assert summary["avg_redirection_time"] == 14.24
+
+    assert stats["time_bucket_info"] == {
+        "strategy": "daily",
+        "interval_minutes": 1440,
+        "display_format": "%Y-%m-%d",
+        "mongo_format": "%Y-%m-%d",
+        "timezone": "UTC",
+    }
+    assert stats["computed_metrics"] == {
+        "unique_click_rate": 40.0,
+        "repeat_click_rate": 60.0,
+        "average_clicks_per_visitor": 2.5,
+    }
+    assert stats["scope"] == "anon"
+    assert stats["short_code"] == "legacy"
+    assert stats["group_by"] == ["time", "browser", "os", "country", "referrer"]
+    assert "generated_at" in stats
+
+
+# ── 7. v2 wire reuses the stats machinery, scoped by url_id ──────────────────
+
+
+def test_v2_wire_scopes_match_by_url_id_not_short_code():
+    doc = _make_v2_doc(alias="abc1234")
+    first_click = datetime(2026, 1, 5, 8, 0, tzinfo=timezone.utc)
+    facet_result = {
+        "_summary": [
+            {
+                "total_clicks": 10,
+                "unique_clicks": 4,
+                "first_click": first_click,
+                "last_click": first_click + timedelta(days=1),
+                "avg_redirection_time": 12.0,
+            }
+        ],
+        "time": [{"_id": "2026-01-05", "total_clicks": 10, "unique_clicks": 4}],
+        "browser": [{"_id": "Chrome", "total_clicks": 6, "unique_clicks": 3}],
+        "country": [{"_id": "Germany", "total_clicks": 10, "unique_clicks": 4}],
+        "city": [{"_id": "Berlin", "total_clicks": 10, "unique_clicks": 4}],
+    }
+    service, click_repo = _build_service(
+        v2_docs=[doc], click_repo=_CapturingClickRepo(facet_result)
+    )
+    with _client(service) as client:
+        resp = client.get(_url("abc1234", _WINDOW))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["generation"] == "v2"
+    stats = body["stats"]
+    metrics = stats["metrics"]
+
+    # v2 emits city, never bots.
+    assert metrics["clicks_by_city"] == [
+        {"city": "Berlin", "clicks": 10, "clicks_percentage": 100.0}
+    ]
+    assert "clicks_by_bots" not in metrics
+    assert metrics["clicks_by_browser"][0] == {
+        "browser": "Chrome",
+        "clicks": 6,
+        "clicks_percentage": 100.0,
+    }
+    assert metrics["clicks_by_country"] == [
+        {"country": "DE", "clicks": 10, "clicks_percentage": 100.0}
+    ]
+    assert stats["summary"]["total_clicks"] == 10
+    assert stats["group_by"] == ["time", "browser", "os", "country", "city", "referrer"]
+
+    # The $match is scoped by meta.url_id — never meta.short_code — so a
+    # same-alias link on a custom domain can never bleed in.
+    assert len(click_repo.pipelines) == 1
+    match = click_repo.pipelines[0][0]["$match"]
+    assert match["meta.url_id"] == doc.id
+    assert "meta.short_code" not in match
+    assert set(match) == {"meta.url_id", "clicked_at"}
+
+
+# ── 8. Effective status is derived (read-only) ───────────────────────────────
+
+
+def test_v2_active_with_past_expire_after_reports_expired_and_hides_long_url():
+    doc = _make_v2_doc(
+        alias="oldlink",
+        expire_after=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service) as client:
+        resp = client.get(_url("oldlink"))
+
+    assert resp.status_code == 200
+    link = resp.json()["link"]
+    assert link["status"] == "expired"
+    assert link["long_url"] is None
+
+
+def test_v2_active_with_max_clicks_reached_reports_expired():
+    doc = _make_v2_doc(alias="capped1", max_clicks=5, total_clicks=5)
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service) as client:
+        resp = client.get(_url("capped1"))
+
+    assert resp.status_code == 200
+    link = resp.json()["link"]
+    assert link["status"] == "expired"
+    assert link["long_url"] is None
+
+
+def test_v1_max_clicks_reached_reports_expired():
+    doc = _make_v1_doc("legacy", **{"max-clicks": 20, "total-clicks": 20})
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy"))
+
+    assert resp.status_code == 200
+    link = resp.json()["link"]
+    assert link["status"] == "expired"
+    assert link["long_url"] is None
+    assert link["max_clicks"] == 20
+
+
+# ── 9. Emoji aliases resolve and collapse to v1 ──────────────────────────────
+
+
+def test_emoji_alias_resolves_as_v1():
+    doc = _make_emoji_doc("🚀", url="https://docs.spoo.me/emoji-urls")
+    service, _ = _build_service(emoji_docs={"🚀": doc})
+    with _client(service) as client:
+        resp = client.get(_url("🚀"))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["generation"] == "v1"
+    link = body["link"]
+    assert link["alias"] == "🚀"
+    assert link["short_url"] == f"https://{_DOMAIN}/🚀"
+    assert link["long_url"] == "https://docs.spoo.me/emoji-urls"
+    assert link["created_at"] is None  # never stored on v1/emoji docs
+
+
+# ── 10. Resolution order + validation ────────────────────────────────────────
+
+
+def test_six_char_alias_falls_back_to_v2():
+    doc = _make_v2_doc(alias="sixsix")
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service) as client:
+        resp = client.get(_url("sixsix"))
+
+    assert resp.status_code == 200
+    assert resp.json()["generation"] == "v2"
+
+
+def test_inverted_date_range_is_a_validation_error():
+    service, _ = _build_service(v2_docs=[_make_v2_doc(alias="anonpub")])
+    with _client(service) as client:
+        resp = client.get(
+            _url(
+                "anonpub",
+                "?start_date=2026-01-10T00:00:00Z&end_date=2026-01-05T00:00:00Z",
+            )
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from dependencies import get_current_user
 from dependencies.services import get_public_stats_service
 from infrastructure.crypto import hash_password
-from schemas.models.url import EmojiUrlDoc, LegacyUrlDoc, UrlV2Doc
+from schemas.models.url import UrlV2Doc
 from services.public_stats_service import PublicStatsService
 from services.stats_service import StatsService
 
@@ -46,6 +46,11 @@ def _make_v2_doc(alias: str = "abc1234", **overrides: Any) -> UrlV2Doc:
 
 
 def _v1_data(code: str, **overrides: Any) -> dict[str, Any]:
+    """RAW v1/emoji document — what the repos' aggregate helper returns.
+
+    Carries the hyphenated legacy keys, including ``creation-date`` /
+    ``creation-time`` (which the typed LegacyUrlDoc drops).
+    """
     data: dict[str, Any] = {
         "_id": code,
         "url": "https://example.com/legacy",
@@ -59,18 +64,12 @@ def _v1_data(code: str, **overrides: Any) -> dict[str, Any]:
         "referrer": {},
         "bots": {},
         "average_redirection_time": 14.236,
+        "creation-date": "2024-04-18",
+        "creation-time": "09:30:00",
         "last-click": "2026-01-06 10:00:00",
     }
     data.update(overrides)
     return data
-
-
-def _make_v1_doc(code: str = "legacy", **overrides: Any) -> LegacyUrlDoc:
-    return LegacyUrlDoc(**_v1_data(code, **overrides))
-
-
-def _make_emoji_doc(code: str, **overrides: Any) -> EmojiUrlDoc:
-    return EmojiUrlDoc(**_v1_data(code, **overrides))
 
 
 # ── Dict-backed repo fakes ────────────────────────────────────────────────────
@@ -87,13 +86,18 @@ class _DictUrlRepo:
 
 
 class _DictLegacyRepo:
-    """Stand-in for Legacy/EmojiUrlRepository — _id-keyed lookups."""
+    """Stand-in for Legacy/EmojiUrlRepository — raw-dict aggregate reads.
 
-    def __init__(self, docs: dict[str, Any] | None = None) -> None:
+    Only ``aggregate`` is exposed: the service must read v1 docs RAW
+    (typed ``find_by_id`` would drop creation-date/creation-time), so a
+    regression to the typed read fails loudly here.
+    """
+
+    def __init__(self, docs: dict[str, dict[str, Any]] | None = None) -> None:
         self._docs = docs or {}
 
-    async def find_by_id(self, short_code: str) -> Any | None:
-        return self._docs.get(short_code)
+    async def aggregate(self, pipeline: list[dict[str, Any]]) -> dict[str, Any] | None:
+        return self._docs.get(pipeline[0]["$match"]["_id"])
 
 
 class _CapturingClickRepo:
@@ -114,8 +118,8 @@ class _CapturingClickRepo:
 def _build_service(
     *,
     v2_docs: list[UrlV2Doc] | None = None,
-    v1_docs: dict[str, LegacyUrlDoc] | None = None,
-    emoji_docs: dict[str, EmojiUrlDoc] | None = None,
+    v1_docs: dict[str, dict[str, Any]] | None = None,
+    emoji_docs: dict[str, dict[str, Any]] | None = None,
     click_repo: _CapturingClickRepo | None = None,
 ) -> tuple[PublicStatsService, _CapturingClickRepo]:
     click_repo = click_repo or _CapturingClickRepo()
@@ -294,7 +298,7 @@ def test_v2_password_gates():
 
 
 def test_v1_password_gates():
-    doc = _make_v1_doc("legacy", password="hunter2")
+    doc = _v1_data("legacy", password="hunter2")
     service, _ = _build_service(v1_docs={"legacy": doc})
     with _client(service) as client:
         no_password = client.get(_url("legacy"))
@@ -314,7 +318,7 @@ def test_v1_password_gates():
 
 
 def test_v1_wire_shape():
-    doc = _make_v1_doc(
+    doc = _v1_data(
         "legacy",
         **{
             "browser": {
@@ -501,7 +505,7 @@ def test_v2_active_with_max_clicks_reached_reports_expired():
 
 
 def test_v1_max_clicks_reached_reports_expired():
-    doc = _make_v1_doc("legacy", **{"max-clicks": 20, "total-clicks": 20})
+    doc = _v1_data("legacy", **{"max-clicks": 20, "total-clicks": 20})
     service, _ = _build_service(v1_docs={"legacy": doc})
     with _client(service) as client:
         resp = client.get(_url("legacy"))
@@ -513,11 +517,44 @@ def test_v1_max_clicks_reached_reports_expired():
     assert link["max_clicks"] == 20
 
 
+# ── 8b. v1 created_at comes from the RAW doc's creation fields ───────────────
+# (the typed LegacyUrlDoc drops creation-date/creation-time; the service
+# reads raw dicts so /stats/{code} agrees with the preview endpoint)
+
+
+def test_v1_created_at_combines_creation_date_and_time():
+    doc = _v1_data(
+        "legacy",
+        **{"creation-date": "2026-03-10", "creation-time": "12:34:56"},
+    )
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy"))
+
+    assert resp.status_code == 200
+    assert resp.json()["link"]["created_at"].startswith("2026-03-10T12:34:56")
+
+
+def test_v1_created_at_null_when_creation_fields_missing_or_unparseable():
+    ancient = _v1_data("legacy")
+    del ancient["creation-date"], ancient["creation-time"]
+    garbled = _v1_data("garble", **{"creation-date": "not a date"})
+    service, _ = _build_service(v1_docs={"legacy": ancient, "garble": garbled})
+    with _client(service) as client:
+        ancient_resp = client.get(_url("legacy"))
+        garbled_resp = client.get(_url("garble"))
+
+    assert ancient_resp.status_code == 200
+    assert ancient_resp.json()["link"]["created_at"] is None
+    assert garbled_resp.status_code == 200
+    assert garbled_resp.json()["link"]["created_at"] is None
+
+
 # ── 9. Emoji aliases resolve and collapse to v1 ──────────────────────────────
 
 
 def test_emoji_alias_resolves_as_v1():
-    doc = _make_emoji_doc("🚀", url="https://docs.spoo.me/emoji-urls")
+    doc = _v1_data("🚀", url="https://docs.spoo.me/emoji-urls")
     service, _ = _build_service(emoji_docs={"🚀": doc})
     with _client(service) as client:
         resp = client.get(_url("🚀"))
@@ -529,7 +566,8 @@ def test_emoji_alias_resolves_as_v1():
     assert link["alias"] == "🚀"
     assert link["short_url"] == f"https://{_DOMAIN}/🚀"
     assert link["long_url"] == "https://docs.spoo.me/emoji-urls"
-    assert link["created_at"] is None  # never stored on v1/emoji docs
+    # The emoji path also reads the raw doc, so creation fields surface.
+    assert link["created_at"].startswith("2024-04-18T09:30:00")
 
 
 # ── 10. Resolution order + validation ────────────────────────────────────────

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -17,6 +17,7 @@ from dependencies import get_current_user
 from dependencies.services import get_public_stats_service
 from infrastructure.crypto import hash_password
 from schemas.models.url import UrlV2Doc
+from services.public_link_resolver import PublicLinkResolver
 from services.public_stats_service import PublicStatsService
 from services.stats_service import StatsService
 
@@ -88,7 +89,7 @@ class _DictUrlRepo:
 class _DictLegacyRepo:
     """Stand-in for Legacy/EmojiUrlRepository — raw-dict aggregate reads.
 
-    Only ``aggregate`` is exposed: the service must read v1 docs RAW
+    Only ``aggregate`` is exposed: the resolver must read v1 docs RAW
     (typed ``find_by_id`` would drop creation-date/creation-time), so a
     regression to the typed read fails loudly here.
     """
@@ -124,14 +125,13 @@ def _build_service(
 ) -> tuple[PublicStatsService, _CapturingClickRepo]:
     click_repo = click_repo or _CapturingClickRepo()
     stats_service = StatsService(click_repo, _DictUrlRepo(), max_date_range_days=90)
-    service = PublicStatsService(
+    resolver = PublicLinkResolver(
         _DictUrlRepo(v2_docs),
         _DictLegacyRepo(v1_docs),
         _DictLegacyRepo(emoji_docs),
-        stats_service,
         system_default_domain=_DOMAIN,
-        max_date_range_days=90,
     )
+    service = PublicStatsService(resolver, stats_service, max_date_range_days=90)
     return service, click_repo
 
 


### PR DESCRIPTION
## Summary

Adds `GET|POST /api/v1/public/stats/{short_code}` — the backend for the already-built public stats page (`/stats/{code}`, spoo-landing PR #4). The wire contract is frozen in the spoo-landing mock (`app/api/mock/[...path]/public.ts`, consumed via `lib/api/public-stats.ts`); this implements it against the real collections per `thoughts/public-stats-endpoint-trd.md`. The endpoint ships dark: nothing serves it until the frontend + Caddy wiring land.

- Resolves BOTH generations plus emoji aliases, scoped to the system default domain (custom-tenant aliases never resolve here). Emoji collapses to `generation: "v1"` on the wire.
- Privacy: a v2 link with `private_stats` answers **byte-identically** to a missing code (404, no oracle). Owner sessions (optional auth on the same request) bypass the privacy and password gates.
- Passwords only ever travel in the POST body — GET ignores `?password=` entirely. 401 `password_required` / `invalid_password` (argon2 for v2, plaintext compare for v1/emoji).
- Effective status is derived READ-ONLY (an ACTIVE link past `expire_after`/max-clicks reports `expired`; no writes from this endpoint), and `long_url` is withheld unless the link is effectively active (owners always get it).
- v2 analytics reuse `StatsService`'s $facet machinery with the $match scoped by `meta.url_id` (never `meta.short_code`, so a same-alias link on a custom domain can't bleed in). v1/emoji synthesize the same wire shape from the embedded counters: lifetime dimensions, windowed daily time series, `bots` dimension, countries converted to ISO alpha-2. v1/emoji docs are read RAW via the repos' `aggregate` helper (the typed model drops `creation-date`/`creation-time`) so `link.created_at` is populated for v1 — same pattern as the public preview endpoint, so `/stats/{code}` and `/{code}+` agree.

## Changes

- `routes/api_v1/public_stats.py` — GET/POST route pair sharing one impl; `dynamic_limit(API_AUTHED, API_ANON)` rate limiting; optional auth via `optional_scopes(STATS_SCOPES)`
- `services/public_stats_service.py` — resolution, privacy/password gates, derived status, v2 reuse + v1 synthesis
- `schemas/dto/requests/public_stats.py`, `schemas/dto/responses/public_stats.py` — `PublicStatsBody`, `PublicLinkFacts`, `PublicStatsResponse`
- `errors.py` — `PasswordRequiredError` / `InvalidPasswordError` (401s with stable codes)
- `routes/api_v1/__init__.py`, `dependencies/services.py`, `dependencies/wiring.py` — router include + service wiring
- `services/public_link_resolver.py` — shared resolver (resolution order, raw v1 reads, derived status, created_at) consumed by BOTH public endpoints (preview + stats) after #240 landed first; `services/stats_service.py` gained the public `compute()` seam + `normalize_timezone`/`to_user_tz`/`add_metadata` so this endpoint touches no privates
- `middleware/rate_limiter.py` — dedicated `PUBLIC_STATS_AUTHED`/`PUBLIC_STATS_ANON` budgets (aggregation cost + password-guess reasoning in the comment)

## Tests

- `tests/integration/api_v1/test_public_stats.py` — 22 tests covering the full contract matrix: byte-identical 404s, private-stats semantics (`True`/`None`/`False`), owner bypass (incl. `long_url` on non-active links), both password gates (incl. GET query-string password ignored and empty POST body), v1 wire synthesis (lifetime dims, windowed time series, ISO countries, `os` key, bots-not-city), v2 wire (city-not-bots, `meta.url_id` $match asserted on the captured pipeline), derived expiry for both generations, emoji resolution, lowercase status + system-domain `short_url`, resolution fallback, date validation, v1 `created_at` from raw creation-date/creation-time (populated, missing, and unparseable).
- Targeted: `uv run pytest tests/integration/api_v1/test_public_stats.py -p no:xdist -o addopts=""` — 22 passed.
- Full sweep: `uv run pytest` — 2147 passed.

## Summary by Sourcery

Add a public per-link statistics API endpoint for short codes, wired through a dedicated service and router, with optional owner authentication and strict privacy/password handling.

New Features:
- Introduce GET/POST /api/v1/public/stats/{short_code} endpoint to serve public stats for short links across V2, legacy, and emoji generations.
- Define request and response DTOs for the public stats endpoint, including link facts and stats payload compatible with the existing stats wire format.

Enhancements:
- Implement PublicStatsService to resolve short codes on the system default domain, enforce privacy and password rules, derive effective status, and either reuse V2 stats aggregation or synthesize V1 analytics.
- Wire PublicStatsService into the FastAPI app dependencies alongside StatsService, enabling DI-based usage from routes.
- Extend error handling with dedicated password_required and invalid_password authentication errors carrying stable error codes.

Tests:
- Add comprehensive integration tests for the public stats endpoint covering privacy semantics, owner bypass, password flows for V1/V2, emoji resolution, derived expiry, stats wiring, and date-window validation.

