### PR TITLE
fix: unmatched routes get negotiated errors, not Starlette's default

### DIFF
--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -12,6 +12,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 from pydantic import ValidationError as PydanticValidationError
 from slowapi.errors import RateLimitExceeded
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from errors import AppError
 from infrastructure.logging import get_logger
@@ -74,6 +75,11 @@ def _wants_json(request: Request) -> bool:
 # The redirect set is smaller on purpose: its 403 bot-block keeps its body.
 EDGE_INTERCEPTED_STATUSES = {404, 410, 429, 451, 500}
 REDIRECT_EDGE_INTERCEPTED_STATUSES = {404, 410, 451}
+
+# Slugs for framework-raised HTTPExceptions (a path matching no route, a
+# method the route doesn't take). Mirrors the AppError error_code
+# vocabulary so the edge composes them identically.
+_HTTP_STATUS_SLUGS = {404: "not_found", 405: "method_not_allowed"}
 
 
 def _error_html(
@@ -148,6 +154,24 @@ def register_error_handlers(app: FastAPI) -> None:
                 content={"error": "Too many requests", "code": "rate_limit_exceeded"},
             )
         return _error_html(request, 429, "TOO MANY REQUESTS", "rate_limit_exceeded")
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ) -> Response:
+        # Requests that match NO route (e.g. /foo/bar — deeper than any
+        # pattern) raise Starlette's own HTTPException and would otherwise
+        # bypass content negotiation entirely: raw {"detail": "Not Found"}
+        # even for browsers, and no X-Error-Code for the edge to compose on.
+        slug = _HTTP_STATUS_SLUGS.get(exc.status_code, f"http_{exc.status_code}")
+        message = str(exc.detail) if exc.detail else "Error"
+        if _wants_json(request):
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"error": message, "code": slug},
+                headers=exc.headers,
+            )
+        return _error_html(request, exc.status_code, message.upper(), slug)
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception) -> Response:

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -228,6 +228,31 @@ def test_app_error_json_when_accept_json():
     assert "application/json" in resp.headers["content-type"]
 
 
+# ── Unmatched routes (framework-raised 404s) ────────────────────────────────
+
+
+def test_unmatched_route_returns_html():
+    """A path matching NO route (nested, deeper than any pattern) must get
+    the same negotiated HTML + X-Error-Code as route-raised 404s — not
+    Starlette's default {"detail": "Not Found"} JSON."""
+    app = _build_test_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/foo/bar", headers={"Accept": "text/html"})
+    assert resp.status_code == 404
+    assert "text/html" in resp.headers["content-type"]
+    assert resp.headers["X-Error-Code"] == "not_found"
+
+
+def test_unmatched_route_json_when_accept_json():
+    app = _build_test_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/foo/bar", headers={"Accept": "application/json"})
+    assert resp.status_code == 404
+    data = resp.json()
+    assert data["code"] == "not_found"
+    assert "detail" not in data
+
+
 # ── Validation errors ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Found during the beta error-composition validation matrix: `beta.spoo.me/foo/bar` (and prod `spoo.me/foo/bar`) answers raw `{"detail": "Not Found"}` JSON to browsers.

## Why it's been invisible

The custom handlers only catch exceptions raised **inside routes** — a dead single-segment code enters `/{short_code}`, raises `NotFoundError`, and gets the branded treatment. A nested path matches **no route pattern**, so Starlette's router raises its own `HTTPException` and FastAPI's stock handler answers before any app negotiation runs. Flask had a blanket `errorhandler(404)`, so this regressed silently in the rewrite; nested dead paths are rare on a shortener, so nobody hit it until now.

## What

- `@app.exception_handler(StarletteHTTPException)` routing through the same `_wants_json` / `_error_html` pair as everything else: browsers get the template (or the `EDGE_COMPOSED_ERRORS` empty body), JSON clients get the app error shape, and `X-Error-Code` rides both — so the edge composes these 404s exactly like route-raised ones.
- Slug map mirrors the `AppError` vocabulary (`not_found`, `method_not_allowed`); unknown statuses fall back to `http_{status}`, which the frontend's slug→status→generic routing degrades on safely.
- Two tests pin the negotiation both ways; full suite 2164 passed.

## Blast radius

Every currently-unmatched path today returns the Starlette default, so the only behavior change is strictly an upgrade (negotiated + composable). API clients relying on `{"detail"}` for unmatched paths would be the one compat concern — but unmatched paths are by definition not part of any published contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route framework-raised 404/405 HTTP exceptions through the existing error negotiation pipeline so unmatched paths return branded, composable errors instead of Starlette defaults.

Bug Fixes:
- Ensure unmatched routes negotiate HTML or JSON responses consistently with route-raised 404s, including setting X-Error-Code.
- Align JSON error payloads for framework-raised HTTPExceptions with the application error schema instead of Starlette's {"detail": "Not Found"} shape.

Enhancements:
- Introduce status-to-slug mapping for framework-raised HTTPExceptions to mirror existing AppError codes and provide safe fallbacks for unknown statuses.

Tests:
- Add integration tests verifying HTML and JSON error negotiation for unmatched nested routes.