### PR TITLE
fix: enforce time-based URL expiry at resolve + derive effective status

### DIFF
--- a/infrastructure/cache/url_cache.py
+++ b/infrastructure/cache/url_cache.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from infrastructure.crypto import verify_password as verify_password_hash
 from infrastructure.logging import get_logger
+from shared.datetime_utils import to_unix_timestamp
 
 if TYPE_CHECKING:
     from schemas.models.url import UrlV2Doc
@@ -31,7 +32,8 @@ class UrlCacheData(BaseModel):
     long_url: str
     block_bots: bool
     password_hash: str | None
-    expiration_time: int | None  # Unix timestamp
+    # Unix timestamp; None = no expiry OR tz-ambiguous v1 value (never expires)
+    expiration_time: int | None
     max_clicks: int | None
     url_status: str  # ACTIVE, INACTIVE, BLOCKED, EXPIRED
     schema_version: str  # "v1" or "v2"
@@ -67,9 +69,9 @@ class UrlCacheData(BaseModel):
             long_url=doc.long_url,
             block_bots=bool(doc.block_bots),
             password_hash=doc.password,
-            expiration_time=(
-                int(doc.expire_after.timestamp()) if doc.expire_after else None
-            ),
+            # to_unix_timestamp treats naive as UTC — v2 datetimes come back
+            # from Mongo naive-UTC, so this stays host-TZ-independent.
+            expiration_time=to_unix_timestamp(doc.expire_after),
             max_clicks=doc.max_clicks,
             url_status=doc.status,
             schema_version="v2",
@@ -83,6 +85,13 @@ class UrlCacheData(BaseModel):
             meta_image_width=im.width if im else None,
             meta_image_height=im.height if im else None,
         )
+
+    def is_time_expired(self, now_ts: float) -> bool:
+        """Time-lapse check for the hot path. ``expiration_time`` is None
+        for links without expiry AND for v1 rows whose stored value is
+        tz-ambiguous (see ``_legacy_doc_to_cache``) — both never expire here.
+        """
+        return self.expiration_time is not None and self.expiration_time <= now_ts
 
     def verify_password(self, password: str | None) -> bool:
         """Check a password against this URL's stored hash.

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -154,6 +154,24 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
             {"$set": {"status": UrlStatus.EXPIRED}},
         )
 
+    async def expire_if_time_reached(self, url_id: ObjectId) -> bool:
+        """Conditionally expire the URL if its expire_after has passed.
+
+        Atomic conditional update mirroring ``expire_if_max_clicks`` —
+        matches only ACTIVE docs so BLOCKED/INACTIVE are never clobbered.
+        Returns True only if this call performed the flip (modified_count).
+        ``$lte`` on a date never matches null/missing (BSON type
+        bracketing), so no explicit null guard is needed.
+        """
+        return await self._update_modified(
+            {
+                "_id": url_id,
+                "status": UrlStatus.ACTIVE,
+                "expire_after": {"$lte": datetime.now(timezone.utc)},
+            },
+            {"$set": {"status": UrlStatus.EXPIRED}},
+        )
+
     async def find_by_owner(
         self,
         query: dict,

--- a/routes/api_v1/management.py
+++ b/routes/api_v1/management.py
@@ -153,7 +153,10 @@ async def update_url_status_v1(
 
     **Note**: `BLOCKED` is an admin-set status — blocked URLs cannot be modified
     or deleted by the owner. `EXPIRED` URLs (auto-set on max clicks or expiry
-    time) can be reactivated by setting status back to `ACTIVE`.
+    time) can be reactivated by setting status back to `ACTIVE` — but only
+    after the expiry condition is lifted (raise/clear `max_clicks`, extend/
+    clear `expire_after` via PATCH), otherwise the URL immediately reads
+    as expired again.
 
     **Use Cases**:
 

--- a/schemas/dto/responses/url.py
+++ b/schemas/dto/responses/url.py
@@ -74,7 +74,13 @@ class UrlResponse(ResponseBase):
         description="Creation time as Unix timestamp.",
         examples=[1704067200],
     )
-    status: UrlStatus = Field(description="URL status.", examples=["ACTIVE"])
+    status: UrlStatus = Field(
+        description=(
+            "URL status. Derived — reflects time and max-click expiry even "
+            "before the stored flip is persisted."
+        ),
+        examples=["ACTIVE"],
+    )
     private_stats: bool | None = Field(
         default=None,
         description="Whether statistics are private (owner-only).",
@@ -104,7 +110,7 @@ class UrlResponse(ResponseBase):
             if doc.owner_id and doc.owner_id != ANONYMOUS_OWNER_ID
             else None,
             created_at=to_unix_timestamp(doc.created_at, default=0),
-            status=doc.status,
+            status=doc.effective_status,
             private_stats=doc.private_stats,
             geo_rules=doc.geo_rules,
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
@@ -127,7 +133,12 @@ class UpdateUrlResponse(ResponseBase):
         examples=["https://example.com/long/url"],
     )
     status: UrlStatus | None = Field(
-        default=None, description="URL status.", examples=["ACTIVE"]
+        default=None,
+        description=(
+            "URL status. Derived — reflects time and max-click expiry even "
+            "before the stored flip is persisted."
+        ),
+        examples=["ACTIVE"],
     )
     password_set: bool = Field(description="Whether the URL is password-protected.")
     max_clicks: int | None = Field(
@@ -168,7 +179,7 @@ class UpdateUrlResponse(ResponseBase):
             id=str(doc.id),
             alias=doc.alias,
             long_url=doc.long_url,
-            status=doc.status,
+            status=doc.effective_status,
             password_set=doc.password is not None,
             max_clicks=doc.max_clicks,
             expire_after=to_unix_timestamp(doc.expire_after),
@@ -187,6 +198,8 @@ class UrlListItem(ResponseBase):
     ``created_at`` and ``last_click`` are ISO 8601 strings (e.g. "2024-01-01T00:00:00Z").
     ``expire_after`` is a Unix timestamp integer or null.
     These formats match the existing endpoint exactly.
+    ``status`` is derived — it reflects time and max-click expiry even
+    before the stored flip is persisted.
     """
 
     id: str
@@ -220,7 +233,7 @@ class UrlListItem(ResponseBase):
             id=str(doc.id),
             alias=doc.alias,
             long_url=doc.long_url,
