### PR TITLE
fix(stats): null avg_redirection_time when no measurements exist

### DIFF
--- a/schemas/dto/responses/stats.py
+++ b/schemas/dto/responses/stats.py
@@ -27,7 +27,9 @@ class StatsSummary(ResponseBase):
     unique_clicks: int
     first_click: datetime | None = None
     last_click: datetime | None = None
-    avg_redirection_time: float
+    # null = no redirect measurements in the range (never 0 — a zero would
+    # read as an instant redirect, not as absence of data)
+    avg_redirection_time: float | None = None
 
 
 class StatsTimeRange(ResponseBase):

--- a/services/export/formatters.py
+++ b/services/export/formatters.py
@@ -75,7 +75,8 @@ class CsvFormatter:
                 ("unique_clicks", summary.get("unique_clicks", 0)),
                 ("first_click", summary.get("first_click", "")),
                 ("last_click", summary.get("last_click", "")),
-                ("avg_redirection_time", summary.get("avg_redirection_time", 0)),
+                # null = no measurement — an empty cell, never a fabricated 0
+                ("avg_redirection_time", summary.get("avg_redirection_time", "")),
             ]
             _write_rows(zf, "summary.csv", summary_rows)
 

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -364,7 +364,14 @@ class PublicStatsService:
             "unique_clicks": len(doc.ips or []),
             "first_click": None,  # not stored on v1 docs
             "last_click": self._stats.to_user_tz(last_click, tz_name),
-            "avg_redirection_time": round(doc.average_redirection_time or 0, 2),
+            # The legacy schema can't tell "never measured" from a true
+            # 0.0 average (it stores 0.0 for both), so falsy maps to null
+            # — same semantic as v2: null = no measurement, never 0.
+            "avg_redirection_time": (
+                round(doc.average_redirection_time, 2)
+                if doc.average_redirection_time
+                else None
+            ),
         }
 
         response: dict[str, Any] = {

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -252,13 +252,14 @@ class StatsService:
             {"$facet": facet_stages},
         ]
 
-        # Default empty summary
+        # Default empty summary. avg_redirection_time is None, not 0 —
+        # "no measurements in range" must never read as an instant redirect.
         summary: dict[str, Any] = {
             "total_clicks": 0,
             "unique_clicks": 0,
             "first_click": None,
             "last_click": None,
-            "avg_redirection_time": 0,
+            "avg_redirection_time": None,
         }
         results: dict[str, list[dict[str, Any]]] = {}
 
@@ -272,13 +273,16 @@ class StatsService:
                 summary_list = facet_results.get("_summary", [])
                 if summary_list:
                     s = summary_list[0]
