### PR TITLE
refactor: move profile picture endpoints to /api/v1/me

### DIFF
--- a/routes/api_v1/me.py
+++ b/routes/api_v1/me.py
@@ -3,6 +3,10 @@ GET    /api/v1/me/features       — per-account feature availability
 GET    /api/v1/me/layouts/{page} — fetch the saved dashboard layout (null = default)
 PUT    /api/v1/me/layouts/{page} — save the layout document verbatim
 DELETE /api/v1/me/layouts/{page} — reset to default (idempotent)
+GET    /api/v1/me/profile-pictures        — available pictures
+POST   /api/v1/me/profile-pictures        — set a provider picture by id
+POST   /api/v1/me/profile-pictures/upload — upload a custom picture (data URI)
+DELETE /api/v1/me/profile-pictures        — unset the picture
 
 Per-user preferences namespace. Layout documents are client-owned JSON blobs:
 the frontend versions and validates them, the server stores them opaquely
@@ -16,12 +20,20 @@ from typing import Annotated, Literal
 
 from fastapi import APIRouter, Path, Request
 
-from dependencies import FeatureFlagSvc, JwtUser, PageLayoutSvc
+from dependencies import FeatureFlagSvc, JwtUser, PageLayoutSvc, ProfilePictureSvc
 from middleware.openapi import AUTH_RESPONSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.dto.requests.layouts import PutLayoutRequest
+from schemas.dto.requests.profile_pictures import (
+    SetProfilePictureRequest,
+    UploadProfilePictureRequest,
+)
 from schemas.dto.responses.features import FeaturesResponse
 from schemas.dto.responses.layouts import LayoutResponse
+from schemas.dto.responses.profile_pictures import (
+    AvailablePicturesResponse,
+    ProfilePictureMessageResponse,
+)
 
 router = APIRouter(prefix="/me", tags=["Me"])
 