-            status=doc.status,
+            status=doc.effective_status,
             created_at=_ensure_utc(doc.created_at),
             expire_after=to_unix_timestamp(doc.expire_after),
             max_clicks=doc.max_clicks,

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -12,7 +12,7 @@ Three separate schemas map to three MongoDB collections:
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from schemas.models.base import ANONYMOUS_OWNER_ID, MongoBaseModel, PyObjectId
+from shared.datetime_utils import as_aware_utc
 
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
 
@@ -179,6 +180,22 @@ class UrlV2Doc(MongoBaseModel):
     total_clicks: int = Field(default=0, ge=0)
     last_click: datetime | None = None
     updated_at: datetime | None = None
+
+    @property
+    def effective_status(self) -> UrlStatus:
+        """Status with derived expiry folded in — time lapse and max-click
+        exhaustion read as EXPIRED even before the persisted flip (the
+        flip happens on the click/redirect path; between observations the
+        stored field may lag). Never read ``status`` raw on a wire path.
+        """
+        if self.status is not UrlStatus.ACTIVE:
+            return self.status
+        expire_after = as_aware_utc(self.expire_after)
+        if expire_after is not None and expire_after <= datetime.now(timezone.utc):
+            return UrlStatus.EXPIRED
+        if self.max_clicks is not None and self.total_clicks >= self.max_clicks:
+            return UrlStatus.EXPIRED
+        return self.status
 
 
 class LegacyUrlDoc(MongoBaseModel):

--- a/services/public_link_resolver.py
+++ b/services/public_link_resolver.py
@@ -15,10 +15,9 @@ Invariants (load-bearing — preserved from the preview endpoint):
     only via the redirect; the public surfaces are system-domain-only.
   - v1/emoji documents are fetched RAW — the typed ``LegacyUrlDoc``
     silently drops ``creation-date`` / ``creation-time``.
-  - Derived expiry is DELIBERATELY STRICTER than the expiry-blind
-    redirect: a public surface must never reveal a destination the
-    redirect would refuse, so status may err toward "expired", never
-    away from it.
+  - Derived expiry is IDENTICAL to the redirect's derivation
+    (``UrlV2Doc.effective_status``): a public surface must never reveal
+    a destination the redirect would refuse.
   - Everything is derived READ-ONLY — nothing here writes.
 """
 
@@ -32,45 +31,24 @@ from urllib.parse import unquote
 from repositories.legacy.emoji_url_repository import EmojiUrlRepository
 from repositories.legacy.legacy_url_repository import LegacyUrlRepository
 from repositories.url_repository import UrlRepository
-from schemas.models.url import SchemaVersion, UrlStatus, UrlV2Doc
+from schemas.models.url import SchemaVersion, UrlV2Doc
 from shared.alias_dispatch import resolution_order
-from shared.datetime_utils import convert_to_gmt, parse_datetime
+from shared.datetime_utils import as_aware_utc, convert_to_gmt, parse_datetime
 
 # ── Derivation helpers (generation-specific primitives) ──────────────────────
 
 
-def as_aware_utc(dt: Any) -> datetime | None:
-    """Normalize a stored datetime for comparison — Mongo returns naive
-    UTC datetimes by default (the client is not ``tz_aware``)."""
-    if not isinstance(dt, datetime):
-        return None
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
-
-
 def v2_effective_status(doc: UrlV2Doc) -> str:
-    """Lowercase wire status, folding derived expiry into ``expired``.
+    """Lowercase wire adapter over ``UrlV2Doc.effective_status``.
 
-    The persisted status flip happens on the click path
-    (``UrlRepository.expire_if_max_clicks``); a time-based flip has no
-    writer at all — the redirect never compares ``expire_after`` to
-    now. The invariant the public surfaces hold is one-directional:
-    they never reveal a destination the redirect would refuse.
-    Deriving time-based expiry here is therefore DELIBERATELY STRICTER
-    than the expiry-blind redirect (a lapsed-but-still-ACTIVE link
-    reads ``expired`` and withholds its destination even though the
-    redirect would still serve it). Do not "fix" that divergence by
-    deleting the check — it errs in the safe direction. Derived here,
-    never written back.
+    The derivation (time lapse + max-click exhaustion folded into
+    EXPIRED) lives on the model and is shared with the redirect's
+    enforcement — the public surfaces and the redirect answer from the
+    same predicate by construction. Only the wire casing is decided
+    here (``"active" | "inactive" | "expired" | "blocked"``, frozen by
+    the public-page contract).
     """
-    if doc.status == UrlStatus.ACTIVE:
-        expire_after = as_aware_utc(doc.expire_after)
-        if expire_after is not None and expire_after <= datetime.now(timezone.utc):
-            return "expired"
-        if doc.max_clicks is not None and doc.total_clicks >= doc.max_clicks:
-            return "expired"
-    return doc.status.value.lower()
+    return doc.effective_status.value.lower()
 
 
 def v1_is_expired(data: dict) -> bool:

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -65,7 +65,7 @@ from schemas.models.url import (
     UrlV2Doc,
 )
 from shared.alias_dispatch import resolution_order
-from shared.datetime_utils import parse_datetime
+from shared.datetime_utils import parse_datetime, to_unix_timestamp
 from shared.generators import generate_short_code_v2
 from shared.reserved_aliases import is_reserved_alias
 from shared.url_utils import extract_hostname
@@ -427,7 +427,8 @@ class UrlService:
         Raises:
             NotFoundError:   URL not found in any collection.
             BlockedUrlError: URL status is BLOCKED (v2 only).
