### PR TITLE
feat(api): add GET /api/v1/apps connected-apps list

### DIFF
--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -54,6 +54,7 @@ class Limits:
     # Device auth flow (extensions, apps, CLIs)
     DEVICE_AUTH = "10 per minute"
     DEVICE_TOKEN = "10 per minute"
+    APP_GRANTS_READ = "60 per minute"
 
     # OAuth
     OAUTH_INIT = "10 per minute"

--- a/routes/api_v1/__init__.py
+++ b/routes/api_v1/__init__.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from routes.api_v1 import (
+    apps,
     custom_domains,
     exports,
     keys,
@@ -25,6 +26,7 @@ router.include_router(stats.router)
 router.include_router(public_stats.router)
 router.include_router(exports.router)
 router.include_router(keys.router)
+router.include_router(apps.router)
 router.include_router(custom_domains.router)
 router.include_router(metadata.router)
 router.include_router(me.router)

--- a/routes/api_v1/apps.py
+++ b/routes/api_v1/apps.py
@@ -1,0 +1,53 @@
+"""
+GET /api/v1/apps — list the caller's connected apps (active device grants)
+
+JWT-only, matching /api/v1/keys: grants are an account-security surface,
+and an API key must not be able to enumerate the account's other delegated
+credentials (or their revoke handles).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from dependencies import AppGrantRepo, AppRegistryDep, JwtUser
+from middleware.openapi import AUTH_RESPONSES
+from middleware.rate_limiter import Limits, limiter
+from schemas.dto.responses.app_grant import AppGrantResponse, AppGrantsListResponse
+
+router = APIRouter(tags=["Apps"])
+
+
+@router.get(
+    "/apps",
+    responses=AUTH_RESPONSES,
+    operation_id="listAppGrants",
+    summary="List Connected Apps",
+)
+@limiter.limit(Limits.APP_GRANTS_READ)
+async def list_app_grants(
+    request: Request,
+    user: JwtUser,
+    grant_repo: AppGrantRepo,
+    app_registry: AppRegistryDep,
+) -> AppGrantsListResponse:
+    """List the apps connected to the authenticated user's account.
+
+    Returns one entry per active device-auth grant (revoked grants are
+    excluded), newest first. `app` is the registry key from
+    `config/apps.yaml` — pass it as `app_id` to `POST /auth/device/revoke`
+    to disconnect an app. An empty `items` array means nothing is
+    connected.
+
+    **Authentication**: Required — JWT Bearer only (API keys cannot list
+    the account's connected apps).
+
+    **Rate Limits**: 60/min
+    """
+    grants = await grant_repo.find_active_for_user(user.user_id)
+    grants.sort(key=lambda g: g.granted_at, reverse=True)
+    return AppGrantsListResponse(
+        items=[
+            AppGrantResponse.from_grant(g, app_registry.get(g.app_id)) for g in grants
+        ]
+    )

--- a/schemas/dto/responses/app_grant.py
+++ b/schemas/dto/responses/app_grant.py
@@ -1,0 +1,89 @@
+"""
+Response DTOs for GET /api/v1/apps.
+
+AppGrantResponse      — one connected app (active device-auth grant)
+AppGrantsListResponse — GET /api/v1/apps (200)
+
+The wire serves the spoo-landing Apps page (lib/api/apps.ts). Grants are
+not scoped — a device grant acts as the full account — so the wire carries
+the registry's consent ``permissions`` strings, never scope slugs
+(thoughts/apps-grants-api-prd.md §2).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import Field, field_serializer
+
+from schemas.dto.base import ResponseBase
+from schemas.models.app import AppEntry
+from schemas.models.app_grant import AppGrantDoc
+
+
+class AppGrantResponse(ResponseBase):
+    """A single connected app as returned by the list endpoint."""
+
+    id: str = Field(
+        description="Grant ID (row identity — revoke keys on `app`, not this)",
+        examples=["665f1c2ab7e94d0c8a1f2b3c"],
+    )
+    app: str = Field(
+        description=(
+            "App registry key (config/apps.yaml). Shares a namespace with the "
+            "frontend catalogue slugs and is the `app_id` handle for "
+            "POST /auth/device/revoke."
+        ),
+        examples=["spoo-cli"],
+    )
+    app_name: str = Field(
+        description="Display name from the registry (falls back to `app`)",
+        examples=["Spoo CLI"],
+    )
+    icon: str | None = Field(
+        default=None,
+        description="Registry icon filename, or null when the entry is gone",
+        examples=["spoo-cli.svg"],
+    )
+    permissions: list[str] = Field(
+        description="Consent-screen permission strings the user granted",
+        examples=[["Access your spoo.me account", "View your analytics"]],
+    )
+    granted_at: datetime = Field(description="When access was granted (ISO 8601 UTC)")
+    last_used_at: datetime | None = Field(
+        default=None,
+        description="Last token exchange/refresh by this app, null if never used",
+    )
+
+    @field_serializer("granted_at", "last_used_at")
+    def _ser_as_utc(self, dt: datetime | None) -> str | None:
+        # PyMongo returns naive datetimes; without explicit tzinfo the JSON
+        # form omits the offset and clients parse it as local time. Stamp
+        # UTC so the wire format is unambiguous (`...+00:00`).
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
+
+    @classmethod
+    def from_grant(cls, doc: AppGrantDoc, entry: AppEntry | None) -> AppGrantResponse:
+        # A grant can outlive its registry entry; it still holds live tokens,
+        # so it is listed with fallback labels rather than hidden.
+        return cls(
+            id=str(doc.id),
+            app=doc.app_id,
+            app_name=entry.name if entry else doc.app_id,
+            icon=entry.icon if entry else None,
+            permissions=list(entry.permissions) if entry else [],
+            granted_at=doc.granted_at,
+            last_used_at=doc.last_used_at,
+        )
+
+
+class AppGrantsListResponse(ResponseBase):
+    """Response body for GET /api/v1/apps."""
+
+    items: list[AppGrantResponse] = Field(
+        description="Active grants, newest granted_at first"
+    )

--- a/schemas/dto/responses/app_grant.py
+++ b/schemas/dto/responses/app_grant.py
@@ -69,13 +69,19 @@ class AppGrantResponse(ResponseBase):
     @classmethod
     def from_grant(cls, doc: AppGrantDoc, entry: AppEntry | None) -> AppGrantResponse:
         # A grant can outlive its registry entry; it still holds live tokens,
-        # so it is listed with fallback labels rather than hidden.
+        # so it is listed with fallback labels rather than hidden. The
+        # permissions fallback must never read as "no access": the grant is
+        # full-account regardless of what the catalogue once said.
         return cls(
             id=str(doc.id),
             app=doc.app_id,
             app_name=entry.name if entry else doc.app_id,
             icon=entry.icon if entry else None,
-            permissions=list(entry.permissions) if entry else [],
+            permissions=(
+                list(entry.permissions)
+                if entry
+                else ["Full access to your spoo.me account"]
+            ),
             granted_at=doc.granted_at,
             last_used_at=doc.last_used_at,
         )

--- a/tests/integration/api_v1/test_apps.py
+++ b/tests/integration/api_v1/test_apps.py
@@ -1,0 +1,176 @@
+"""Tests for GET /api/v1/apps."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from dependencies import (
+    get_app_grant_repo,
+    get_app_registry,
+    get_current_user,
+    require_jwt,
+)
+from schemas.models.app import AppEntry
+from schemas.models.app_grant import AppGrantDoc
+
+from .conftest import _build_test_app, _make_api_key_doc, _make_user
+
+
+def _make_grant(
+    user_id: ObjectId,
+    app_id: str = "spoo-cli",
+    granted_at: datetime | None = None,
+    last_used_at: datetime | None = None,
+) -> AppGrantDoc:
+    return AppGrantDoc.from_mongo(
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "app_id": app_id,
+            # Naive on purpose: PyMongo returns naive datetimes, and the DTO
+            # serializer must stamp UTC on the wire.
+            "granted_at": granted_at or datetime(2026, 6, 10, 12, 0, 0),
+            "last_used_at": last_used_at,
+            "revoked_at": None,
+        }
+    )
+
+
+def _registry() -> dict[str, AppEntry]:
+    return {
+        "spoo-cli": AppEntry(
+            name="Spoo CLI",
+            icon="spoo-cli.svg",
+            description="Shorten links from your terminal",
+            status="live",
+            permissions=["Access your spoo.me account", "View your analytics"],
+        )
+    }
+
+
+class TestListAppGrants:
+    def test_requires_auth(self):
+        application = _build_test_app(
+            {get_current_user: lambda: None, get_app_grant_repo: lambda: AsyncMock()}
+        )
+        with TestClient(application, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/apps")
+
+        assert resp.status_code == 401
+
+    def test_api_key_auth_rejected(self):
+        user = _make_user(api_key_doc=_make_api_key_doc())
+
+        application = _build_test_app(
+            {get_current_user: lambda: user, get_app_grant_repo: lambda: AsyncMock()}
+        )
+        with TestClient(application, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/apps")
+
+        assert resp.status_code == 403
+
+    def test_no_grants_returns_empty_items(self):
+        user = _make_user()
+        mock_repo = AsyncMock()
+        mock_repo.find_active_for_user = AsyncMock(return_value=[])
+
+        application = _build_test_app(
+            {require_jwt: lambda: user, get_app_grant_repo: lambda: mock_repo}
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get("/api/v1/apps")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"items": []}
+        mock_repo.find_active_for_user.assert_called_once_with(user.user_id)
+
+    def test_grant_maps_registry_entry(self):
+        user = _make_user()
+        grant = _make_grant(user.user_id, last_used_at=None)
+        mock_repo = AsyncMock()
+        mock_repo.find_active_for_user = AsyncMock(return_value=[grant])
+
+        application = _build_test_app(
+            {
+                require_jwt: lambda: user,
+                get_app_grant_repo: lambda: mock_repo,
+                get_app_registry: lambda: _registry(),
+            }
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get("/api/v1/apps")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 1
+        item = body["items"][0]
+        assert item == {
+            "id": str(grant.id),
+            "app": "spoo-cli",
+            "app_name": "Spoo CLI",
+            "icon": "spoo-cli.svg",
+            "permissions": [
+                "Access your spoo.me account",
+                "View your analytics",
+            ],
+            "granted_at": "2026-06-10T12:00:00+00:00",
+            "last_used_at": None,
+        }
+
+    def test_grant_without_registry_entry_falls_back(self):
+        user = _make_user()
+        grant = _make_grant(user.user_id, app_id="spoo-retired")
+        mock_repo = AsyncMock()
+        mock_repo.find_active_for_user = AsyncMock(return_value=[grant])
+
+        application = _build_test_app(
+            {
+                require_jwt: lambda: user,
+                get_app_grant_repo: lambda: mock_repo,
+                get_app_registry: lambda: _registry(),
+            }
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get("/api/v1/apps")
+
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["app"] == "spoo-retired"
+        assert item["app_name"] == "spoo-retired"
+        assert item["icon"] is None
+        assert item["permissions"] == []
+
+    def test_grants_sorted_newest_granted_first(self):
+        user = _make_user()
+        older = _make_grant(
+            user.user_id,
+            app_id="spoo-retired",
+            granted_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        newer = _make_grant(
+            user.user_id,
+            app_id="spoo-cli",
+            granted_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+            last_used_at=datetime(2026, 7, 12, 9, 30, 41, tzinfo=timezone.utc),
+        )
+        mock_repo = AsyncMock()
+        mock_repo.find_active_for_user = AsyncMock(return_value=[older, newer])
+
+        application = _build_test_app(
+            {
+                require_jwt: lambda: user,
+                get_app_grant_repo: lambda: mock_repo,
+                get_app_registry: lambda: _registry(),
+            }
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get("/api/v1/apps")
+
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert [i["app"] for i in items] == ["spoo-cli", "spoo-retired"]
+        assert items[0]["last_used_at"] == "2026-07-12T09:30:41+00:00"

--- a/tests/integration/api_v1/test_apps.py
+++ b/tests/integration/api_v1/test_apps.py
@@ -142,7 +142,9 @@ class TestListAppGrants:
         assert item["app"] == "spoo-retired"
         assert item["app_name"] == "spoo-retired"
         assert item["icon"] is None
-        assert item["permissions"] == []
+        # Never understate access: the grant is still full-account even
+        # when its catalogue entry is gone.
+        assert item["permissions"] == ["Full access to your spoo.me account"]
 
     def test_grants_sorted_newest_granted_first(self):
         user = _make_user()


### PR DESCRIPTION
Adds the missing API for the dashboard Apps page: the user's own device-grant list as JSON. Today only the Jinja apps page renders grants; the Next frontend adapter (lib/api/apps.ts) swallows the 404 into an empty list, so the page always shows nothing connected.

## Wire

```
GET /api/v1/apps
Authorization: Bearer <jwt>   # or access_token cookie

200 {
  "items": [
    {
      "id": "665f1c2ab7e94d0c8a1f2b3c",
      "app": "spoo-cli",
      "app_name": "Spoo CLI",
      "icon": "spoo-cli.svg",
      "permissions": ["Access your spoo.me account", "View your analytics"],
      "granted_at": "2026-06-10T12:00:00+00:00",
      "last_used_at": "2026-07-12T09:30:41+00:00"
    }
  ]
}
```

Active grants only, newest first. `app` is the config/apps.yaml registry key (shares a namespace with the frontend catalogue slugs) and is the `app_id` handle for the existing revoke endpoint. The wire carries the registry's consent `permissions` strings, not scope slugs: grants are not scoped (device JWTs act as the full account), and a security surface must not understate access.

## Gating

JWT-only via `require_jwt`, mirroring /api/v1/keys: an API key is a delegated credential, and letting it enumerate the account's other delegated credentials plus their revoke handles is a confused deputy. No `apps:*` scope exists and no programmatic consumer needs one. Rate limit 60/min (`Limits.APP_GRANTS_READ`), same budget as the sibling dashboard reads.

## Notes

- No new service, index, or wiring: `AppGrantRepo` and `AppRegistryDep` already exist, `find_active_for_user` is reused as is, and the `(user_id, revoked_at)` index already covers the query.
- `POST /auth/device/revoke` is untouched; the frontend mock aligns to its shipped Form contract in a spoo-landing follow-up.

## Tests

`tests/integration/api_v1/test_apps.py` (6 tests): 401 anonymous, 403 API-key auth, empty list, full registry mapping with UTC-stamped timestamps, registry-gone fallback, newest-first ordering.

- `uv run pytest tests/integration/api_v1/test_apps.py -q`: 6 passed
- `uv run pytest -q`: 2205 passed
- `uv run ruff check .` and `uv run ruff format --check .`: clean

## Merge safety

New endpoint, purely additive. No existing route, schema, or wire changes; nothing dark to flip. The endpoint is inert until the frontend stops mocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `GET /api/v1/apps` to list the authenticated caller’s connected apps (JWT-only).
  - Returns app metadata (name, icon), permissions, and grant/last-used timestamps serialized in UTC.
  - Orders results from newest to oldest and falls back to basic app info when registry details are unavailable.
  - Added a dedicated rate limit for connected-app listing.
- **Tests**
  - Added integration coverage for auth requirements, empty results, mapping, fallback behavior, ordering, and UTC timestamp serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