@@ -130,3 +142,96 @@ async def delete_page_layout(
     **Authentication**: Required.
     """
     await layout_service.delete_layout(user.user_id, page)
+
+
+@router.get(
+    "/profile-pictures",
+    responses=AUTH_RESPONSES,
+    operation_id="getMyProfilePictures",
+    summary="Get Available Profile Pictures",
+)
+@limiter.limit(Limits.DASHBOARD_READ)
+async def get_profile_pictures(
+    request: Request,
+    user: JwtUser,
+    svc: ProfilePictureSvc,
+) -> AvailablePicturesResponse:
+    """List the profile pictures available to this account.
+
+    One entry per linked OAuth provider picture, with `is_current` marking
+    the active one.
+
+    **Authentication**: Required.
+    """
+    pictures = await svc.get_available_pictures(user.user_id)
+    return AvailablePicturesResponse(pictures=pictures)
+
+
+@router.post(
+    "/profile-pictures",
+    responses=AUTH_RESPONSES,
+    operation_id="setMyProfilePicture",
+    summary="Set Profile Picture",
+)
+@limiter.limit(Limits.PROFILE_PICTURE_SET)
+async def set_profile_picture(
+    request: Request,
+    body: SetProfilePictureRequest,
+    user: JwtUser,
+    svc: ProfilePictureSvc,
+) -> ProfilePictureMessageResponse:
+    """Set the profile picture to one of the available provider pictures.
+
+    `picture_id` must be an id returned by the GET endpoint; unknown ids
+    yield 404.
+
+    **Authentication**: Required.
+    """
+    await svc.set_picture(user.user_id, body.picture_id)
+    return ProfilePictureMessageResponse(message="Profile picture updated successfully")
+
+
+@router.post(
+    "/profile-pictures/upload",
+    responses=AUTH_RESPONSES,
+    operation_id="uploadMyProfilePicture",
+    summary="Upload Profile Picture",
+)
+@limiter.limit(Limits.PROFILE_PICTURE_UPLOAD)
+async def upload_profile_picture(
+    request: Request,
+    body: UploadProfilePictureRequest,
+    user: JwtUser,
+    svc: ProfilePictureSvc,
+) -> ProfilePictureMessageResponse:
+    """Upload a custom profile picture as a base64 data URI.
+
+    Accepts image/png, image/jpeg and image/webp; size and content-type
+    validation happens server-side against the configured upload cap.
+
+    **Authentication**: Required.
+    """
+    await svc.upload_picture(user.user_id, body.image)
+    return ProfilePictureMessageResponse(message="Profile picture updated successfully")
+
+
+@router.delete(
+    "/profile-pictures",
+    responses=AUTH_RESPONSES,
+    operation_id="deleteMyProfilePicture",
+    summary="Remove Profile Picture",
+)
+@limiter.limit(Limits.PROFILE_PICTURE_SET)
+async def unset_profile_picture(
+    request: Request,
+    user: JwtUser,
+    svc: ProfilePictureSvc,
+) -> ProfilePictureMessageResponse:
+    """Unset the profile picture so the account falls back to the default.
+
+    Idempotent: returns 200 whether or not a picture was set.
+
+    **Authentication**: Required.
+    """
+    await svc.unset_picture(user.user_id)
+    return ProfilePictureMessageResponse(message="Profile picture removed")

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -8,17 +8,14 @@ GET  /dashboard/statistics  → statistics page
 GET  /dashboard/settings    → settings page
 GET  /dashboard/billing     → billing page
 GET  /dashboard/apps          → connected apps + ecosystem
-GET  /dashboard/profile-pictures  → available pictures (JSON)
-POST /dashboard/profile-pictures  → set profile picture (JSON)
-POST /dashboard/profile-pictures/upload  → upload a custom picture (JSON)
-DELETE /dashboard/profile-pictures       → unset picture (JSON)
+GET  /dashboard/profile-pictures  → available pictures (JSON, legacy)
+POST /dashboard/profile-pictures  → set profile picture (JSON, legacy)
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse, Response
-from pydantic import BaseModel, Field
 
 from dependencies import (
     AppGrantRepo,
@@ -31,8 +28,13 @@ from dependencies import (
 from infrastructure.logging import get_logger
 from infrastructure.templates import templates
 from middleware.rate_limiter import Limits, limiter
+from schemas.dto.requests.profile_pictures import SetProfilePictureRequest
+from schemas.dto.responses.profile_pictures import (
+    AvailablePicturesResponse,
+    ProfilePictureMessageResponse,
+)
 from schemas.models.app import AppStatus
-from services.profile_picture_service import AvailablePicture, ProfilePictureService
+from services.profile_picture_service import ProfilePictureService
 
 log = get_logger(__name__)
 
@@ -238,27 +240,9 @@ async def dashboard_apps(
     )
 
 
-# ── Profile pictures (JSON API) ─────────────────────────────────────────────
-
-
-class SetProfilePictureRequest(BaseModel):
-    picture_id: str = Field(min_length=1, max_length=200)
-
-
-class UploadProfilePictureRequest(BaseModel):
-    # Size/type gates run in the service against the configured cap
-    # (R2_UPLOAD_MAX_BYTES) — same posture as meta-tag image uploads.
-    image: str = Field(
-        min_length=1, description="base64 data URI (image/png, image/jpeg, image/webp)"
-    )
-
-
-class AvailablePicturesResponse(BaseModel):
-    pictures: list[AvailablePicture]
-
-
-class ProfilePictureMessageResponse(BaseModel):
-    message: str
+# ── Profile pictures (JSON API, legacy) ──────────────────────────────────────
+# Canonical home: /api/v1/me/profile-pictures (routes/api_v1/me.py). This pair
+# exists only for the legacy Jinja dashboard; drop it with the Jinja pages.
 
 
 @router.get("/profile-pictures")
@@ -282,26 +266,3 @@ async def set_profile_picture(
 ) -> ProfilePictureMessageResponse:
     await svc.set_picture(user.user_id, body.picture_id)
     return ProfilePictureMessageResponse(message="Profile picture updated successfully")
-
-
-@router.post("/profile-pictures/upload")
-@limiter.limit(Limits.PROFILE_PICTURE_UPLOAD)
-async def upload_profile_picture(
-    request: Request,
-    body: UploadProfilePictureRequest,
-    user: JwtUser,
-    svc: ProfilePictureSvc,
-) -> ProfilePictureMessageResponse:
-    await svc.upload_picture(user.user_id, body.image)
-    return ProfilePictureMessageResponse(message="Profile picture updated successfully")
-
-
-@router.delete("/profile-pictures")
-@limiter.limit(Limits.PROFILE_PICTURE_SET)
-async def unset_profile_picture(
-    request: Request,
-    user: JwtUser,
-    svc: ProfilePictureSvc,
-) -> ProfilePictureMessageResponse:
-    await svc.unset_picture(user.user_id)
-    return ProfilePictureMessageResponse(message="Profile picture removed")

--- a/schemas/dto/requests/profile_pictures.py
+++ b/schemas/dto/requests/profile_pictures.py
@@ -1,0 +1,19 @@
+"""Request DTOs for profile picture endpoints."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from schemas.dto.base import RequestBase
+
+
+class SetProfilePictureRequest(RequestBase):
+    picture_id: str = Field(min_length=1, max_length=200)
+
+
+class UploadProfilePictureRequest(RequestBase):
+    # Size/type gates run in the service against the configured cap
+    # (R2_UPLOAD_MAX_BYTES) — same posture as meta-tag image uploads.
+    image: str = Field(
+        min_length=1, description="base64 data URI (image/png, image/jpeg, image/webp)"
+    )

--- a/schemas/dto/responses/profile_pictures.py
+++ b/schemas/dto/responses/profile_pictures.py
@@ -1,0 +1,17 @@
+"""Response DTOs for profile picture endpoints."""
+
+from __future__ import annotations
+
+from schemas.dto.base import ResponseBase
+
+# AvailablePicture is the service's own serialization shape (plain fields,
+# no logic) — reused verbatim so the wire format has a single source of truth.
+from services.profile_picture_service import AvailablePicture
+
+
+class AvailablePicturesResponse(ResponseBase):
+    pictures: list[AvailablePicture]
+
+
+class ProfilePictureMessageResponse(ResponseBase):
+    message: str

--- a/tests/integration/api_v1/test_me_profile_pictures.py
+++ b/tests/integration/api_v1/test_me_profile_pictures.py
@@ -1,0 +1,215 @@
+"""/api/v1/me/profile-pictures — list, set, upload and unset the profile picture."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from dependencies import (
+    get_current_user,
+    get_profile_picture_service,
+    require_auth,
+    require_jwt,
+)
+from errors import NotFoundError, ValidationError
+from services.profile_picture_service import ProfilePictureService
+
+from .conftest import _build_test_app, _make_api_key_doc, _make_user
+
+_PICTURES = [
+    {
+        "id": "google_uid",
+        "url": "https://pic.example/a.jpg",
+        "source": "google",
+        "is_current": True,
+    }
+]
+
+
+def _mock_svc(pictures=None):
+    svc = MagicMock(spec=ProfilePictureService)
+    svc.get_available_pictures = AsyncMock(return_value=pictures or [])
+    svc.set_picture = AsyncMock()
+    svc.upload_picture = AsyncMock()
+    svc.unset_picture = AsyncMock()
+    return svc
+
+
+def _app(user, svc=None):
+    return _build_test_app(
+        {
+            require_jwt: lambda: user,
+            get_current_user: lambda: user,
+            get_profile_picture_service: lambda: svc or _mock_svc(),
+        }
+    )
+
+
+# ── Auth gating ──────────────────────────────────────────────────────────────
+
+
+def test_all_endpoints_require_auth():
+    # No auth override at all: the real require_jwt runs and rejects.
+    app = _build_test_app({get_profile_picture_service: lambda: _mock_svc()})
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert client.get("/api/v1/me/profile-pictures").status_code == 401
+        assert (
+            client.post(
+                "/api/v1/me/profile-pictures", json={"picture_id": "x"}
+            ).status_code
+            == 401
+        )
+        assert (
+            client.post(
+                "/api/v1/me/profile-pictures/upload",
+                json={"image": "data:image/png;base64,aGk="},
+            ).status_code
+            == 401
+        )
+        assert client.delete("/api/v1/me/profile-pictures").status_code == 401
+
+
+def test_all_endpoints_reject_api_key_auth():
+    # /me/* is JWT-only: a request that authenticates with a valid API key
+    # (any scope) must get 403 from the real require_jwt, matching the
+    # features/layouts siblings and PATCH /auth/me.
+    user = _make_user(api_key_doc=_make_api_key_doc())
+    svc = _mock_svc()
+    app = _build_test_app(
+        {
+            require_auth: lambda: user,
+            get_profile_picture_service: lambda: svc,
+        }
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert client.get("/api/v1/me/profile-pictures").status_code == 403
+        assert (
+            client.post(
+                "/api/v1/me/profile-pictures", json={"picture_id": "x"}
+            ).status_code
+            == 403
+        )
+        assert (
+            client.post(
+                "/api/v1/me/profile-pictures/upload",
+                json={"image": "data:image/png;base64,aGk="},
+            ).status_code
+            == 403
+        )
+        assert client.delete("/api/v1/me/profile-pictures").status_code == 403
+    svc.set_picture.assert_not_called()
+    svc.upload_picture.assert_not_called()
+    svc.unset_picture.assert_not_called()
+
+
+# ── GET (available pictures) ─────────────────────────────────────────────────
+
+
+def test_get_returns_available_pictures():
+    user = _make_user()
+    svc = _mock_svc(pictures=_PICTURES)
+    with TestClient(_app(user, svc)) as client:
+        resp = client.get("/api/v1/me/profile-pictures")
+    assert resp.status_code == 200
+    assert resp.json()["pictures"] == _PICTURES
+    svc.get_available_pictures.assert_called_once_with(user.user_id)
+
+
+# ── POST (set provider picture) ──────────────────────────────────────────────
+
+
+def test_set_picture_success():
+    user = _make_user()
+    svc = _mock_svc()
+    with TestClient(_app(user, svc)) as client:
+        resp = client.post(
+            "/api/v1/me/profile-pictures", json={"picture_id": "google_uid"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Profile picture updated successfully"
+    svc.set_picture.assert_called_once_with(user.user_id, "google_uid")
+
+
+def test_set_picture_missing_id_returns_422():
+    user = _make_user()
+    with TestClient(_app(user)) as client:
+        resp = client.post("/api/v1/me/profile-pictures", json={})
+    assert resp.status_code == 422
+
+
+def test_set_picture_unknown_id_returns_404():
+    user = _make_user()
+    svc = _mock_svc()
+    svc.set_picture = AsyncMock(side_effect=NotFoundError("Picture not found"))
+    with TestClient(_app(user, svc)) as client:
+        resp = client.post("/api/v1/me/profile-pictures", json={"picture_id": "bad_id"})
+    assert resp.status_code == 404
+
+
+# ── POST /upload (custom picture) ────────────────────────────────────────────
+
+
+def test_upload_success():
+    user = _make_user()
+    svc = _mock_svc()
+    with TestClient(_app(user, svc)) as client:
+        resp = client.post(
+            "/api/v1/me/profile-pictures/upload",
+            json={"image": "data:image/png;base64,aGk="},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Profile picture updated successfully"
+    svc.upload_picture.assert_called_once_with(
+        user.user_id, "data:image/png;base64,aGk="
+    )
+
+
+def test_upload_missing_image_returns_422():
+    user = _make_user()
+    with TestClient(_app(user)) as client:
+        resp = client.post("/api/v1/me/profile-pictures/upload", json={})
+    assert resp.status_code == 422
+
+
+def test_upload_invalid_image_returns_400():
+    user = _make_user()
+    svc = _mock_svc()
+    svc.upload_picture = AsyncMock(
+        side_effect=ValidationError(
+            "image bytes do not match the declared image type", field="image"
+        )
+    )
+    with TestClient(_app(user, svc)) as client:
+        resp = client.post(
+            "/api/v1/me/profile-pictures/upload",
+            json={"image": "data:image/png;base64,aGk="},
+        )
+    assert resp.status_code == 400
+    assert resp.json()["field"] == "image"
+
+
+# ── DELETE (unset) ───────────────────────────────────────────────────────────
+
+
+def test_delete_returns_success():
+    user = _make_user()
+    svc = _mock_svc()
+    with TestClient(_app(user, svc)) as client:
+        resp = client.delete("/api/v1/me/profile-pictures")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Profile picture removed"
+    svc.unset_picture.assert_called_once_with(user.user_id)
+
+
+def test_delete_is_idempotent():
+    # Unsetting when no picture is set is still a 200: the service clears
+    # the field unconditionally, so a second delete looks exactly the same.
+    user = _make_user()
+    svc = _mock_svc()
+    with TestClient(_app(user, svc)) as client:
+        first = client.delete("/api/v1/me/profile-pictures")
+        second = client.delete("/api/v1/me/profile-pictures")
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert svc.unset_picture.await_count == 2

--- a/tests/integration/test_dashboard_routes.py
+++ b/tests/integration/test_dashboard_routes.py
@@ -22,7 +22,7 @@ from dependencies import (
     get_current_user,
     get_profile_picture_service,
 )
-from errors import NotFoundError, ValidationError
+from errors import NotFoundError
 from middleware.error_handler import register_error_handlers
 from middleware.rate_limiter import limiter
 from routes.dashboard_routes import router as dashboard_router
@@ -50,8 +50,6 @@ def _mock_svc(profile=None, pictures=None):
     svc.get_dashboard_profile = AsyncMock(return_value=profile or _PROFILE)
     svc.get_available_pictures = AsyncMock(return_value=pictures or [])
     svc.set_picture = AsyncMock()
-    svc.upload_picture = AsyncMock()
-    svc.unset_picture = AsyncMock()
     return svc
 
 
@@ -211,76 +209,6 @@ def test_profile_pictures_post_invalid_id_returns_404():
     assert resp.status_code == 404
 
 
-# ── Profile picture upload ───────────────────────────────────────────────────
-
-
-def test_profile_picture_upload_unauth_returns_401():
-    app = _build_test_app(user=None)
-    with TestClient(app) as c:
-        resp = c.post(
-            "/dashboard/profile-pictures/upload",
-            json={"image": "data:image/png;base64,aGk="},
-        )
-    assert resp.status_code == 401
-
-
-def test_profile_picture_upload_missing_image_returns_422():
-    app = _build_test_app(user=_TEST_USER)
-    with TestClient(app) as c:
-        resp = c.post("/dashboard/profile-pictures/upload", json={})
-    assert resp.status_code == 422
-
-
-def test_profile_picture_upload_valid_returns_success():
-    svc = _mock_svc()
-    app = _build_test_app(user=_TEST_USER, svc=svc)
-    with TestClient(app) as c:
-        resp = c.post(
-            "/dashboard/profile-pictures/upload",
-            json={"image": "data:image/png;base64,aGk="},
-        )
-    assert resp.status_code == 200
-    assert resp.json()["message"] == "Profile picture updated successfully"
-    svc.upload_picture.assert_called_once()
-
-
-def test_profile_picture_upload_invalid_image_returns_400():
-    svc = _mock_svc()
-    svc.upload_picture = AsyncMock(
-        side_effect=ValidationError(
-            "image bytes do not match the declared image type", field="image"
-        )
-    )
-    app = _build_test_app(user=_TEST_USER, svc=svc)
-    with TestClient(app) as c:
-        resp = c.post(
-            "/dashboard/profile-pictures/upload",
-            json={"image": "data:image/png;base64,aGk="},
-        )
-    assert resp.status_code == 400
-    assert resp.json()["field"] == "image"
-
-
-# ── Profile picture unset ────────────────────────────────────────────────────
-
-
-def test_profile_picture_delete_unauth_returns_401():
-    app = _build_test_app(user=None)
-    with TestClient(app) as c:
-        resp = c.delete("/dashboard/profile-pictures")
-    assert resp.status_code == 401
-
-
-def test_profile_picture_delete_returns_success():
-    svc = _mock_svc()
-    app = _build_test_app(user=_TEST_USER, svc=svc)
-    with TestClient(app) as c:
-        resp = c.delete("/dashboard/profile-pictures")
-    assert resp.status_code == 200
-    assert resp.json()["message"] == "Profile picture removed"
-    svc.unset_picture.assert_called_once_with(_TEST_USER.user_id)
-
-
 def test_profile_picture_endpoints_reject_api_key_auth():
     """The whole account-profile surface is JWT-only, matching PATCH /auth/me."""
     svc = _mock_svc()
@@ -294,13 +222,4 @@ def test_profile_picture_endpoints_reject_api_key_auth():
             c.post("/dashboard/profile-pictures", json={"picture_id": "x"}).status_code
             == 403
         )
-        assert (
-            c.post(
-                "/dashboard/profile-pictures/upload", json={"image": "data:;base64,x"}
-            ).status_code
-            == 403
-        )
-        assert c.delete("/dashboard/profile-pictures").status_code == 403
     svc.set_picture.assert_not_called()
-    svc.upload_picture.assert_not_called()
-    svc.unset_picture.assert_not_called()


### PR DESCRIPTION
## Why

The profile picture JSON endpoints were registered under `/dashboard/*`. That prefix is a page namespace: the edge routes `/dashboard/*` to the frontend router, so any API living there needs special-case routing to keep working. The account-self API group `/api/v1/me` (features, layouts) is the natural home for account-scoped operations, so the profile picture surface moves there.

## What changed

New endpoints under `/api/v1/me`, wire-identical to the old handlers (same DTOs, same service calls, same rate limits, same JWT-only gating as their `/me` siblings):

| Old | New |
| --- | --- |
| `GET /dashboard/profile-pictures` | `GET /api/v1/me/profile-pictures` |
| `POST /dashboard/profile-pictures` | `POST /api/v1/me/profile-pictures` |
| `POST /dashboard/profile-pictures/upload` | `POST /api/v1/me/profile-pictures/upload` |
| `DELETE /dashboard/profile-pictures` | `DELETE /api/v1/me/profile-pictures` |

On the `/dashboard` side:

- `POST /dashboard/profile-pictures/upload` and `DELETE /dashboard/profile-pictures` are removed. They were never part of a release and nothing ships against them, so no compatibility is owed.
- `GET` and `POST /dashboard/profile-pictures` stay untouched, including their JWT-only gating. The legacy Jinja settings page still calls exactly these two (`static/js/dashboard/settings.js`), so they remain until the Jinja dashboard retires. A comment on the pair points at the canonical `/api/v1/me` home.

The request/response DTOs move to `schemas/dto/requests/profile_pictures.py` and `schemas/dto/responses/profile_pictures.py` so both routers share one definition. `ProfilePictureService` is untouched.

## Tests

- New `tests/integration/api_v1/test_me_profile_pictures.py`: 401 without auth and 403 with API key auth across all four endpoints, happy paths for list/set/upload/unset, 422 on missing fields, 404 on unknown picture id, 400 on invalid image payloads, and delete idempotency.
- `tests/integration/test_dashboard_routes.py`: dropped the removed endpoints' cases, kept full coverage of the shipped pair including its API-key 403 test.
- Unit tests for the service are unchanged since the service is unchanged.

`pytest` on the affected files: 57 passed. `ruff check .` and `ruff format --check .` are clean.

## Merge safety

The `/api/v1/me` endpoints are a pure addition. The only removals are the two `/dashboard` routes that never shipped, and the two routes the legacy dashboard actually uses are byte-for-byte the same behavior. Nothing in production changes shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated API endpoints to view available profile pictures, select a picture, upload a custom image, and remove the current picture.
  * Added support for common image formats, including PNG, JPEG, and WebP.
  * Added validation and clear responses for invalid or missing profile picture data.

* **Changes**
  * Retained the dashboard’s legacy view and selection routes while moving upload and removal actions to the API.

* **Tests**
  * Added coverage for authentication, validation, successful updates, error handling, and repeat removal requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->