-            GoneError:       URL status is EXPIRED or INACTIVE (v2 only).
+            GoneError:       URL status is EXPIRED or INACTIVE (v2 only),
+                             or the expiration time has passed (any schema).
         """
         scope = domain or self._system_default_domain
         is_custom = scope != self._system_default_domain
@@ -448,6 +449,7 @@ class UrlService:
                     source="cache",
                 )
                 _raise_for_status(cached.url_status)
+            await self._raise_if_time_expired(cached, schema, short_code, "cache")
             if should_sample("cache_operation"):
                 log.debug(
                     "url_cache_hit",
@@ -502,7 +504,41 @@ class UrlService:
             )
             raise GoneError("URL has expired (max clicks reached)")
 
+        # 4c. Raise for URLs whose expiration time has passed (any schema)
+        await self._raise_if_time_expired(url_cache_data, schema, short_code, "db")
+
         return url_cache_data, schema
+
+    async def _raise_if_time_expired(
+        self, data: UrlCacheData, schema: SchemaVersion, short_code: str, source: str
+    ) -> None:
+        """Enforce time-based expiry at resolve time. v2: persist the flip
+        (mirrors max-clicks, ``expire_if_time_reached``) then raise; v1/emoji
+        have no status field — lazy-raise forever.
+
+        Post-flip reads stay O(1): the DB branch recaches the link as
+        minimal EXPIRED on the next resolve (cache populate runs before
+        the non-ACTIVE raise) — do NOT "optimize" that recache away.
+        """
+        if not data.is_time_expired(time.time()):
+            return
+        log.info(
+            "url_resolve_expired_time",
+            short_code=short_code,
+            schema=schema,
+            source=source,
+        )
+        if schema == SchemaVersion.V2 and data.url_status == UrlStatus.ACTIVE:
+            flipped = await self._url_repo.expire_if_time_reached(ObjectId(data.id))
+            if flipped:
+                log.info(
+                    "url_expired",
+                    url_id=data.id,
+                    short_code=short_code,
+                    reason="expiration_time_reached",
+                )
+                await self._url_cache.invalidate(short_code, data.domain)
+        raise GoneError("URL has expired (expiration time reached)")
 
     async def check_alias_available(
         self, alias: str, *, domain: str | None = None
@@ -910,7 +946,11 @@ class UrlService:
     def _auto_reactivate(
         self, existing: UrlV2Doc, update_ops: dict, now: datetime
     ) -> None:
-        """Reactivate an EXPIRED URL if expiry conditions improve.
+        """Reactivate an EXPIRED URL if the REQUESTED CHANGE improves an
+        expiry condition — every arm requires its field in ``update_ops``
+        so ambient values can't resurrect the URL (an unrelated edit to a
+        max-clicks-expired link with a future expire_after must not
+        reactivate it).
 
         Only applies when the URL is currently EXPIRED and the caller
         did not explicitly set a new status.
@@ -925,11 +965,13 @@ class UrlService:
 
         max_clicks_cleared = "max_clicks" in update_ops and new_max is None
         max_clicks_raised = (
-            new_max is not None
-            and existing.max_clicks is not None
+            "max_clicks" in update_ops
+            and new_max is not None
             and new_max > existing.total_clicks
         )
-        expire_extended = new_expire is not None and new_expire > now
+        expire_extended = (
+            "expire_after" in update_ops and new_expire is not None and new_expire > now
+        )
         expire_cleared = "expire_after" in update_ops and new_expire is None
 
         if max_clicks_cleared or max_clicks_raised or expire_extended or expire_cleared:
@@ -1027,9 +1069,15 @@ class UrlService:
 
         f = query.parsed_filter
 
+        # Compound clauses (status, search) may each carry their own $or —
+        # collect them and compose via $and so they can't clobber each other.
+        and_clauses: list[dict] = []
+
         if f:
             if f.status:
-                mongo_query["status"] = f.status
+                and_clauses.append(
+                    effective_status_clause(f.status, datetime.now(timezone.utc))
+                )
 
             date_range: dict = {}
             if f.created_after:
@@ -1056,11 +1104,18 @@ class UrlService:
             if f.search:
                 try:
                     pattern = re.compile(re.escape(f.search), re.IGNORECASE)
-                    mongo_query["$or"] = [{"alias": pattern}, {"long_url": pattern}]
+                    and_clauses.append(
+                        {"$or": [{"alias": pattern}, {"long_url": pattern}]}
+                    )
                 except re.error:
                     raise ValidationError(
                         "Invalid search pattern", field="filter.search"
                     ) from None
+
+        if len(and_clauses) == 1:
+            mongo_query.update(and_clauses[0])
+        elif and_clauses:
+            mongo_query["$and"] = and_clauses
 
         sort_order = (
             -1 if query.sort_order.lower() in ("desc", "descending", "-1") else 1
@@ -1208,6 +1263,34 @@ def _raise_for_status(status: UrlStatus) -> None:
     raise GoneError("URL has expired or is no longer active")
 
 
+def _derived_expiry_arms(now: datetime) -> list[dict]:
+    """Mongo arms matching ACTIVE-stored docs whose effective status is
+    EXPIRED. MUST express the same predicate as
+    ``UrlV2Doc.effective_status`` — pinned by test.
+    """
+    return [
+        {"status": UrlStatus.ACTIVE, "expire_after": {"$lte": now}},
+        {
+            "status": UrlStatus.ACTIVE,
+            "max_clicks": {"$ne": None},
+            "$expr": {"$gte": ["$total_clicks", "$max_clicks"]},
+        },
+    ]
+
+
+def effective_status_clause(status: UrlStatus, now: datetime) -> dict:
+    """Mongo filter matching docs by EFFECTIVE status (see
+    ``UrlV2Doc.effective_status``) — the stored field alone lags for
+    ACTIVE docs whose expiry has passed but whose flip hasn't been
+    observed yet.
+    """
+    if status is UrlStatus.EXPIRED:
+        return {"$or": [{"status": UrlStatus.EXPIRED}, *_derived_expiry_arms(now)]}
+    if status is UrlStatus.ACTIVE:
+        return {"status": UrlStatus.ACTIVE, "$nor": _derived_expiry_arms(now)}
+    return {"status": status}  # INACTIVE / BLOCKED: stored is truth
+
+
 def _legacy_doc_to_cache(
     short_code: str,
     doc: LegacyUrlDoc | EmojiUrlDoc,
@@ -1219,9 +1302,13 @@ def _legacy_doc_to_cache(
     v1/emoji shorts only exist under the system default domain — they
     predate custom domains and won't ever be created elsewhere.
     """
+    # Only tz-aware stored values enforce expiry — a naive v1
+    # ``expiration-time`` is ambiguous and never expires, matching
+    # ``v1_is_expired`` (public pages) and ``convert_to_gmt`` (legacy
+    # stats) so the redirect and the read surfaces agree on v1.
     expiration_time = None
