### PR TITLE
feat: profile editing (user_name update, picture upload and unset)

### DIFF
--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -288,7 +288,12 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         token_factory,
         app.state.email_provider,
     )
-    app.state.profile_picture_service = ProfilePictureService(user_repo)
+    app.state.profile_picture_service = ProfilePictureService(
+        user_repo,
+        r2_storage=r2_storage,
+        upload_max_bytes=r2.upload_max_bytes,
+        key_secret=settings.secret_key,
+    )
     app.state.contact_service = ContactService(
         contact_webhook,
         report_webhook,

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -46,6 +46,7 @@ class Limits:
     AUTH_READ = "60 per minute"
     ONBOARDING_WRITE = "30 per minute"
     SET_PASSWORD = "5 per minute"
+    PROFILE_UPDATE = "10 per minute"
     RESEND_VERIFICATION = "1 per minute; 3 per hour"
     EMAIL_VERIFY = "10 per hour"
     PASSWORD_RESET_REQUEST = "3 per hour"

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -94,8 +94,10 @@ class Limits:
     DOMAIN_DELETE = "10 per minute"
     DOMAIN_WRITE = "30 per minute"
 
-    # Dashboard — profile pictures
+    # Dashboard — profile pictures. Uploads are tighter: each one is an
+    # R2 PUT on our dime.
     PROFILE_PICTURE_SET = "10 per minute"
+    PROFILE_PICTURE_UPLOAD = "5 per minute"
 
     # Contact / report
     CONTACT = "5 per minute; 20 per hour; 50 per day"

--- a/routes/auth/routes.py
+++ b/routes/auth/routes.py
@@ -9,6 +9,7 @@ POST /auth/register
 POST /auth/refresh
 POST /auth/logout
 GET  /auth/me
+PATCH /auth/me
 POST /auth/set-password
 """
 
@@ -24,6 +25,7 @@ from dependencies import (
     JwtConfig,
     JwtUser,
     PasswordSvc,
+    ProfilePictureSvc,
     UserRepo,
     fetch_user_profile,
 )
@@ -36,6 +38,7 @@ from schemas.dto.requests.auth import (
     LoginRequest,
     RegisterRequest,
     SetPasswordRequest,
+    UpdateProfileRequest,
 )
 from schemas.dto.responses.auth import (
     LoginResponse,
@@ -261,6 +264,37 @@ async def me(
     """
     profile = await fetch_user_profile(user_repo, ObjectId(str(user.user_id)))
     return MeResponse(user=UserProfileResponse.from_user(profile))
+
+
+@router.patch(
+    "/auth/me",
+    responses=ERROR_RESPONSES,
+    operation_id="updateCurrentUser",
+    summary="Update Current User",
+)
+@limiter.limit(Limits.PROFILE_UPDATE)
+async def update_me(
+    request: Request,
+    body: UpdateProfileRequest,
+    user: JwtUser,
+    profile_service: ProfilePictureSvc,
+) -> MeResponse:
+    """Update the authenticated user's profile.
+
+    Currently only ``user_name`` is editable. Registration makes the
+    display name write-once, so accounts that skipped it need this to
+    set one later. Send a string to set the name or ``null`` to clear it.
+
+    **Authentication**: Required (JWT only — API keys cannot rename the account)
+
+    **Rate Limits**: 10/min
+    """
+    # Same normalization as register: strip, whitespace-only → not set.
+    user_name = (body.user_name or "").strip() or None
+    updated = await profile_service.update_user_name(
+        ObjectId(str(user.user_id)), user_name
+    )
+    return MeResponse(user=UserProfileResponse.from_user(updated))
 
 
 @router.post(

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -23,8 +23,8 @@ from pydantic import BaseModel, Field
 from dependencies import (
     AppGrantRepo,
     AppRegistryDep,
-    AuthUser,
     CurrentUser,
+    JwtUser,
     OptionalUser,
     ProfilePictureSvc,
 )
@@ -265,7 +265,7 @@ class ProfilePictureMessageResponse(BaseModel):
 @limiter.limit(Limits.DASHBOARD_READ)
 async def get_profile_pictures(
     request: Request,
-    user: AuthUser,
+    user: JwtUser,
     svc: ProfilePictureSvc,
 ) -> AvailablePicturesResponse:
     pictures = await svc.get_available_pictures(user.user_id)
@@ -277,7 +277,7 @@ async def get_profile_pictures(
 async def set_profile_picture(
     request: Request,
     body: SetProfilePictureRequest,
-    user: AuthUser,
+    user: JwtUser,
     svc: ProfilePictureSvc,
 ) -> ProfilePictureMessageResponse:
     await svc.set_picture(user.user_id, body.picture_id)
@@ -289,7 +289,7 @@ async def set_profile_picture(
 async def upload_profile_picture(
     request: Request,
     body: UploadProfilePictureRequest,
-    user: AuthUser,
+    user: JwtUser,
     svc: ProfilePictureSvc,
 ) -> ProfilePictureMessageResponse:
     await svc.upload_picture(user.user_id, body.image)
@@ -300,7 +300,7 @@ async def upload_profile_picture(
 @limiter.limit(Limits.PROFILE_PICTURE_SET)
 async def unset_profile_picture(
     request: Request,
-    user: AuthUser,
+    user: JwtUser,
     svc: ProfilePictureSvc,
 ) -> ProfilePictureMessageResponse:
     await svc.unset_picture(user.user_id)

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -10,6 +10,8 @@ GET  /dashboard/billing     → billing page
 GET  /dashboard/apps          → connected apps + ecosystem
 GET  /dashboard/profile-pictures  → available pictures (JSON)
 POST /dashboard/profile-pictures  → set profile picture (JSON)
+POST /dashboard/profile-pictures/upload  → upload a custom picture (JSON)
+DELETE /dashboard/profile-pictures       → unset picture (JSON)
 """
 
 from __future__ import annotations
@@ -243,6 +245,14 @@ class SetProfilePictureRequest(BaseModel):
     picture_id: str = Field(min_length=1, max_length=200)
 
 
+class UploadProfilePictureRequest(BaseModel):
+    # Size/type gates run in the service against the configured cap
+    # (R2_UPLOAD_MAX_BYTES) — same posture as meta-tag image uploads.
+    image: str = Field(
+        min_length=1, description="base64 data URI (image/png, image/jpeg, image/webp)"
+    )
+
+
 class AvailablePicturesResponse(BaseModel):
     pictures: list[AvailablePicture]
 
@@ -272,3 +282,26 @@ async def set_profile_picture(
 ) -> ProfilePictureMessageResponse:
     await svc.set_picture(user.user_id, body.picture_id)
     return ProfilePictureMessageResponse(message="Profile picture updated successfully")
+
+
+@router.post("/profile-pictures/upload")
+@limiter.limit(Limits.PROFILE_PICTURE_UPLOAD)
+async def upload_profile_picture(
+    request: Request,
+    body: UploadProfilePictureRequest,
+    user: AuthUser,
+    svc: ProfilePictureSvc,
+) -> ProfilePictureMessageResponse:
+    await svc.upload_picture(user.user_id, body.image)
+    return ProfilePictureMessageResponse(message="Profile picture updated successfully")
+
+
+@router.delete("/profile-pictures")
+@limiter.limit(Limits.PROFILE_PICTURE_SET)
+async def unset_profile_picture(
+    request: Request,
+    user: AuthUser,
+    svc: ProfilePictureSvc,
+) -> ProfilePictureMessageResponse:
+    await svc.unset_picture(user.user_id)
+    return ProfilePictureMessageResponse(message="Profile picture removed")

--- a/schemas/dto/requests/auth.py
+++ b/schemas/dto/requests/auth.py
@@ -3,6 +3,7 @@ Request DTOs for authentication endpoints.
 
 LoginRequest                  — POST /auth/login
 RegisterRequest               — POST /auth/register
+UpdateProfileRequest          — PATCH /auth/me
 SetPasswordRequest            — POST /auth/set-password
 VerifyEmailRequest            — POST /auth/verify-email
 SendVerificationRequest       — POST /auth/send-verification  (no body)
@@ -51,6 +52,22 @@ class RegisterRequest(RequestBase):
         min_length=1,
         max_length=255,
         description="Display name (optional)",
+        examples=["Jane Doe"],
+    )
+
+
+class UpdateProfileRequest(RequestBase):
+    """Request body for PATCH /auth/me.
+
+    ``user_name`` is required but nullable: an explicit ``null`` clears
+    the display name (an accidental ``{}`` must not). Bounds mirror
+    RegisterRequest — the two write paths for the same field.
+    """
+
+    user_name: str | None = Field(
+        min_length=1,
+        max_length=255,
+        description="New display name, or null to clear it",
         examples=["Jane Doe"],
     )
 

--- a/schemas/dto/responses/auth.py
+++ b/schemas/dto/responses/auth.py
@@ -14,7 +14,7 @@ VerifyEmailResponse — POST /auth/verify-email  (200)
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field
 
@@ -51,8 +51,10 @@ class UserPfp(ResponseBase):
         description="Profile picture URL",
         examples=["https://lh3.googleusercontent.com/a/photo"],
     )
-    source: OAuthProvider | None = Field(
-        default=None, description="Source of the profile picture", examples=["google"]
+    source: OAuthProvider | Literal["upload"] | None = Field(
+        default=None,
+        description="Source of the profile picture — an OAuth provider or `upload`",
+        examples=["google"],
     )
 
 

--- a/schemas/models/user.py
+++ b/schemas/models/user.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -83,10 +84,14 @@ class AuthProviderEntry(BaseModel):
 
 
 class ProfilePicture(BaseModel):
-    """Embedded profile picture sub-document."""
+    """Embedded profile picture sub-document.
+
+    ``source`` is the OAuth provider the picture came from, or ``upload``
+    for a user-uploaded image (stored in R2).
+    """
 
     url: str
-    source: OAuthProvider
+    source: OAuthProvider | Literal["upload"]
     last_updated: datetime | None = None
 
 

--- a/services/image_ingest.py
+++ b/services/image_ingest.py
@@ -1,0 +1,83 @@
+"""Shared data-URI image ingestion primitives.
+
+Meta-tag og:images and profile-picture uploads accept the same payload
+(a base64 data URI) and must enforce the same abuse posture: a size cap,
+strict base64, and a magic-byte match against the declared MIME type.
+This module owns those gates plus the owner-scoped storage-key prefix;
+callers own the surrounding flow (https passthrough, storage-key layout,
+error fields).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from errors import ValidationError
+from shared.image_sniff import MIME, ImageInfo, sniff_image
+
+if TYPE_CHECKING:
+    from bson import ObjectId
+
+_DATA_URI_RE = re.compile(
+    r"^data:image/(?P<fmt>png|jpeg|webp);base64,(?P<b64>[A-Za-z0-9+/=]+)$"
+)
+
+
+@dataclass(frozen=True)
+class DecodedImage:
+    data: bytes
+    content_type: str  # declared MIME, verified against the magic bytes
+    info: ImageInfo
+
+
+def split_image_data_uri(value: str) -> tuple[str, str] | None:
+    """Return ``(fmt, b64)`` when ``value`` is a supported image data URI."""
+    m = _DATA_URI_RE.match(value)
+    if m is None:
+        return None
+    return m["fmt"], m["b64"]
+
+
+def decode_image_data_uri(
+    fmt: str, b64: str, *, max_bytes: int, field: str
+) -> DecodedImage:
+    """Decode and validate a data-URI payload; raises ValidationError."""
+    if len(b64) > (max_bytes * 4) // 3 + 4:  # cheap pre-decode gate
+        raise ValidationError(f"image exceeds {max_bytes} bytes", field=field)
+    try:
+        data = base64.b64decode(b64, validate=True)
+    except binascii.Error:
+        raise ValidationError(
+            "image data URI is not valid base64", field=field
+        ) from None
+    if len(data) > max_bytes:
+        raise ValidationError(f"image exceeds {max_bytes} bytes", field=field)
+
+    info = sniff_image(data)
+    declared_mime = f"image/{fmt}"
+    if info is None or MIME[info.format] != declared_mime:
+        # Magic bytes are the security gate — the declared type must match
+        # what the bytes actually are.
+        raise ValidationError(
+            "image bytes do not match the declared image type",
+            field=field,
+        )
+    return DecodedImage(data=data, content_type=declared_mime, info=info)
+
+
+def owner_key_prefix(owner_id: ObjectId, secret: str) -> str:
+    """Non-reversible per-owner path segment for storage keys.
+
+    A raw ObjectId in a public URL leaks the account's creation time and
+    lets anyone correlate a user's links; the HMAC keeps per-owner sweeps
+    and dedup without exposing it. Rotating SECRET_KEY re-keys future
+    uploads (old sweeps need the old secret).
+    """
+    digest = hmac.new(secret.encode(), str(owner_id).encode(), hashlib.sha256)
+    return digest.hexdigest()[:16]

--- a/services/meta_tags/images.py
+++ b/services/meta_tags/images.py
@@ -6,22 +6,26 @@ decoded, magic-byte validated, and uploaded to R2. Self-hosting the bytes
 is the abuse control: we can scan and take down what we host, and a
 hosted image can't be swapped after validation (the TOCTOU hole external
 URLs have).
+
+The decode/validation gates live in services.image_ingest — shared with
+profile-picture uploads so both surfaces enforce the same posture.
 """
 
 from __future__ import annotations
 
-import base64
-import binascii
 import hashlib
-import hmac
-import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from errors import ValidationError
 from infrastructure.logging import get_logger
-from shared.image_sniff import EXT, MIME, sniff_image
+from services.image_ingest import (
+    decode_image_data_uri,
+    owner_key_prefix,
+    split_image_data_uri,
+)
+from shared.image_sniff import EXT
 
 if TYPE_CHECKING:
     from bson import ObjectId
@@ -30,28 +34,12 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
-_DATA_URI_RE = re.compile(
-    r"^data:image/(?P<fmt>png|jpeg|webp);base64,(?P<b64>[A-Za-z0-9+/=]+)$"
-)
-
 
 @dataclass(frozen=True)
 class IngestedImage:
     url: str  # what gets stored in meta_tags.image
     r2_hosted: bool  # True ⇒ validated synchronously here, skip the async job
     image_meta: dict | None  # {width,height,bytes,content_type,checked_at} | None
-
-
-def owner_key_prefix(owner_id: ObjectId, secret: str) -> str:
-    """Non-reversible per-owner path segment for storage keys.
-
-    A raw ObjectId in a public URL leaks the account's creation time and
-    lets anyone correlate a user's links; the HMAC keeps per-owner sweeps
-    and dedup without exposing it. Rotating SECRET_KEY re-keys future
-    uploads (old sweeps need the old secret).
-    """
-    digest = hmac.new(secret.encode(), str(owner_id).encode(), hashlib.sha256)
-    return digest.hexdigest()[:16]
 
 
 async def ingest_meta_image(
@@ -66,8 +54,8 @@ async def ingest_meta_image(
     if value.startswith("https://"):
         return IngestedImage(url=value, r2_hosted=False, image_meta=None)
 
-    m = _DATA_URI_RE.match(value)
-    if m is None:
+    parts = split_image_data_uri(value)
+    if parts is None:
         raise ValidationError(
             "image must be an https URL or a base64 data URI "
             "(image/png, image/jpeg, image/webp)",
@@ -80,51 +68,32 @@ async def ingest_meta_image(
             "host the image yourself and pass an https URL",
             field="meta_tags.image",
         )
-    if len(m["b64"]) > (max_bytes * 4) // 3 + 4:  # cheap pre-decode gate
-        raise ValidationError(
-            f"image exceeds {max_bytes} bytes", field="meta_tags.image"
-        )
-    try:
-        data = base64.b64decode(m["b64"], validate=True)
-    except binascii.Error:
-        raise ValidationError(
-            "image data URI is not valid base64", field="meta_tags.image"
-        ) from None
-    if len(data) > max_bytes:
-        raise ValidationError(
-            f"image exceeds {max_bytes} bytes", field="meta_tags.image"
-        )
-
-    info = sniff_image(data)
-    declared_mime = f"image/{m['fmt']}"
-    if info is None or MIME[info.format] != declared_mime:
-        # Magic bytes are the security gate — the declared type must match
-        # what the bytes actually are.
-        raise ValidationError(
-            "image bytes do not match the declared image type",
-            field="meta_tags.image",
-        )
+    fmt, b64 = parts
+    decoded = decode_image_data_uri(
+        fmt, b64, max_bytes=max_bytes, field="meta_tags.image"
+    )
 
     # Content-addressed + owner-scoped: idempotent re-uploads dedupe, and
     # abuse takedowns can prefix-sweep og/{prefix}/. Old objects are not
     # deleted on replace (orphan GC is future work; orphans are pennies).
     prefix = owner_key_prefix(owner_id, key_secret)
-    key = f"og/{prefix}/{hashlib.sha256(data).hexdigest()}.{EXT[info.format]}"
-    url = await storage.put_object(key, data, content_type=declared_mime)
+    digest = hashlib.sha256(decoded.data).hexdigest()
+    key = f"og/{prefix}/{digest}.{EXT[decoded.info.format]}"
+    url = await storage.put_object(key, decoded.data, content_type=decoded.content_type)
     log.info(
         "meta_image_uploaded",
         owner_id=str(owner_id),
-        bytes=len(data),
-        format=info.format,
+        bytes=len(decoded.data),
+        format=decoded.info.format,
     )
     return IngestedImage(
         url=url,
         r2_hosted=True,
         image_meta={
-            "width": info.width,
-            "height": info.height,
-            "bytes": len(data),
-            "content_type": declared_mime,
+            "width": decoded.info.width,
+            "height": decoded.info.height,
+            "bytes": len(decoded.data),
+            "content_type": decoded.content_type,
             "checked_at": datetime.now(timezone.utc),
         },
     )

--- a/services/profile_picture_service.py
+++ b/services/profile_picture_service.py
@@ -1,5 +1,6 @@
 """
-ProfilePictureService — dashboard profile and profile picture management.
+ProfilePictureService — dashboard profile, display name, and profile
+picture management.
 
 Extracts user profile building and profile picture logic from the route layer.
 """
@@ -14,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from errors import NotFoundError
 from infrastructure.logging import get_logger
 from repositories.user_repository import UserRepository
-from schemas.models.user import OAuthProvider, ProfilePicture
+from schemas.models.user import OAuthProvider, ProfilePicture, UserDoc
 
 log = get_logger(__name__)
 
@@ -65,6 +66,26 @@ class ProfilePictureService:
             profile["pfp"] = {"url": user_doc.pfp.url, "source": user_doc.pfp.source}
 
         return profile
+
+    async def update_user_name(
+        self, user_id: ObjectId, user_name: str | None
+    ) -> UserDoc:
+        """Set (or clear, with None) the user's display name.
+
+        Returns the updated user document for the profile response.
+        Raises NotFoundError if the user is not found.
+        """
+        user_doc = await self._user_repo.find_by_id(user_id)
+        if not user_doc:
+            raise NotFoundError("User not found")
+
+        await self._user_repo.update(user_id, {"$set": {"user_name": user_name}})
+        log.info(
+            "user_name_updated",
+            user_id=str(user_id),
+            cleared=user_name is None,
+        )
+        return user_doc.model_copy(update={"user_name": user_name})
 
     async def get_available_pictures(self, user_id: ObjectId) -> list[AvailablePicture]:
         """Return profile pictures available from connected OAuth providers.

--- a/services/profile_picture_service.py
+++ b/services/profile_picture_service.py
@@ -2,20 +2,34 @@
 ProfilePictureService — dashboard profile, display name, and profile
 picture management.
 
-Extracts user profile building and profile picture logic from the route layer.
+Extracts user profile building and profile picture logic from the route
+layer. Uploaded pictures ride the same R2 plumbing (and the same abuse
+posture — size cap, strict base64, magic-byte MIME match) as meta-tag
+og:images; see services.image_ingest.
 """
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from bson import ObjectId
 from pydantic import BaseModel, ConfigDict, Field
 
-from errors import NotFoundError
+from errors import NotFoundError, ValidationError
 from infrastructure.logging import get_logger
 from repositories.user_repository import UserRepository
 from schemas.models.user import OAuthProvider, ProfilePicture, UserDoc
+from services.image_ingest import (
+    decode_image_data_uri,
+    owner_key_prefix,
+    split_image_data_uri,
+)
+from shared.image_sniff import EXT
+
+if TYPE_CHECKING:
+    from infrastructure.storage.r2 import R2StorageClient
 
 log = get_logger(__name__)
 
@@ -32,8 +46,18 @@ class AvailablePicture(BaseModel):
 
 
 class ProfilePictureService:
-    def __init__(self, user_repo: UserRepository) -> None:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        *,
+        r2_storage: R2StorageClient | None = None,
+        upload_max_bytes: int = 512_000,
+        key_secret: str = "",
+    ) -> None:
         self._user_repo = user_repo
+        self._r2_storage = r2_storage
+        self._upload_max_bytes = upload_max_bytes
+        self._key_secret = key_secret
 
     async def get_dashboard_profile(self, user_id: ObjectId) -> dict | None:
         """Fetch a minimal user profile for dashboard template rendering.
@@ -143,3 +167,66 @@ class ProfilePictureService:
                     return
 
         raise NotFoundError("Picture not found")
+
+    async def upload_picture(self, user_id: ObjectId, image: str) -> None:
+        """Set the profile picture from an uploaded base64 data URI.
+
+        Same gates as meta-tag og:image uploads (decode_image_data_uri),
+        stored content-addressed under profile-pictures/{owner-prefix}/.
+        Raises NotFoundError if the user is not found, ValidationError on
+        a bad payload or when R2 is not configured.
+        """
+        user_doc = await self._user_repo.find_by_id(user_id)
+        if not user_doc:
+            raise NotFoundError("User not found")
+
+        parts = split_image_data_uri(image)
+        if parts is None:
+            raise ValidationError(
+                "image must be a base64 data URI (image/png, image/jpeg, image/webp)",
+                field="image",
+            )
+        if self._r2_storage is None or not self._r2_storage.is_configured:
+            raise ValidationError(
+                "Image upload is not available on this deployment",
+                field="image",
+            )
+        fmt, b64 = parts
+        decoded = decode_image_data_uri(
+            fmt, b64, max_bytes=self._upload_max_bytes, field="image"
+        )
+
+        # Content-addressed + owner-scoped, mirroring og/ keys: re-uploads
+        # dedupe, takedowns can prefix-sweep profile-pictures/{prefix}/.
+        # Replaced objects are not deleted (same orphan-GC stance as og/).
+        prefix = owner_key_prefix(user_id, self._key_secret)
+        digest = hashlib.sha256(decoded.data).hexdigest()
+        key = f"profile-pictures/{prefix}/{digest}.{EXT[decoded.info.format]}"
+        url = await self._r2_storage.put_object(
+            key, decoded.data, content_type=decoded.content_type
+        )
+
+        pfp = ProfilePicture(
+            url=url,
+            source="upload",
+            last_updated=datetime.now(timezone.utc),
+        )
+        await self._user_repo.update(user_id, {"$set": {"pfp": pfp.model_dump()}})
+        log.info(
+            "profile_picture_uploaded",
+            user_id=str(user_id),
+            bytes=len(decoded.data),
+            format=decoded.info.format,
+        )
+
+    async def unset_picture(self, user_id: ObjectId) -> None:
+        """Clear the profile picture back to none (initials avatar).
+
+        Idempotent. Raises NotFoundError if the user is not found.
+        """
+        user_doc = await self._user_repo.find_by_id(user_id)
+        if not user_doc:
+            raise NotFoundError("User not found")
+
+        await self._user_repo.update(user_id, {"$set": {"pfp": None}})
+        log.info("profile_picture_unset", user_id=str(user_id))

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -27,6 +27,7 @@ from dependencies import (
     get_credential_service,
     get_oauth_service,
     get_password_service,
+    get_profile_picture_service,
     get_user_repo,
     get_verification_service,
     require_auth,
@@ -300,6 +301,102 @@ def test_me_requires_auth():
     with TestClient(app, raise_server_exceptions=False) as client:
         resp = client.get("/auth/me")
     assert resp.status_code == 401
+
+
+# ── Update profile (PATCH /auth/me) ───────────────────────────────────────────
+
+
+def _update_me_app(mock_svc, mock_user):
+    return build_test_app(
+        auth_router,
+        oauth_router,
+        overrides={
+            get_profile_picture_service: lambda: mock_svc,
+            require_auth: lambda: mock_user,
+        },
+    )
+
+
+def test_update_me_sets_user_name_and_strips():
+    user_oid = ObjectId()
+    updated = _make_user_doc(user_id=user_oid).model_copy(
+        update={"user_name": "Jane Doe"}
+    )
+    mock_svc = AsyncMock()
+    mock_svc.update_user_name.return_value = updated
+    mock_user = CurrentUser(user_id=user_oid, email_verified=True)
+
+    app = _update_me_app(mock_svc, mock_user)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={"user_name": "  Jane Doe  "})
+    assert resp.status_code == 200
+    assert resp.json()["user"]["user_name"] == "Jane Doe"
+    mock_svc.update_user_name.assert_awaited_once_with(user_oid, "Jane Doe")
+
+
+def test_update_me_null_clears_user_name():
+    user_oid = ObjectId()
+    updated = _make_user_doc(user_id=user_oid).model_copy(update={"user_name": None})
+    mock_svc = AsyncMock()
+    mock_svc.update_user_name.return_value = updated
+    mock_user = CurrentUser(user_id=user_oid, email_verified=True)
+
+    app = _update_me_app(mock_svc, mock_user)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={"user_name": None})
+    assert resp.status_code == 200
+    assert resp.json()["user"]["user_name"] is None
+    mock_svc.update_user_name.assert_awaited_once_with(user_oid, None)
+
+
+def test_update_me_whitespace_only_normalizes_to_none():
+    user_oid = ObjectId()
+    updated = _make_user_doc(user_id=user_oid).model_copy(update={"user_name": None})
+    mock_svc = AsyncMock()
+    mock_svc.update_user_name.return_value = updated
+    mock_user = CurrentUser(user_id=user_oid, email_verified=True)
+
+    app = _update_me_app(mock_svc, mock_user)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={"user_name": "   "})
+    assert resp.status_code == 200
+    mock_svc.update_user_name.assert_awaited_once_with(user_oid, None)
+
+
+def test_update_me_missing_field_returns_422():
+    mock_user = CurrentUser(user_id=ObjectId(), email_verified=True)
+    app = _update_me_app(AsyncMock(), mock_user)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={})
+    assert resp.status_code == 422
+
+
+def test_update_me_too_long_returns_422():
+    mock_user = CurrentUser(user_id=ObjectId(), email_verified=True)
+    app = _update_me_app(AsyncMock(), mock_user)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={"user_name": "x" * 256})
+    assert resp.status_code == 422
+
+
+def test_update_me_requires_auth():
+    app = build_test_app(auth_router, oauth_router, overrides={})
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={"user_name": "Jane"})
+    assert resp.status_code == 401
+
+
+def test_update_me_rejects_api_key_auth():
+    """An API key must not be able to rename the account — JWT only."""
+    mock_svc = AsyncMock()
+    mock_user = CurrentUser(
+        user_id=ObjectId(), email_verified=True, api_key_doc=MagicMock()
+    )
+    app = _update_me_app(mock_svc, mock_user)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.patch("/auth/me", json={"user_name": "Jane"})
+    assert resp.status_code == 403
+    mock_svc.update_user_name.assert_not_awaited()
 
 
 # ── Set password ──────────────────────────────────────────────────────────────