+                    # $avg yields None when no click in range carried a
+                    # redirect_ms measurement — pass it through as null.
+                    avg_redirect = s.get("avg_redirection_time")
                     summary = {
                         "total_clicks": s.get("total_clicks", 0),
                         "unique_clicks": s.get("unique_clicks", 0),
                         "first_click": self._fmt_tz(s.get("first_click"), tz_name),
                         "last_click": self._fmt_tz(s.get("last_click"), tz_name),
-                        "avg_redirection_time": round(
-                            s.get("avg_redirection_time") or 0, 2
+                        "avg_redirection_time": (
+                            round(avg_redirect, 2) if avg_redirect is not None else None
                         ),
                     }
 

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -457,6 +457,27 @@ def test_v1_wire_shape():
     assert "generated_at" in stats
 
 
+def test_v1_never_measured_avg_redirection_time_is_null_not_zero():
+    """No measurement = null on the wire, never a fabricated 0.
+
+    Pre-measurement legacy docs either lack the field entirely or carry
+    the schema default 0.0 — both mean "never measured", and neither may
+    surface as an instant-redirect 0.
+    """
+    ancient = _v1_data("legacy")
+    del ancient["average_redirection_time"]
+    zeroed = _v1_data("zeroed", average_redirection_time=0.0)
+    service, _ = _build_service(v1_docs={"legacy": ancient, "zeroed": zeroed})
+    with _client(service) as client:
+        missing = client.get(_url("legacy", _WINDOW))
+        zero = client.get(_url("zeroed", _WINDOW))
+
+    assert missing.status_code == 200
+    assert missing.json()["stats"]["summary"]["avg_redirection_time"] is None
+    assert zero.status_code == 200
+    assert zero.json()["stats"]["summary"]["avg_redirection_time"] is None
+
+
 # ── 6b. Drifted v1 analytics entries are skipped, never a 500 ─────────────────
 # (live repro on beta: a dimension entry whose value was a bare LIST hit
 # ``int(entry)`` → TypeError → unhandled → the whole stats page 500ed on
@@ -639,6 +660,26 @@ def test_v2_wire_scopes_match_by_url_id_not_short_code():
     assert match["meta.url_id"] == doc.id
     assert "meta.short_code" not in match
     assert set(match) == {"meta.url_id", "clicked_at"}
+
+
+def test_v2_zero_clicks_window_yields_null_avg_redirection_time():
+    """Zero clicks in the window: null = no measurement, never 0."""
+    doc = _make_v2_doc(alias="quiet12")
+    # The real $facet shape for an empty window: every facet is [].
+    facet_result: dict[str, Any] = {
+        "_summary": [],
+        **{dim: [] for dim in ("time", "browser", "os", "country", "city", "referrer")},
+    }
+    service, _ = _build_service(
+        v2_docs=[doc], click_repo=_CapturingClickRepo(facet_result)
+    )
+    with _client(service) as client:
+        resp = client.get(_url("quiet12", _WINDOW))
+
+    assert resp.status_code == 200
+    summary = resp.json()["stats"]["summary"]
+    assert summary["total_clicks"] == 0
+    assert summary["avg_redirection_time"] is None
 
 
 # ── 8. Effective status is derived (read-only) ───────────────────────────────

--- a/tests/integration/test_legacy_stats_routes.py
+++ b/tests/integration/test_legacy_stats_routes.py
@@ -218,6 +218,24 @@ def test_analytics_post_returns_json():
     assert "average_monthly_clicks" in data
 
 
+def test_analytics_post_missing_avg_redirection_time_stays_numeric_zero():
+    """Legacy wire compat: the shipped Flask-era JSON always carried a
+    number here and old clients do not null-guard, so the 0 default stays
+    on this surface (the modern API uses null for "no measurement")."""
+    db = _mock_db()
+    url_data = dict(SAMPLE_URL_DATA)
+    del url_data["average_redirection_time"]
+
+    with patch("routes.legacy.stats.LegacyUrlRepository") as MockLegacyRepo:
+        MockLegacyRepo.return_value.aggregate = AsyncMock(return_value=url_data)
+
+        app = build_test_app(legacy_stats_router, overrides={get_db: lambda: db})
+        with TestClient(app) as client:
+            resp = client.post("/stats/abc123")
+    assert resp.status_code == 200
+    assert resp.json()["average_redirection_time"] == 0
+
+
 def test_analytics_get_renders_stats_page():
     db = _mock_db()
 

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -113,3 +113,15 @@ class TestStatsResponse:
         assert d["scope"] == "all"
         assert d["summary"]["total_clicks"] == 10
         assert "clicks_by_time" in d["metrics"]
+
+    def test_summary_avg_redirection_time_is_nullable(self):
+        # null = no measurement in the range — distinct from a real 0.0
+        s = StatsSummary(total_clicks=0, unique_clicks=0)
+        assert s.avg_redirection_time is None
+        assert s.model_dump()["avg_redirection_time"] is None
+        assert (
+            StatsSummary(
+                total_clicks=5, unique_clicks=3, avg_redirection_time=12.34
+            ).avg_redirection_time
+            == 12.34
+        )

--- a/tests/unit/services/test_export_service.py
+++ b/tests/unit/services/test_export_service.py
@@ -133,6 +133,17 @@ class TestFormatters:
         assert "total_clicks" in csv_text
         assert "100" in csv_text
 
+    def test_csv_formatter_null_avg_redirection_time_writes_empty_cell(self):
+        # null = no measurement — the export must not fabricate a 0
+        data = {
+            **SAMPLE_STATS,
+            "summary": {**SAMPLE_STATS["summary"], "avg_redirection_time": None},
+        }
+        content = CsvFormatter().serialize(data)
+        with zipfile.ZipFile(BytesIO(content)) as zf, zf.open("summary.csv") as f:
+            csv_text = f.read().decode("utf-8")
+        assert "avg_redirection_time,\r\n" in csv_text
+
     def test_csv_formatter_empty_metrics_produces_summary_only(self):
         data = {**SAMPLE_STATS, "metrics": {}}
         content = CsvFormatter().serialize(data)

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -393,6 +393,38 @@ class TestResponseStructure:
             owner_id=OWNER_ID,
         )
         assert result["metrics"]["clicks_by_browser"] == []