-    if doc.expiration_time:
-        expiration_time = int(doc.expiration_time.timestamp())
+    if doc.expiration_time is not None and doc.expiration_time.tzinfo is not None:
+        expiration_time = to_unix_timestamp(doc.expiration_time)
     return UrlCacheData(
         id=short_code,
         alias=short_code,

--- a/shared/datetime_utils.py
+++ b/shared/datetime_utils.py
@@ -62,6 +62,16 @@ def to_unix_timestamp(dt: datetime | None, default: int | None = None) -> int | 
     return int(dt.timestamp())
 
 
+def as_aware_utc(dt: Any) -> datetime | None:
+    """Normalize a stored datetime for comparison — Mongo returns naive
+    UTC datetimes by default (the client is not ``tz_aware``)."""
+    if not isinstance(dt, datetime):
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 def convert_to_gmt(expiration_time: str) -> datetime | None:
     """Parse an ISO 8601 string and convert to UTC.
 

--- a/tests/unit/infrastructure/test_cache.py
+++ b/tests/unit/infrastructure/test_cache.py
@@ -3,8 +3,10 @@
 import json
 from unittest.mock import AsyncMock, patch
 
+from bson import ObjectId
+
 from infrastructure.cache.dual_cache import DualCache
-from infrastructure.cache.url_cache import UrlCache
+from infrastructure.cache.url_cache import UrlCache, UrlCacheData
 
 from .conftest import _fake_redis, _url_data
 
@@ -291,3 +293,56 @@ class TestUrlCacheDataGeoRules:
         result = await cache2.get("abc1234", DOMAIN)
         assert result is not None
         assert result.geo_rules == rules
+
+
+class TestUrlCacheDataIsTimeExpired:
+    def _data(self, expiration_time):
+        return UrlCacheData(
+            id="x",
+            alias="abc1234",
+            long_url="https://example.com",
+            block_bots=False,
+            password_hash=None,
+            expiration_time=expiration_time,
+            max_clicks=None,
+            url_status="ACTIVE",
+            schema_version="v2",
+            owner_id=None,
+        )
+
+    def test_none_never_expires(self):
+        assert self._data(None).is_time_expired(1_800_000_000) is False
+
+    def test_past_is_expired(self):
+        assert self._data(1_000).is_time_expired(2_000) is True
+
+    def test_boundary_equal_is_expired(self):
+        # <= convention, shared with UrlV2Doc.effective_status
+        assert self._data(2_000).is_time_expired(2_000) is True
+
+    def test_future_is_not_expired(self):
+        assert self._data(3_000).is_time_expired(2_000) is False
+
+
+class TestFromV2DocExpirationNormalization:
+    def test_naive_expire_after_treated_as_utc(self):
+        """Mongo returns naive UTC — the projection must not interpret it
+        in host-local time."""
+        from datetime import datetime, timezone
+
+        from schemas.models.url import UrlV2Doc
+
+        naive = datetime(2025, 6, 1, 12, 0, 0)  # naive UTC from Mongo
+        doc = UrlV2Doc.from_mongo(
+            {
+                "_id": ObjectId(),
+                "alias": "abc1234",
+                "domain": "spoo.me",
+                "created_at": naive,
+                "long_url": "https://example.com",
+                "expire_after": naive,
+            }
+        )
+        data = UrlCacheData.from_v2_doc(doc)
+        expected = int(naive.replace(tzinfo=timezone.utc).timestamp())
+        assert data.expiration_time == expected

--- a/tests/unit/repositories/test_url_repository.py
+++ b/tests/unit/repositories/test_url_repository.py
@@ -167,6 +167,29 @@ class TestUrlRepository:
         assert await self._repo(col).expire_if_max_clicks(URL_OID, 100) is False
 
     @pytest.mark.asyncio
+    async def test_expire_if_time_reached_flips_active_past_expiry(self):
+        col = make_collection()
+        col.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+        result = await self._repo(col).expire_if_time_reached(URL_OID)
+        (filter_doc, update_doc) = col.update_one.call_args[0]
+        assert filter_doc["_id"] == URL_OID
+        # ACTIVE guard: BLOCKED/INACTIVE must never be clobbered, and the
+        # flip stays idempotent between concurrent resolves.
+        assert filter_doc["status"] == "ACTIVE"
+        assert "$lte" in filter_doc["expire_after"]
+        assert isinstance(filter_doc["expire_after"]["$lte"], datetime)
+        assert update_doc == {"$set": {"status": "EXPIRED"}}
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_expire_if_time_reached_returns_false_when_not_flipped(self):
+        """Not matched (future/absent expiry, non-ACTIVE) or already
+        flipped by a concurrent resolve — either way, no side effects."""
+        col = make_collection()
+        col.update_one = AsyncMock(return_value=MagicMock(modified_count=0))
+        assert await self._repo(col).expire_if_time_reached(URL_OID) is False
+
+    @pytest.mark.asyncio
     async def test_find_by_owner_returns_models(self):
         col = make_collection()
         cursor = col.find.return_value

--- a/tests/unit/schemas/dto/test_url.py
+++ b/tests/unit/schemas/dto/test_url.py
@@ -564,3 +564,39 @@ class TestMetaTagsResponseWarnings:
         # known while dims are not — only the byte warning applies.
         w = self._warnings(self._meta(bytes_=400_000))
         assert w == ["image exceeds 300KB; WhatsApp may silently drop it"]
+
+
+# ── Derived status in from_doc (time/max-click expiry folded) ────────────────
+
+
+class TestFromDocDerivedStatus:
+    """All three DTOs serialize EFFECTIVE status — a stored-ACTIVE doc
+    whose expiry has passed must read EXPIRED on the wire even before
+    the persisted flip happens."""
+
+    PAST = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+    def test_url_response_derives_expired(self):
+        r = UrlResponse.from_doc(_make_doc(expire_after=self.PAST), "https://spoo.me")
+        assert r.status == "EXPIRED"
+
+    def test_update_response_derives_expired(self):
+        r = UpdateUrlResponse.from_doc(_make_doc(expire_after=self.PAST))
+        assert r.status == "EXPIRED"
+
+    def test_list_item_derives_expired(self):
+        r = UrlListItem.from_doc(_make_doc(expire_after=self.PAST))
+        assert r.status == "EXPIRED"
+
+    def test_list_item_derives_expired_from_max_clicks(self):
+        r = UrlListItem.from_doc(_make_doc(max_clicks=10, total_clicks=42))
+        assert r.status == "EXPIRED"
+
+    def test_inactive_stored_is_not_folded(self):
+        r = UrlListItem.from_doc(_make_doc(status="INACTIVE", expire_after=self.PAST))
+        assert r.status == "INACTIVE"
+
+    def test_future_expiry_stays_active(self):
+        future = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        r = UrlListItem.from_doc(_make_doc(expire_after=future))
+        assert r.status == "ACTIVE"

--- a/tests/unit/schemas/models/test_url.py
+++ b/tests/unit/schemas/models/test_url.py
@@ -1,11 +1,19 @@
 """Unit tests for UrlV2Doc, LegacyUrlDoc, EmojiUrlDoc, and LinkMetaTags."""
 
+from datetime import timedelta
+
 import pytest
 from bson import ObjectId
 from pydantic import ValidationError as PydanticValidationError
 
 from schemas.models.base import ANONYMOUS_OWNER_ID
-from schemas.models.url import EmojiUrlDoc, LegacyUrlDoc, LinkMetaTags, UrlV2Doc
+from schemas.models.url import (
+    EmojiUrlDoc,
+    LegacyUrlDoc,
+    LinkMetaTags,
+    UrlStatus,
+    UrlV2Doc,
+)
 
 from .conftest import now, oid
 
@@ -297,3 +305,75 @@ class TestLinkMetaTags:
             }
         )
         assert doc.meta_tags is None
+
+
+# ── UrlV2Doc.effective_status ─────────────────────────────────────────────────
+
+
+class TestUrlV2DocEffectiveStatus:
+    """The derived-status predicate shared by the redirect, the DTOs, and
+    the public resolver. The Mongo filter clause must express the same
+    predicate — pinned in tests/unit/services/test_url_service.py."""
+
+    def _make(self, **overrides):
+        base = {
+            "_id": oid(),
+            "alias": "abc1234",
+            "owner_id": oid(),
+            "domain": "spoo.me",
+            "created_at": now(),
+            "long_url": "https://example.com",
+        }
+        base.update(overrides)
+        return UrlV2Doc.model_validate(base)
+
+    def test_active_without_expiry_stays_active(self):
+        assert self._make().effective_status == UrlStatus.ACTIVE
+
+    def test_active_with_future_expiry_stays_active(self):
+        doc = self._make(expire_after=now() + timedelta(hours=1))
+        assert doc.effective_status == UrlStatus.ACTIVE
+
+    def test_active_with_past_expiry_reads_expired(self):
+        doc = self._make(expire_after=now() - timedelta(seconds=1))
+        assert doc.effective_status == UrlStatus.EXPIRED
+
+    def test_boundary_expiry_equal_to_now_reads_expired(self):
+        # <= convention — an expiry stamped exactly now is already expired.
+        doc = self._make(expire_after=now() - timedelta(microseconds=1))
+        assert doc.effective_status == UrlStatus.EXPIRED
+
+    def test_naive_past_expiry_treated_as_utc(self):
+        # Mongo returns naive UTC datetimes — they must still enforce.
+        naive_past = (now() - timedelta(hours=1)).replace(tzinfo=None)
+        doc = self._make(expire_after=naive_past)
+        assert doc.effective_status == UrlStatus.EXPIRED
+
+    def test_max_clicks_exhausted_reads_expired(self):
+        doc = self._make(max_clicks=5, total_clicks=5)
+        assert doc.effective_status == UrlStatus.EXPIRED
+
+    def test_max_clicks_not_exhausted_stays_active(self):
+        doc = self._make(max_clicks=5, total_clicks=4)
+        assert doc.effective_status == UrlStatus.ACTIVE
+
+    @pytest.mark.parametrize("status", ["INACTIVE", "BLOCKED", "EXPIRED"])
+    def test_non_active_stored_status_never_folded(self, status):
+        # Derivation only applies to ACTIVE — stored non-ACTIVE is truth.
+        doc = self._make(status=status, expire_after=now() - timedelta(hours=1))
+        assert doc.effective_status == UrlStatus(status)
+
+    def test_wire_casing_pin(self):
+        """The public-page contract is frozen lowercase — .value.lower()
+        in v2_effective_status is load-bearing over UPPERCASE enum values."""
+        from services.public_link_resolver import v2_effective_status
+
+        assert v2_effective_status(self._make()) == "active"
+        expired = self._make(expire_after=now() - timedelta(hours=1))
+        assert v2_effective_status(expired) == "expired"
+        assert {s.value for s in UrlStatus} == {
+            "ACTIVE",
+            "INACTIVE",
+            "EXPIRED",
+            "BLOCKED",
+        }

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -2428,9 +2428,7 @@ class TestUrlServiceTimeExpiry:
         with pytest.raises(GoneError):
             await svc.resolve("customalias", domain="links.acme.com")
 
-        url_repo.find_by_alias.assert_awaited_once_with(
-            "customalias", "links.acme.com"
-        )
+        url_repo.find_by_alias.assert_awaited_once_with("customalias", "links.acme.com")
         url_repo.expire_if_time_reached.assert_awaited_once_with(URL_OID)
         url_cache.invalidate.assert_awaited_once_with("customalias", "links.acme.com")
 

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -2412,6 +2412,28 @@ class TestUrlServiceTimeExpiry:
         with pytest.raises(GoneError):
             await svc.resolve("abcdef")
 
+    @pytest.mark.asyncio
+    async def test_custom_domain_past_expiry_flips_and_invalidates_scoped_key(self):
+        """Custom tenants ride the same enforcement — dispatch is v2-only,
+        the flip is by _id, and the invalidation must target the
+        tenant-scoped cache key (data.domain), not the system default."""
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = None
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        url_repo.find_by_alias.return_value = make_url_v2_doc(
+            alias="customalias", expire_after=past, domain="links.acme.com"
+        )
+        url_repo.expire_if_time_reached.return_value = True
+
+        with pytest.raises(GoneError):
+            await svc.resolve("customalias", domain="links.acme.com")
+
+        url_repo.find_by_alias.assert_awaited_once_with(
+            "customalias", "links.acme.com"
+        )
+        url_repo.expire_if_time_reached.assert_awaited_once_with(URL_OID)
+        url_cache.invalidate.assert_awaited_once_with("customalias", "links.acme.com")
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestEffectiveStatusClause — Mongo clause ≡ UrlV2Doc.effective_status

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -7,8 +7,9 @@ Tests verify behavior, not implementation details.
 
 from __future__ import annotations
 
+import time as time_module
 import typing
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -24,7 +25,7 @@ from errors import (
 )
 from infrastructure.cache.url_cache import UrlCacheData
 from schemas.models.base import ANONYMOUS_OWNER_ID
-from schemas.models.url import EmojiUrlDoc, LegacyUrlDoc, UrlV2Doc
+from schemas.models.url import EmojiUrlDoc, LegacyUrlDoc, UrlStatus, UrlV2Doc
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Constants
@@ -113,6 +114,8 @@ def make_active_cache(
     block_bots: bool = False,
     max_clicks: int | None = None,
     password_hash: str | None = None,
+    expiration_time: int | None = None,
+    url_status: str = "ACTIVE",
 ) -> UrlCacheData:
     return UrlCacheData(
         id=str(URL_OID),
@@ -120,11 +123,12 @@ def make_active_cache(
         long_url="https://example.com",
         block_bots=block_bots,
         password_hash=password_hash,
-        expiration_time=None,
+        expiration_time=expiration_time,
         max_clicks=max_clicks,
-        url_status="ACTIVE",
+        url_status=url_status,
         schema_version=schema,
         owner_id=str(USER_OID),
+        domain=SYSTEM_DEFAULT_DOMAIN,
     )
 
 
@@ -2237,3 +2241,415 @@ class TestValidateMetaTags:
                 MetaTagsRequest(title="ok"), long_url="https://evil-token.com/login"
             )
         assert exc.value.field == "long_url"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestUrlServiceTimeExpiry — resolve-time enforcement of expire_after
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUrlServiceTimeExpiry:
+    """Time-based expiry is enforced lazily at resolve (both cache-hit and
+    DB paths); v2 additionally persists the status flip, mirroring
+    max-clicks (expire_if_time_reached + invalidate)."""
+
+    PAST_TS = int(time_module.time()) - 3600
+    FUTURE_TS = int(time_module.time()) + 3600
+
+    def _svc(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        return svc, url_repo, url_cache, legacy_repo, emoji_repo
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_v2_past_expiry_raises_gone_and_flips(self):
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = make_active_cache(expiration_time=self.PAST_TS)
+        url_repo.expire_if_time_reached.return_value = True
+
+        with pytest.raises(GoneError):
+            await svc.resolve(ALIAS)
+
+        url_repo.expire_if_time_reached.assert_awaited_once_with(URL_OID)
+        url_cache.invalidate.assert_awaited_once_with(ALIAS, SYSTEM_DEFAULT_DOMAIN)
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_v2_future_expiry_resolves(self):
+        svc, url_repo, url_cache, *_ = self._svc()
+        cached = make_active_cache(expiration_time=self.FUTURE_TS)
+        url_cache.get.return_value = cached
+
+        result, _schema = await svc.resolve(ALIAS)
+
+        assert result is cached
+        url_repo.expire_if_time_reached.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flip_already_done_elsewhere_skips_invalidate(self):
+        """modified_count=0 (concurrent resolve won the flip) — still 410,
+        but no duplicate invalidation side effect."""
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = make_active_cache(expiration_time=self.PAST_TS)
+        url_repo.expire_if_time_reached.return_value = False
+
+        with pytest.raises(GoneError):
+            await svc.resolve(ALIAS)
+
+        url_cache.invalidate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_path_v2_past_expiry_raises_gone_after_recache(self):
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = None
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        url_repo.find_by_alias.return_value = make_url_v2_doc(expire_after=past)
+        url_repo.expire_if_time_reached.return_value = True
+
+        with pytest.raises(GoneError):
+            await svc.resolve(ALIAS)
+
+        # Recache-before-raise keeps hot expired links O(1) — the entry is
+        # written (step 3) before the expiry raise (step 4c).
+        url_cache.set.assert_awaited_once()
+        url_repo.expire_if_time_reached.assert_awaited_once_with(URL_OID)
+
+    @pytest.mark.asyncio
+    async def test_stored_blocked_wins_over_time_expiry(self):
+        """Ordering: stored-status checks run first — BLOCKED must keep
+        raising BlockedUrlError, and no flip may touch a BLOCKED doc."""
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = make_active_cache(
+            expiration_time=self.PAST_TS, url_status="BLOCKED"
+        )
+
+        with pytest.raises(BlockedUrlError):
+            await svc.resolve(ALIAS)
+
+        url_repo.expire_if_time_reached.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stored_expired_skips_flip(self):
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = make_active_cache(
+            expiration_time=self.PAST_TS, url_status="EXPIRED"
+        )
+
+        with pytest.raises(GoneError):
+            await svc.resolve(ALIAS)
+
+        url_repo.expire_if_time_reached.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cached_v1_past_expiry_raises_gone_without_flip(self):
+        """v1 has no status field — lazy-raise forever, never a flip."""
+        svc, url_repo, url_cache, *_ = self._svc()
+        url_cache.get.return_value = make_active_cache(
+            schema="v1", alias="abcdef", expiration_time=self.PAST_TS
+        )
+
+        with pytest.raises(GoneError):
+            await svc.resolve("abcdef")
+
+        url_repo.expire_if_time_reached.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_emoji_past_aware_expiry_raises_gone(self):
+        svc, url_repo, url_cache, _legacy_repo, emoji_repo = self._svc()
+        url_cache.get.return_value = None
+        emoji_repo.find_by_id.return_value = EmojiUrlDoc.from_mongo(
+            {
+                "_id": "🐍🔥💎",
+                "url": "https://emoji.example.com",
+                "block-bots": False,
+                "total-clicks": 0,
+                "expiration-time": datetime.now(timezone.utc) - timedelta(hours=1),
+            }
+        )
+
+        with pytest.raises(GoneError):
+            await svc.resolve("🐍🔥💎")
+
+        url_repo.expire_if_time_reached.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_v1_naive_expiry_is_ambiguous_and_resolves(self):
+        """tz-naive v1 expiration-time never enforces — matches
+        v1_is_expired (public pages) and convert_to_gmt (legacy stats)."""
+        svc, _url_repo, url_cache, legacy_repo, _emoji_repo = self._svc()
+        url_cache.get.return_value = None
+        naive_past = datetime(2020, 1, 1)  # naive → ambiguous
+        legacy_repo.find_by_id.return_value = LegacyUrlDoc.from_mongo(
+            {
+                "_id": "abcdef",
+                "url": "https://legacy.example.com",
+                "block-bots": False,
+                "total-clicks": 0,
+                "expiration-time": naive_past,
+            }
+        )
+
+        result, schema = await svc.resolve("abcdef")
+
+        assert result.expiration_time is None
+        assert schema == "v1"
+
+    @pytest.mark.asyncio
+    async def test_db_v1_aware_past_expiry_raises_gone(self):
+        svc, _url_repo, url_cache, legacy_repo, _emoji_repo = self._svc()
+        url_cache.get.return_value = None
+        legacy_repo.find_by_id.return_value = LegacyUrlDoc.from_mongo(
+            {
+                "_id": "abcdef",
+                "url": "https://legacy.example.com",
+                "block-bots": False,
+                "total-clicks": 0,
+                "expiration-time": datetime.now(timezone.utc) - timedelta(hours=1),
+            }
+        )
+
+        with pytest.raises(GoneError):
+            await svc.resolve("abcdef")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestEffectiveStatusClause — Mongo clause ≡ UrlV2Doc.effective_status
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _matches_expired_clause(doc: UrlV2Doc, now: datetime) -> bool:
+    """Python evaluation of effective_status_clause(EXPIRED, now) — must
+    mirror _derived_expiry_arms exactly (the predicate-pin's referee)."""
+    if doc.status == "EXPIRED":
+        return True
+    if doc.status == "ACTIVE":
+        expire = doc.expire_after
+        if expire is not None:
+            aware = expire if expire.tzinfo else expire.replace(tzinfo=timezone.utc)
+            if aware <= now:
+                return True
+        if doc.max_clicks is not None and doc.total_clicks >= doc.max_clicks:
+            return True
+    return False
+
+
+class TestEffectiveStatusClause:
+    def test_expired_clause_shape(self):
+        from services.url_service import effective_status_clause
+
+        now = datetime.now(timezone.utc)
+        clause = effective_status_clause(UrlStatus.EXPIRED, now)
+        assert clause == {
+            "$or": [
+                {"status": UrlStatus.EXPIRED},
+                {"status": UrlStatus.ACTIVE, "expire_after": {"$lte": now}},
+                {
+                    "status": UrlStatus.ACTIVE,
+                    "max_clicks": {"$ne": None},
+                    "$expr": {"$gte": ["$total_clicks", "$max_clicks"]},
+                },
+            ]
+        }
+
+    def test_active_clause_is_complement_of_derived_arms(self):
+        from services.url_service import (
+            _derived_expiry_arms,
+            effective_status_clause,
+        )
+
+        now = datetime.now(timezone.utc)
+        clause = effective_status_clause(UrlStatus.ACTIVE, now)
+        assert clause == {
+            "status": UrlStatus.ACTIVE,
+            "$nor": _derived_expiry_arms(now),
+        }
+
+    @pytest.mark.parametrize("status", [UrlStatus.INACTIVE, UrlStatus.BLOCKED])
+    def test_stored_is_truth_for_admin_states(self, status):
+        from services.url_service import effective_status_clause
+
+        clause = effective_status_clause(status, datetime.now(timezone.utc))
+        assert clause == {"status": status}
+
+    def test_predicate_pin_matrix(self):
+        """effective_status == EXPIRED iff doc matches the EXPIRED clause,
+        across the full status x expiry x max-clicks matrix. If this
+        fails, the model property and the Mongo filter have diverged."""
+        now = datetime.now(timezone.utc)
+        statuses = ["ACTIVE", "INACTIVE", "EXPIRED", "BLOCKED"]
+        expiries = [None, now - timedelta(hours=1), now + timedelta(hours=1)]
+        clicks = [(None, 0), (5, 5), (5, 2)]
+
+        for status in statuses:
+            for expire_after in expiries:
+                for max_clicks, total_clicks in clicks:
+                    doc = make_url_v2_doc(
+                        status=status,
+                        expire_after=expire_after,
+                        max_clicks=max_clicks,
+                    )
+                    doc.total_clicks = total_clicks
+                    case = f"{status}/{expire_after}/{max_clicks}:{total_clicks}"
+                    assert (doc.effective_status == UrlStatus.EXPIRED) == (
+                        _matches_expired_clause(doc, now)
+                    ), case
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestListFilterComposition — status/search $or clauses compose via $and
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestListFilterComposition:
+    def _svc(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        url_repo.count_by_query.return_value = 0
+        url_repo.find_by_owner.return_value = []
+        return svc, url_repo
+
+    @pytest.mark.asyncio
+    async def test_expired_filter_includes_derived_arms(self):
+        svc, url_repo = self._svc()
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        await svc.list_by_owner(USER_OID, ListUrlsQuery(filter='{"status": "EXPIRED"}'))
+
+        q = url_repo.count_by_query.call_args[0][0]
+        assert q["owner_id"] == USER_OID
+        arms = q["$or"]
+        assert {"status": UrlStatus.EXPIRED} in arms
+        assert any(a.get("expire_after") for a in arms)
+
+    @pytest.mark.asyncio
+    async def test_active_filter_excludes_derived_expired(self):
+        svc, url_repo = self._svc()
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        await svc.list_by_owner(USER_OID, ListUrlsQuery(filter='{"status": "ACTIVE"}'))
+
+        q = url_repo.count_by_query.call_args[0][0]
+        assert q["status"] == UrlStatus.ACTIVE
+        assert "$nor" in q
+
+    @pytest.mark.asyncio
+    async def test_status_and_search_compose_via_and(self):
+        """Both clauses carry $or — naive merging would clobber one."""
+        svc, url_repo = self._svc()
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        await svc.list_by_owner(
+            USER_OID,
+            ListUrlsQuery(filter='{"status": "EXPIRED", "search": "example"}'),
+        )
+
+        q = url_repo.count_by_query.call_args[0][0]
+        assert "$or" not in q  # neither clause owns the top level
+        status_clause, search_clause = None, None
+        for clause in q["$and"]:
+            if any("status" in arm for arm in clause["$or"]):
+                status_clause = clause
+            else:
+                search_clause = clause
+        assert status_clause is not None
+        assert search_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_search_only_still_merges_to_top_level(self):
+        svc, url_repo = self._svc()
+        from schemas.dto.requests.url import ListUrlsQuery
+
+        await svc.list_by_owner(USER_OID, ListUrlsQuery(filter='{"search": "ex"}'))
+
+        q = url_repo.count_by_query.call_args[0][0]
+        assert "$or" in q
+        assert "$and" not in q
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestAutoReactivateRequiresRequestedChange — §7 resurrection regressions
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAutoReactivateRequiresRequestedChange:
+    """Reactivation is driven by the REQUESTED change — ambient field
+    values must not resurrect an EXPIRED URL on unrelated edits."""
+
+    def _expired_doc(self, **overrides):
+        base = {
+            "_id": URL_OID,
+            "alias": ALIAS,
+            "owner_id": USER_OID,
+            "domain": SYSTEM_DEFAULT_DOMAIN,
+            "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "long_url": "https://example.com",
+            "status": "EXPIRED",
+            "private_stats": True,
+        }
+        base.update(overrides)
+        return UrlV2Doc.from_mongo(base)
+
+    def _svc(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.update.return_value = True
+        return svc, url_repo
+
+    @pytest.mark.asyncio
+    async def test_unrelated_edit_does_not_resurrect(self):
+        """Max-clicks-expired doc with a future expire_after: editing only
+        long_url must NOT flip it back to ACTIVE."""
+        svc, url_repo = self._svc()
+        url_repo.find_by_id.return_value = self._expired_doc(
+            max_clicks=3,
+            total_clicks=3,
+            expire_after=datetime.now(timezone.utc) + timedelta(days=30),
+        )
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(
+            URL_OID, UpdateUrlRequest(long_url="https://other.org"), USER_OID
+        )
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert "status" not in update_doc["$set"]
+
+    @pytest.mark.asyncio
+    async def test_noop_update_does_not_write(self):
+        svc, url_repo = self._svc()
+        url_repo.find_by_id.return_value = self._expired_doc(
+            max_clicks=3,
+            total_clicks=3,
+            expire_after=datetime.now(timezone.utc) + timedelta(days=30),
+        )
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        result = await svc.update(URL_OID, UpdateUrlRequest(), USER_OID)
+
+        url_repo.update.assert_not_called()
+        assert result.status == UrlStatus.EXPIRED
+
+    @pytest.mark.asyncio
+    async def test_extending_expiry_on_time_flipped_doc_reactivates(self):
+        """The legitimate path still works: a time-expired (flipped) doc
+        whose expire_after is explicitly extended goes back to ACTIVE."""
+        svc, url_repo = self._svc()
+        url_repo.find_by_id.return_value = self._expired_doc(
+            expire_after=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        future = datetime.now(timezone.utc) + timedelta(days=7)
+        await svc.update(URL_OID, UpdateUrlRequest(expire_after=future), USER_OID)
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert update_doc["$set"]["status"] == "ACTIVE"


### PR DESCRIPTION
## The bug

\`expire_after\` is accepted, stored, validated, and documented — but was never enforced at redirect time. A URL whose expiry passed kept redirecting forever, and its stored \`status\` stayed \`ACTIVE\` everywhere (dashboard pill, list filters, update responses). The only thing that ever flipped status to \`EXPIRED\` was max-clicks.

This is a regression with a paper trail: expiry **was** enforced at redirect from Feb 2024 (\`51628a0\`) until the Dual-Cache rewrite (\`0c64b08\`, Jun 2025) dropped the check as collateral damage — the cache object stopped carrying the field, and the check never came back. The FastAPI migration faithfully ported the broken behavior, then the v2 API re-documented \`expire_after\` as a working feature.

Design doc: \`thoughts/time-based-expiry-trd.md\` (derive-on-read + opportunistic flip; no scheduler, no new index, no edge changes).

## What this does

**One derivation, four consumers.** \`UrlV2Doc.effective_status\` folds time lapse and max-click exhaustion into \`EXPIRED\` (only for stored-\`ACTIVE\` docs — \`INACTIVE\`/\`BLOCKED\` stay authoritative). The redirect, the DTOs, the list filter, and the public resolver all answer from this one predicate; a matrix test pins the model property and the Mongo clause against each other so they can't silently diverge.

- **Resolve enforcement** — \`resolve()\` now 410s past-expiry links on both the cache-hit and DB paths (\`expiration_time\` was already in every cache entry, so cache staleness is a non-issue). v2 additionally persists the flip via \`expire_if_time_reached\` — atomic conditional update mirroring \`expire_if_max_clicks\` (\`status: ACTIVE\` guard, \`modified_count\`, invalidate-only-when-flipped). v1/emoji have no status field and lazy-raise forever. Post-flip reads stay O(1): the link recaches as minimal \`EXPIRED\`.
- **Truthful reads** — \`UrlResponse\` / \`UpdateUrlResponse\` / \`UrlListItem\` serialize effective status; \`filter.status=EXPIRED\` now matches time-expired-but-stored-ACTIVE links (and \`ACTIVE\` excludes them) via a clause built from shared arms, composed with the search filter through \`$and\` so the two \`$or\`s can't clobber each other.
- **v1 tz-ambiguity alignment** — a naive \`expiration-time\` never enforces at the redirect, matching \`v1_is_expired\` (public pages) and \`convert_to_gmt\` (legacy stats), so all v1 surfaces agree on the ambiguous rows.
- **\`_auto_reactivate\` tightened** (adjacent bug) — reactivation now requires the improving field in the requested change; previously a max-clicks-expired link with a future \`expire_after\` was resurrected by any unrelated edit, including a no-op update.
- \`public_link_resolver.v2_effective_status\` shrinks to the lowercase wire adapter (casing pinned by test); management docstring updated to describe the reactivation path accurately.

## Deliberately out of scope

- **Edge**: expiring links stay barred from KV promotion (\`has_expiration\` skip). The add-expiry-to-already-promoted-link window is accepted as TTL-bounded (≤ ~6 min) — same invalidation-v1 staleness class as editing \`long_url\` on a promoted link. Follow-up PR (TRD §11) adds \`expires_at\` to the KV contract + a worker-side check with passthrough-on-expired, after this deploys.
- **Sweeper**: nothing needs to happen *at* expiry time until a \`link.expired\` webhook exists; derive-on-read makes enforcement exact without one.
- **v2 max-clicks at resolve**: cached v2 \`total_clicks\` is stale by design; the click path owns that flip. Unchanged.

## Verification

- 2245 tests pass; 46 new (enforcement on every path/ordering incl. BLOCKED-wins, flip idempotency, tz rules, DTO derivation, clause composition, predicate-pin matrix, resurrection regressions).
- Live smoke (uvicorn :8010, real Mongo/Redis, throwaway DB): stored-ACTIVE link with past expiry → 410 on first visit, Mongo status flipped to EXPIRED (\`url_expired reason=expiration_time_reached\`), second visit 410 from recache, future-expiry link 302s, public preview answers \`"status":"expired"\` with \`destination: null\`.

Post-release watch: \`url_resolve_expired_time\` volume in Axiom (steps up, then settles) and the 410 rate on the redirect route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL `status` is now consistently derived from time-based (`expire_after`) and click-based (`max_clicks`/`total_clicks`) expiry across responses, listings, redirects, and cached links.
  * Expired URLs are reliably prevented from resolving, including cache-hit enforcement with automatic DB status flipping and cache invalidation.
  * Listing filters for status and search now compose correctly without overriding each other.
  * Improved expiration handling for both timezone-aware and timezone-naive datetimes.

* **Documentation**
  * Updated guidance for `PATCH /api/v1/urls/{url_id}/status` reactivation rules for `EXPIRED` URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->