--- a/tests/integration/test_dashboard_routes.py
+++ b/tests/integration/test_dashboard_routes.py
@@ -291,9 +291,7 @@ def test_profile_picture_endpoints_reject_api_key_auth():
     with TestClient(app, raise_server_exceptions=False) as c:
         assert c.get("/dashboard/profile-pictures").status_code == 403
         assert (
-            c.post(
-                "/dashboard/profile-pictures", json={"picture_id": "x"}
-            ).status_code
+            c.post("/dashboard/profile-pictures", json={"picture_id": "x"}).status_code
             == 403
         )
         assert (

--- a/tests/integration/test_dashboard_routes.py
+++ b/tests/integration/test_dashboard_routes.py
@@ -279,3 +279,30 @@ def test_profile_picture_delete_returns_success():
     assert resp.status_code == 200
     assert resp.json()["message"] == "Profile picture removed"
     svc.unset_picture.assert_called_once_with(_TEST_USER.user_id)
+
+
+def test_profile_picture_endpoints_reject_api_key_auth():
+    """The whole account-profile surface is JWT-only, matching PATCH /auth/me."""
+    svc = _mock_svc()
+    api_key_user = CurrentUser(
+        user_id=ObjectId(), email_verified=True, api_key_doc=MagicMock()
+    )
+    app = _build_test_app(user=api_key_user, svc=svc)
+    with TestClient(app, raise_server_exceptions=False) as c:
+        assert c.get("/dashboard/profile-pictures").status_code == 403
+        assert (
+            c.post(
+                "/dashboard/profile-pictures", json={"picture_id": "x"}
+            ).status_code
+            == 403
+        )
+        assert (
+            c.post(
+                "/dashboard/profile-pictures/upload", json={"image": "data:;base64,x"}
+            ).status_code
+            == 403
+        )
+        assert c.delete("/dashboard/profile-pictures").status_code == 403
+    svc.set_picture.assert_not_called()
+    svc.upload_picture.assert_not_called()
+    svc.unset_picture.assert_not_called()

--- a/tests/integration/test_dashboard_routes.py
+++ b/tests/integration/test_dashboard_routes.py
@@ -22,7 +22,7 @@ from dependencies import (
     get_current_user,
     get_profile_picture_service,
 )
-from errors import NotFoundError
+from errors import NotFoundError, ValidationError
 from middleware.error_handler import register_error_handlers
 from middleware.rate_limiter import limiter
 from routes.dashboard_routes import router as dashboard_router
@@ -50,6 +50,8 @@ def _mock_svc(profile=None, pictures=None):
     svc.get_dashboard_profile = AsyncMock(return_value=profile or _PROFILE)
     svc.get_available_pictures = AsyncMock(return_value=pictures or [])
     svc.set_picture = AsyncMock()
+    svc.upload_picture = AsyncMock()
+    svc.unset_picture = AsyncMock()
     return svc
 
 
@@ -207,3 +209,73 @@ def test_profile_pictures_post_invalid_id_returns_404():
     with TestClient(app) as c:
         resp = c.post("/dashboard/profile-pictures", json={"picture_id": "bad_id"})
     assert resp.status_code == 404
+
+
+# ── Profile picture upload ───────────────────────────────────────────────────
+
+
+def test_profile_picture_upload_unauth_returns_401():
+    app = _build_test_app(user=None)
+    with TestClient(app) as c:
+        resp = c.post(
+            "/dashboard/profile-pictures/upload",
+            json={"image": "data:image/png;base64,aGk="},
+        )
+    assert resp.status_code == 401
+
+
+def test_profile_picture_upload_missing_image_returns_422():
+    app = _build_test_app(user=_TEST_USER)
+    with TestClient(app) as c:
+        resp = c.post("/dashboard/profile-pictures/upload", json={})
+    assert resp.status_code == 422
+
+
+def test_profile_picture_upload_valid_returns_success():
+    svc = _mock_svc()
+    app = _build_test_app(user=_TEST_USER, svc=svc)
+    with TestClient(app) as c:
+        resp = c.post(
+            "/dashboard/profile-pictures/upload",
+            json={"image": "data:image/png;base64,aGk="},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Profile picture updated successfully"
+    svc.upload_picture.assert_called_once()
+
+
+def test_profile_picture_upload_invalid_image_returns_400():
+    svc = _mock_svc()
+    svc.upload_picture = AsyncMock(
+        side_effect=ValidationError(
+            "image bytes do not match the declared image type", field="image"
+        )
+    )
+    app = _build_test_app(user=_TEST_USER, svc=svc)
+    with TestClient(app) as c:
+        resp = c.post(
+            "/dashboard/profile-pictures/upload",
+            json={"image": "data:image/png;base64,aGk="},
+        )
+    assert resp.status_code == 400
+    assert resp.json()["field"] == "image"
+
+
+# ── Profile picture unset ────────────────────────────────────────────────────
+
+
+def test_profile_picture_delete_unauth_returns_401():
+    app = _build_test_app(user=None)
+    with TestClient(app) as c:
+        resp = c.delete("/dashboard/profile-pictures")
+    assert resp.status_code == 401
+
+
+def test_profile_picture_delete_returns_success():
+    svc = _mock_svc()
+    app = _build_test_app(user=_TEST_USER, svc=svc)
+    with TestClient(app) as c:
+        resp = c.delete("/dashboard/profile-pictures")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Profile picture removed"
+    svc.unset_picture.assert_called_once_with(_TEST_USER.user_id)

--- a/tests/unit/services/test_profile_picture_service.py
+++ b/tests/unit/services/test_profile_picture_service.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import base64
 import os
+import struct
+import zlib
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,7 +15,7 @@ os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 
 from bson import ObjectId
 
-from errors import NotFoundError
+from errors import NotFoundError, ValidationError
 from services.profile_picture_service import ProfilePictureService
 
 
@@ -45,11 +48,35 @@ def _make_user_doc(pfp_url=None, providers=None):
     return doc
 
 
-def _make_service(user_doc=None):
+def _make_service(user_doc=None, storage=None):
     repo = MagicMock()
     repo.find_by_id = AsyncMock(return_value=user_doc)
     repo.update = AsyncMock()
-    return ProfilePictureService(repo), repo
+    return ProfilePictureService(repo, r2_storage=storage), repo
+
+
+def _png_bytes(width=3, height=2) -> bytes:
+    ihdr = struct.pack(">II", width, height) + b"\x08\x06\x00\x00\x00"
+    chunk = (
+        struct.pack(">I", 13)
+        + b"IHDR"
+        + ihdr
+        + struct.pack(">I", zlib.crc32(b"IHDR" + ihdr))
+    )
+    return b"\x89PNG\r\n\x1a\n" + chunk
+
+
+def _data_uri(data: bytes, mime="image/png") -> str:
+    return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+
+def _storage(configured=True) -> MagicMock:
+    s = MagicMock()
+    s.is_configured = configured
+    s.put_object = AsyncMock(
+        return_value="https://og.spoo.me/profile-pictures/x/abc.png"
+    )
+    return s
 
 
 # ── get_dashboard_profile ────────────────────────────────────────────────────
@@ -171,7 +198,7 @@ async def test_set_picture_rejects_arbitrary_url():
     repo.update.assert_not_called()
 
 
-# ── update_user_name ─────────────────────────────────────────────────────────────
+# ── update_user_name ─────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -196,3 +223,92 @@ async def test_update_user_name_user_not_found_raises():
     with pytest.raises(NotFoundError, match="User not found"):
         await svc.update_user_name(ObjectId(), "Jane Doe")
     repo.update.assert_not_called()
+
+
+# ── upload_picture ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upload_picture_stores_r2_url_with_upload_source():
+    user = _make_user_doc()
+    storage = _storage()
+    svc, repo = _make_service(user, storage=storage)
+    await svc.upload_picture(user.id, _data_uri(_png_bytes()))
+    storage.put_object.assert_awaited_once()
+    key = storage.put_object.call_args[0][0]
+    assert key.startswith("profile-pictures/")
+    assert key.endswith(".png")
+    pfp = repo.update.call_args[0][1]["$set"]["pfp"]
+    assert pfp["url"] == "https://og.spoo.me/profile-pictures/x/abc.png"
+    assert pfp["source"] == "upload"
+
+
+@pytest.mark.asyncio
+async def test_upload_picture_rejects_non_data_uri():
+    user = _make_user_doc()
+    svc, repo = _make_service(user, storage=_storage())
+    with pytest.raises(ValidationError, match="data URI"):
+        await svc.upload_picture(user.id, "https://example.com/pic.png")
+    repo.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_picture_rejects_mime_mismatch():
+    # Declared jpeg, bytes are PNG — the security gate.
+    user = _make_user_doc()
+    svc, repo = _make_service(user, storage=_storage())
+    with pytest.raises(ValidationError, match="do not match"):
+        await svc.upload_picture(user.id, _data_uri(_png_bytes(), mime="image/jpeg"))
+    repo.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_picture_rejects_oversized():
+    user = _make_user_doc()
+    svc, repo = _make_service(user, storage=_storage())
+    big = _data_uri(b"\x89PNG\r\n\x1a\n" + b"0" * 600_000)
+    with pytest.raises(ValidationError, match="exceeds"):
+        await svc.upload_picture(user.id, big)
+    repo.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_picture_storage_unconfigured_raises():
+    user = _make_user_doc()
+    svc, repo = _make_service(user, storage=None)
+    with pytest.raises(ValidationError, match="not available"):
+        await svc.upload_picture(user.id, _data_uri(_png_bytes()))
+    repo.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_picture_user_not_found_raises():
+    svc, _ = _make_service(None, storage=_storage())
+    with pytest.raises(NotFoundError, match="User not found"):
+        await svc.upload_picture(ObjectId(), _data_uri(_png_bytes()))
+
+
+# ── unset_picture ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unset_picture_clears_pfp():
+    user = _make_user_doc(pfp_url="https://img.example.com/pic.jpg")
+    svc, repo = _make_service(user)
+    await svc.unset_picture(user.id)
+    repo.update.assert_called_once_with(user.id, {"$set": {"pfp": None}})
+
+
+@pytest.mark.asyncio
+async def test_unset_picture_idempotent_when_no_pfp():
+    user = _make_user_doc()
+    svc, repo = _make_service(user)
+    await svc.unset_picture(user.id)
+    repo.update.assert_called_once_with(user.id, {"$set": {"pfp": None}})
+
+
+@pytest.mark.asyncio
+async def test_unset_picture_user_not_found_raises():
+    svc, _ = _make_service(None)
+    with pytest.raises(NotFoundError, match="User not found"):
+        await svc.unset_picture(ObjectId())

--- a/tests/unit/services/test_profile_picture_service.py
+++ b/tests/unit/services/test_profile_picture_service.py
@@ -169,3 +169,30 @@ async def test_set_picture_rejects_arbitrary_url():
     with pytest.raises(NotFoundError):
         await svc.set_picture(user.id, "evil_attacker_id")
     repo.update.assert_not_called()
+
+
+# ── update_user_name ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_user_name_sets_name():
+    user = _make_user_doc()
+    svc, repo = _make_service(user)
+    await svc.update_user_name(user.id, "Jane Doe")
+    repo.update.assert_called_once_with(user.id, {"$set": {"user_name": "Jane Doe"}})
+
+
+@pytest.mark.asyncio
+async def test_update_user_name_clears_with_none():
+    user = _make_user_doc()
+    svc, repo = _make_service(user)
+    await svc.update_user_name(user.id, None)
+    repo.update.assert_called_once_with(user.id, {"$set": {"user_name": None}})
+
+
+@pytest.mark.asyncio
+async def test_update_user_name_user_not_found_raises():
+    svc, repo = _make_service(None)
+    with pytest.raises(NotFoundError, match="User not found"):
+        await svc.update_user_name(ObjectId(), "Jane Doe")
+    repo.update.assert_not_called()


### PR DESCRIPTION
Two small account-profile features: post-registration display name editing and custom profile picture upload with unset.

## Endpoints

### PATCH /auth/me

```
PATCH /auth/me
{"user_name": "Jane Doe"}     -> 200 {"user": {...UserProfileResponse, "user_name": "Jane Doe"}}
{"user_name": null}           -> 200, clears the name
{}                            -> 422 (field required; an accidental empty PATCH must not clear)
{"user_name": "x" * 256}      -> 422
```

Returns the same `MeResponse` shape as `GET /auth/me`, so the frontend can write it straight into the session cache. Normalization mirrors register exactly: strip, whitespace-only becomes null. Bounds mirror `RegisterRequest` (1..255) since these are the two write paths for the same field.

Gating: `JwtUser` (same `require_jwt` dependency keys.py uses), so an API key cannot rename the account. Rate limit 10/min (`PROFILE_UPDATE`).

### POST /dashboard/profile-pictures/upload

```
POST /dashboard/profile-pictures/upload
{"image": "data:image/png;base64,..."}   -> 200 {"message": "Profile picture updated successfully"}
bad type / oversized / bad base64        -> 400 {"error": ..., "code": "validation_error", "field": "image"}
R2 not configured (self-host)            -> 400 with a clear message
```

### DELETE /dashboard/profile-pictures

```
DELETE /dashboard/profile-pictures       -> 200 {"message": "Profile picture removed"}
```

Idempotent; sets `pfp` back to null so the initials avatar takes over. Both live next to the existing GET/POST `/dashboard/profile-pictures` pair with the same auth (`AuthUser`) and the same message response shape, so the Next settings page AvatarRow extends without new conventions.

## R2 reuse

The upload path reuses the meta-tags (PR #231) plumbing wholesale. The data-URI decode, base64 pre-decode gate, decoded size cap (`R2_UPLOAD_MAX_BYTES`, default 512KB), and magic-byte MIME match were extracted from `services/meta_tags/images.py` into `services/image_ingest.py` (pure move, no behavior change; the og ingest tests pass unchanged). Objects are stored content-addressed under `profile-pictures/{hmac-owner-prefix}/{sha256}.{ext}` mirroring the `og/` layout, via the same `R2StorageClient.put_object` (immutable cache headers, inline disposition, nosniff). Takedowns can prefix-sweep `profile-pictures/{prefix}/` the same way as `og/`; replaced objects are not deleted (same orphan-GC stance).

`pfp.source` gains an `upload` variant (`OAuthProvider | Literal["upload"]`) rather than widening the OAuth enum, which is also used to validate provider path params.

## Abuse posture note

Meta-tag images run two write-time checks: the ingest gates above, plus a blocklist regex scan over the user-supplied title/description/image URL text. Profile pictures get the identical ingest gates. The blocklist scan does not apply here because there is no user-supplied text or URL: the only stored value is the R2 URL we minted. No moderation step was invented beyond what the meta-tags path runs; if image-content scanning lands for og uploads later, both paths now share one ingest module to hang it on.

## Tests

- `tests/unit/services/test_profile_picture_service.py`: update_user_name set/clear/not-found; upload with real PNG bytes through the actual decode path (stores R2 URL with `source: "upload"`, key under `profile-pictures/`), rejects non-data-URI, MIME mismatch, oversized, unconfigured storage, unknown user; unset clears and is idempotent.
- `tests/integration/test_auth_routes.py`: PATCH /auth/me sets and strips, null clears, whitespace normalizes to null, 422 on missing/overlong, 401 unauthenticated, 403 via API key.
- `tests/integration/test_dashboard_routes.py`: upload 401/422/200/400(+field echo), delete 401/200.
- Full suite: 2224 passed. `ruff check` and `ruff format --check` clean.

## Merge safety

Additive only: no existing endpoint, response shape, or stored document changes. `ProfilePictureService` gains keyword-only constructor args with defaults (unconfigured R2 keeps the old constructor behavior; upload then 400s with a clear message, matching the meta-tags self-host degradation contract). The meta-tags refactor is a pure extraction with its existing tests green. Existing `pfp` documents deserialize unchanged; the `source` union only widens. Nothing here is gated by a flag because both surfaces are dark until the frontend wires them.