+        assert result["summary"]["avg_redirection_time"] is None
+
+    @pytest.mark.asyncio
+    async def test_avg_redirection_time_rounded_when_measured(self):
+        svc, click_repo, url_repo = make_service()
+        url_repo.check_stats_privacy.return_value = privacy_info()
+        click_repo.aggregate.return_value = facet_response(avg_redirect=120.456)
+
+        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        assert result["summary"]["avg_redirection_time"] == 120.46
+
+    @pytest.mark.asyncio
+    async def test_avg_redirection_time_null_when_no_clicks_in_range(self):
+        """Zero clicks in the window (empty _summary facet): null, never 0."""
+        svc, click_repo, url_repo = make_service()
+        url_repo.check_stats_privacy.return_value = privacy_info()
+        click_repo.aggregate.return_value = [{"_summary": [], "time": []}]
+
+        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        assert result["summary"]["total_clicks"] == 0
+        assert result["summary"]["avg_redirection_time"] is None
+
+    @pytest.mark.asyncio
+    async def test_avg_redirection_time_null_when_clicks_carry_no_measurement(self):
+        """Clicks exist but $avg found no redirect_ms values: null, never 0."""
+        svc, click_repo, url_repo = make_service()
+        url_repo.check_stats_privacy.return_value = privacy_info()
+        click_repo.aggregate.return_value = facet_response(total=3, avg_redirect=None)
+
+        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        assert result["summary"]["total_clicks"] == 3
+        assert result["summary"]["avg_redirection_time"] is None
 
 
 # ── Tests: timezone handling ──────────────────────────────────────────────────


### PR DESCRIPTION

## What changed

`avg_redirection_time` conflated "no measurement" with "instant redirect": a range with zero clicks returned `0`. The semantic rule is now: **null = no measurement in the range, a number = a real measured average.** `0` is never invented.

- `schemas/dto/responses/stats.py` - `StatsSummary.avg_redirection_time` is `float | None` (default `None`).
- `services/stats_service.py` - the empty-summary default is `None`, and `$avg`'s `None` (no clicks in range, or clicks that carried no `redirect_ms`) passes through instead of being coalesced to `0`. This covers both `GET /api/v1/stats` and the v2 branch of the public stats endpoint, which reuse the same `compute()` seam.
- `services/public_stats_service.py` - the v1/emoji synthesis maps a falsy stored `average_redirection_time` to null: the legacy schema stores `0.0` for "never measured", so it cannot be distinguished from a true zero average (which real redirects never produce).
- `services/export/formatters.py` - the CSV summary writes an empty cell instead of a fabricated `0`; JSON/XML/XLSX already serialize `None` honestly.
- Legacy Flask-era surfaces (`/stats/{code}` JSON + templates) intentionally keep their numeric `0`: that wire is shipped and old clients do not null-guard. Pinned by a new test.

## Blast radius

Additive-null on a wire field. The dashboard adapter already null-guards client-side (`lib/api/stats.ts` in the frontend repo), and the public stats page consumes the same summary shape via `lib/api/public-stats.ts`. Other server-side consumers found and handled: the export formatters (above) and the legacy routes (unchanged by design). No other reader of the field exists in the repo.

## Tests

139 passed across the affected suites (`uv run pytest -q`):

- unit: zero-clicks range yields null; clicks-without-measurement yields null; a real average still rounds (`120.456 -> 120.46`); DTO accepts and serializes null.
- integration (public stats, real StatsService machinery): v2 empty `$facet` window yields null; v1 docs with a missing field or the stored `0.0` default yield null; the existing `14.24` measured-value pin still passes.
- integration (legacy): missing doc field still surfaces as numeric `0` on the legacy JSON wire.
- export: CSV writes an empty cell for null.

Both lint gates pass: `ruff check` and `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
