### PR TITLE
fix(public-stats): skip malformed v1 dimension entries instead of 500ing

### DIFF
--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -421,7 +421,11 @@ class PublicStatsService:
                     skipped.append(raw_value)
                     continue
                 ips = entry.get("ips") or []
-                if not isinstance(ips, (list, tuple, set)):
+                if isinstance(ips, (list, tuple, set)):
+                    # v1 wrote plain strings; drifted elements (nested
+                    # lists, dicts) don't hash — count stands, uniques don't
+                    ips = [ip for ip in ips if isinstance(ip, str)]
+                else:
                     ips = []  # unknown container — count stands, uniques don't
             else:  # defensively tolerate bare counters in legacy data
                 try:

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -435,10 +435,13 @@ class PublicStatsService:
             unique_ips.setdefault(value, set()).update(ips)
 
         if skipped:
+            # Cardinality is unbounded (one entry per distinct referrer/etc),
+            # so cap the sample — skipped_count carries the true total.
             log.info(
                 "v1_dimension_entries_skipped",
                 dimension=key,
-                values=skipped,
+                skipped_count=len(skipped),
+                values=skipped[:20],
             )
 
         ordered = sorted(clicks, key=lambda value: clicks[value], reverse=True)

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -403,19 +403,43 @@ class PublicStatsService:
         unique rows ride the same order so the frontend zip keeps the
         backend's ranking. Values that transform to the same output (e.g.
         two spellings hitting the "XX" country fallback) are merged.
+
+        v1 data spans four years of Flask-era schema drift, so entries
+        whose count defies both known forms (a bare list was seen live)
+        are SKIPPED — one drifted sub-entry must never 500 the whole
+        stats page, and inventing a count for an unknown shape would be
+        dishonest. Skips are logged once per dimension, not per row.
         """
         clicks: dict[str, int] = {}
         unique_ips: dict[str, set[str]] = {}
+        skipped: list[str] = []
         for raw_value, entry in (source or {}).items():
             if isinstance(entry, dict):
-                count = int(entry.get("counts", 0) or 0)
+                try:
+                    count = int(entry.get("counts", 0) or 0)
+                except (TypeError, ValueError):
+                    skipped.append(raw_value)
+                    continue
                 ips = entry.get("ips") or []
+                if not isinstance(ips, (list, tuple, set)):
+                    ips = []  # unknown container — count stands, uniques don't
             else:  # defensively tolerate bare counters in legacy data
-                count = int(entry or 0)
+                try:
+                    count = int(entry or 0)
+                except (TypeError, ValueError):
+                    skipped.append(raw_value)
+                    continue
                 ips = []
             value = transform(raw_value) if transform else raw_value
             clicks[value] = clicks.get(value, 0) + count
             unique_ips.setdefault(value, set()).update(ips)
+
+        if skipped:
+            log.info(
+                "v1_dimension_entries_skipped",
+                dimension=key,
+                values=skipped,
+            )
 
         ordered = sorted(clicks, key=lambda value: clicks[value], reverse=True)
         clicks_rows = [{key: value, "clicks": clicks[value]} for value in ordered]

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -550,6 +550,32 @@ def test_v1_non_list_ips_container_keeps_count_drops_uniques():
     ]
 
 
+def test_v1_unhashable_ips_elements_keep_count_and_clean_uniques():
+    # A recognised ips container holding drifted UNHASHABLE elements
+    # (nested lists) must not TypeError the set-union — string elements
+    # still count as uniques, the rest are dropped.
+    doc = _v1_data(
+        "legacy",
+        **{
+            "browser": {
+                "Chrome": {"counts": 7, "ips": [["1.1.1.1"], "2.2.2.2", {"a": 1}]}
+            }
+        },
+    )
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy", _WINDOW))
+
+    assert resp.status_code == 200
+    metrics = resp.json()["stats"]["metrics"]
+    assert metrics["clicks_by_browser"] == [
+        {"browser": "Chrome", "clicks": 7, "clicks_percentage": 100.0}
+    ]
+    assert metrics["unique_clicks_by_browser"] == [
+        {"browser": "Chrome", "unique_clicks": 1, "unique_clicks_percentage": 100.0}
+    ]
+
+
 # NOTE: no malformed TIME-SERIES bucket test — that path is unreachable.
 # counter/unique_counter/bots are typed dict[str, int] on LegacyUrlDoc, so
 # pydantic coerces scalar drift ("7" → 7) and rejects non-scalars at

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -457,6 +457,106 @@ def test_v1_wire_shape():
     assert "generated_at" in stats
 
 
+# ── 6b. Drifted v1 analytics entries are skipped, never a 500 ─────────────────
+# (live repro on beta: a dimension entry whose value was a bare LIST hit
+# ``int(entry)`` → TypeError → unhandled → the whole stats page 500ed on
+# every request, forever. Skip, don't sink: malformed sub-entries drop out,
+# everything parseable still renders.)
+
+
+def test_v1_malformed_dimension_entries_are_skipped_not_500():
+    doc = _v1_data(
+        "legacy",
+        **{
+            # Clean dimension — must render untouched.
+            "browser": {
+                "Chrome": {"counts": 12, "ips": ["1.1.1.1", "2.2.2.2"]},
+            },
+            # The live repro shape: entry is a bare list.
+            "referrer": {
+                "google_com": ["1.1.1.1", "2.2.2.2"],
+                "t_co": {"counts": 4, "ips": ["3.3.3.3"]},
+            },
+            # Dict entry whose counts is itself junk.
+            "os_name": {
+                "Windows": {"counts": ["huh"], "ips": ["1.1.1.1"]},
+                "Linux": {"counts": 2, "ips": ["4.4.4.4"]},
+            },
+            # Bare scalar that isn't int-able.
+            "country": {
+                "United States": "not-a-number",
+                "India": {"counts": 5, "ips": ["3.3.3.3"]},
+            },
+        },
+    )
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy", _WINDOW))
+
+    assert resp.status_code == 200
+    metrics = resp.json()["stats"]["metrics"]
+
+    # Clean dimension is untouched.
+    assert metrics["clicks_by_browser"] == [
+        {"browser": "Chrome", "clicks": 12, "clicks_percentage": 100.0}
+    ]
+    assert metrics["unique_clicks_by_browser"] == [
+        {"browser": "Chrome", "unique_clicks": 2, "unique_clicks_percentage": 100.0}
+    ]
+
+    # Malformed entries are absent; their clean siblings render.
+    assert metrics["clicks_by_referrer"] == [
+        {"referrer": "t_co", "clicks": 4, "clicks_percentage": 100.0}
+    ]
+    assert metrics["clicks_by_os"] == [
+        {"os": "Linux", "clicks": 2, "clicks_percentage": 100.0}
+    ]
+    assert metrics["clicks_by_country"] == [
+        {"country": "IN", "clicks": 5, "clicks_percentage": 100.0}
+    ]
+
+
+def test_v1_every_entry_malformed_yields_empty_dimension_not_500():
+    doc = _v1_data("legacy", **{"referrer": {"google_com": ["1.1.1.1"]}})
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy", _WINDOW))
+
+    assert resp.status_code == 200
+    metrics = resp.json()["stats"]["metrics"]
+    assert metrics["clicks_by_referrer"] == []
+    assert metrics["unique_clicks_by_referrer"] == []
+
+
+def test_v1_non_list_ips_container_keeps_count_drops_uniques():
+    # A parseable count with an unrecognisable ips container renders the
+    # count honestly and reports zero uniques — no guessing, no crash.
+    doc = _v1_data(
+        "legacy",
+        **{"browser": {"Chrome": {"counts": 7, "ips": "1.1.1.1"}}},
+    )
+    service, _ = _build_service(v1_docs={"legacy": doc})
+    with _client(service) as client:
+        resp = client.get(_url("legacy", _WINDOW))
+
+    assert resp.status_code == 200
+    metrics = resp.json()["stats"]["metrics"]
+    assert metrics["clicks_by_browser"] == [
+        {"browser": "Chrome", "clicks": 7, "clicks_percentage": 100.0}
+    ]
+    # (no percentage key — add_metadata omits it when the total is zero)
+    assert metrics["unique_clicks_by_browser"] == [
+        {"browser": "Chrome", "unique_clicks": 0}
+    ]
+
+
+# NOTE: no malformed TIME-SERIES bucket test — that path is unreachable.
+# counter/unique_counter/bots are typed dict[str, int] on LegacyUrlDoc, so
+# pydantic coerces scalar drift ("7" → 7) and rejects non-scalars at
+# from_mongo, before the synthesis loops run. The dimension maps are
+# dict[str, Any] — which is exactly why drift reaches _v1_dimension_rows.
+
+
 # ── 7. v2 wire reuses the stats machinery, scoped by url_id ──────────────────
 
 


### PR DESCRIPTION
## The bug (empirically hit on beta)

`PublicStatsService._v1_dimension_rows` adapts the legacy v1 analytics dicts (`browser`, `os_name`, `country`, `referrer` — shape `{value: entry}`). It handled entry as `{"counts": n, "ips": [...]}` and, defensively, as a bare int-able scalar. Any other shape fell into `int(entry or 0)` and raised. Real beta traceback:

```
{"error": "int() argument must be a string, a bytes-like object or a real number, not 'list'",
 "error_type": "TypeError", "path": "/api/v1/public/stats/spring", "event": "unhandled_exception"}
```

**Blast radius:** the exception is unhandled, so ONE malformed sub-entry anywhere in a v1 doc makes that link's public stats page 500 on **every request, forever** — post-cutover visitors get the composed 5xx apology page for stats that are otherwise perfectly renderable. v1 data spans four years of Flask-era schema drift; the defensive scalar branch exists *because* shapes vary — it just didn't go far enough.

## The fix — skip, don't sink

- An entry whose count can't be parsed (bare list — the live repro — dict with junk `counts`, non-numeric scalar) is **dropped**; every parseable entry in the dimension still renders.
- No guessed semantics: a list is not `len()`-counted into a click count — skipping is honest, inventing numbers isn't.
- One `v1_dimension_entries_skipped` info log per dimension naming the skipped values — not one log per row, so a crusty doc can't spam.
- Bonus hardening in the same function: a parseable count with an unrecognisable `ips` container (e.g. a bare string) keeps the honest click count and reports zero uniques instead of crashing/garbage.
- Happy paths are byte-identical.

## Time-series loops (inspected, deliberately unchanged)

The `int(count or 0)` loops over `counter`/`unique_counter`/`bots` look like the same hazard but are **unreachable with non-scalar values**: those fields are typed `dict[str, int]` on `LegacyUrlDoc`, so pydantic coerces scalar drift (`"7"` → 7, `2.0` → 2) and rejects non-scalars at `from_mongo` — before the synthesis loops run (verified empirically). The dimension maps are `dict[str, Any]`, which is exactly why drift reaches `_v1_dimension_rows` and nowhere else. A hypothetical list-valued counter bucket would fail at model validation — a layer shared with the redirect path (`find_by_id`), where such docs would already be failing loudly; no evidence any exist (counters are written via `$inc`, which can only produce numbers). Loosening the shared model is a bigger call than this fix warrants.

## Tests

+3 (2193 → 2196), all green; `ruff check` + `ruff format` clean.

- `test_v1_malformed_dimension_entries_are_skipped_not_500` — live-repro list shape, junk `counts`, non-numeric scalar, each next to a clean sibling → 200, clean entries render, malformed absent.
- `test_v1_every_entry_malformed_yields_empty_dimension_not_500` — worst case degrades to an empty dimension, not a 500.
- `test_v1_non_list_ips_container_keeps_count_drops_uniques` — pins the count-stands/uniques-drop behavior.
- Comment in the test file pins *why* there's no malformed time-series test (unreachable via pydantic typing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden v1 public stats dimension processing to tolerate drifted legacy analytics data by skipping unparseable entries, preserving valid metrics, and adding targeted logging and tests.

Bug Fixes:
- Prevent malformed v1 analytics dimension entries from causing 500 errors by skipping unparseable entries and hardening IP container handling.

Enhancements:
- Log skipped v1 analytics dimension entries once per dimension for better visibility into legacy schema drift.

Tests:
- Add integration tests covering malformed v1 dimension entries, all- malformed dimensions yielding empty results, and non-list IP containers keeping counts but dropping uniques.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when displaying legacy statistics containing malformed dimension data.
  * Malformed or non-integer legacy counter values are now skipped instead of causing server errors.
  * If the uniques payload is malformed, total click counts are still rendered while uniques are safely omitted or set to zero as appropriate.
  * Added coverage to ensure the endpoint stays HTTP 200 and returns empty/sanitized dimension results when all dimension entries are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->