### PR TITLE
fix(auth): serialize auth timestamps with explicit UTC offset

### DIFF
--- a/schemas/dto/base.py
+++ b/schemas/dto/base.py
@@ -1,11 +1,36 @@
 """
-Shared base classes for request and response DTOs.
+Shared base classes and field types for request and response DTOs.
 
 All DTOs inherit from these to get consistent Pydantic configuration
 without repeating ``model_config`` in every class.
+
+``UtcDatetime`` is the standard type for response timestamp fields:
+it serializes as ISO 8601 with an explicit UTC offset, stamping naive
+datetimes (PyMongo read-backs) as UTC on the way out.
 """
 
-from pydantic import BaseModel, ConfigDict
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, PlainSerializer
+
+
+def _stamp_utc(dt: datetime) -> str:
+    # PyMongo returns naive datetimes; without explicit tzinfo the JSON
+    # form omits the offset and clients parse it as local time. Stamp
+    # UTC so the wire format is unambiguous (`...+00:00`).
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+UtcDatetime = Annotated[datetime, PlainSerializer(_stamp_utc, return_type=str)]
+"""Response datetime that always serializes with an explicit UTC offset.
+
+Use this for every new response timestamp field. Naive values (Mongo
+read-backs, the client is not ``tz_aware``) are stamped as UTC; aware
+values keep their instant. Wire form is ``2025-01-01T00:00:00+00:00``.
+"""
 
 
 class RequestBase(BaseModel):

--- a/schemas/dto/responses/app_grant.py
+++ b/schemas/dto/responses/app_grant.py
@@ -12,11 +12,9 @@ the registry's consent ``permissions`` strings, never scope slugs
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from pydantic import Field
 
-from pydantic import Field, field_serializer
-
-from schemas.dto.base import ResponseBase
+from schemas.dto.base import ResponseBase, UtcDatetime
 from schemas.models.app import AppEntry
 from schemas.models.app_grant import AppGrantDoc
 
@@ -49,22 +47,13 @@ class AppGrantResponse(ResponseBase):
         description="Consent-screen permission strings the user granted",
         examples=[["Access your spoo.me account", "View your analytics"]],
     )
-    granted_at: datetime = Field(description="When access was granted (ISO 8601 UTC)")
-    last_used_at: datetime | None = Field(
+    granted_at: UtcDatetime = Field(
+        description="When access was granted (ISO 8601 UTC)"
+    )
+    last_used_at: UtcDatetime | None = Field(
         default=None,
         description="Last token exchange/refresh by this app, null if never used",
     )
-
-    @field_serializer("granted_at", "last_used_at")
-    def _ser_as_utc(self, dt: datetime | None) -> str | None:
-        # PyMongo returns naive datetimes; without explicit tzinfo the JSON
-        # form omits the offset and clients parse it as local time. Stamp
-        # UTC so the wire format is unambiguous (`...+00:00`).
-        if dt is None:
-            return None
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.isoformat()
 
     @classmethod
     def from_grant(cls, doc: AppGrantDoc, entry: AppEntry | None) -> AppGrantResponse:

--- a/schemas/dto/responses/auth.py
+++ b/schemas/dto/responses/auth.py
@@ -13,12 +13,11 @@ VerifyEmailResponse — POST /auth/verify-email  (200)
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field
 
-from schemas.dto.base import ResponseBase
+from schemas.dto.base import ResponseBase, UtcDatetime
 from schemas.models.user import OAuthProvider, ProviderProfile
 
 if TYPE_CHECKING:
@@ -36,7 +35,7 @@ class AuthProviderInfo(ResponseBase):
         description="Email address from the OAuth provider",
         examples=["user@gmail.com"],
     )
-    linked_at: datetime | None = Field(
+    linked_at: UtcDatetime | None = Field(
         default=None,
         description="When the provider was linked",
         examples=["2025-01-15T10:30:00+00:00"],
@@ -73,7 +72,7 @@ class UserProfileResponse(ResponseBase):
     )
     plan: str = Field(description="Subscription plan", examples=["free"])
     password_set: bool = Field(description="Whether the user has set a password")
-    onboarded_at: datetime | None = Field(
+    onboarded_at: UtcDatetime | None = Field(
         default=None,
         description="When the user completed onboarding (null = never)",
     )
@@ -202,7 +201,7 @@ class OAuthProviderDetail(ResponseBase):
     email_verified: bool = Field(
         default=False, description="Email verified by provider"
     )
-    linked_at: datetime | None = Field(
+    linked_at: UtcDatetime | None = Field(
         default=None, description="When the provider was linked"
     )
     profile: ProviderProfile = Field(
@@ -242,6 +241,6 @@ class OnboardingCompleteResponse(ResponseBase):
     """Response body for POST /auth/onboarding/complete (200)."""
 
     success: bool = Field(description="Always true on success")
-    onboarded_at: datetime = Field(
+    onboarded_at: UtcDatetime = Field(
         description="When onboarding was completed (first completion wins)"
     )

--- a/schemas/dto/responses/custom_domain.py
+++ b/schemas/dto/responses/custom_domain.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Literal
 
-from pydantic import Field, field_serializer
+from pydantic import Field
 
-from schemas.dto.base import ResponseBase
+from schemas.dto.base import ResponseBase, UtcDatetime
 from schemas.enums.domain_status import DomainStatus, VerificationMethod
 from schemas.models.custom_domain import CustomDomainDoc
 
@@ -39,9 +38,9 @@ class CustomDomainResponse(ResponseBase):
         default_factory=list,
         description="Human-readable setup warnings/instructions specific to this domain.",
     )
-    created_at: datetime
-    updated_at: datetime | None = None
-    last_verified_at: datetime | None = None
+    created_at: UtcDatetime
+    updated_at: UtcDatetime | None = None
+    last_verified_at: UtcDatetime | None = None
     last_verification_error: str | None = None
     root_redirect: str | None = Field(
         default=None,
@@ -55,17 +54,6 @@ class CustomDomainResponse(ResponseBase):
         default=None,
         description="Override body served at /robots.txt. Honored only when status=ACTIVE.",
     )
-
-    @field_serializer("created_at", "updated_at", "last_verified_at")
-    def _ser_as_utc(self, dt: datetime | None) -> str | None:
-        # PyMongo returns naive datetimes; without explicit tzinfo the JSON
-        # form omits the offset and clients parse it as local time. Stamp
-        # UTC so the wire format is unambiguous (`...+00:00`).
-        if dt is None:
-            return None
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.isoformat()
 
     @classmethod
     def from_doc(cls, doc: CustomDomainDoc) -> CustomDomainResponse:

--- a/tests/integration/test_onboarding_routes.py
+++ b/tests/integration/test_onboarding_routes.py
@@ -116,6 +116,29 @@ def test_complete_is_idempotent_and_keeps_original_stamp():
     assert resp.json()["onboarded_at"].startswith("2026-07-01")
 
 
+def test_complete_first_call_emits_explicit_utc_offset():
+    repo = AsyncMock()
+    repo.complete_onboarding = AsyncMock(return_value=True)
+    with _build(user_repo=repo) as client:
+        resp = client.post("/auth/onboarding/complete", json={})
+    assert resp.json()["onboarded_at"].endswith("+00:00")
+
+
+def test_complete_repeat_call_matches_first_call_wire_format():
+    # The repeat path echoes the Mongo read-back, which is NAIVE (the
+    # client is not tz_aware). The wire form must be identical to the
+    # first call's aware stamp — offsetless ISO parses as local time in
+    # JS, and a format that flips between calls is worse.
+    repo = AsyncMock()
+    repo.complete_onboarding = AsyncMock(return_value=False)  # already stamped
+    doc = AsyncMock()
+    doc.onboarded_at = datetime(2026, 7, 1)  # naive, as read back from Mongo
+    repo.find_by_id = AsyncMock(return_value=doc)
+    with _build(user_repo=repo) as client:
+        resp = client.post("/auth/onboarding/complete", json={})
+    assert resp.json()["onboarded_at"] == "2026-07-01T00:00:00+00:00"
+
+
 def test_complete_rejects_oversized_heard_from():
     with _build() as client:
         resp = client.post("/auth/onboarding/complete", json={"heard_from": "x" * 65})

--- a/tests/unit/schemas/dto/test_auth.py
+++ b/tests/unit/schemas/dto/test_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from pydantic import ValidationError
 
@@ -13,6 +15,8 @@ from schemas.dto.requests.auth import (
 )
 from schemas.dto.responses.auth import (
     AuthProviderInfo,
+    OAuthProviderDetail,
+    OnboardingCompleteResponse,
     UserProfileResponse,
 )
 
@@ -116,3 +120,65 @@ class TestUserProfileResponse:
             ],
         )
         assert r.auth_providers[0].provider == "google"
+
+
+# ── UTC stamping on the wire ───────────────────────────────────────────────────
+#
+# PyMongo (no tz_aware) hands back naive datetimes. Without an explicit
+# offset in the JSON, `new Date("2026-07-13T09:00:00")` in a browser parses
+# the value as LOCAL time and silently shifts the instant. These tests pin
+# that every auth timestamp leaves with an explicit UTC offset.
+
+_NAIVE = datetime(2025, 1, 15, 10, 30)  # what a Mongo read-back looks like
+_AWARE = datetime(2025, 1, 15, 10, 30, tzinfo=timezone.utc)
+_WIRE = "2025-01-15T10:30:00+00:00"
+
+
+def _profile(**overrides) -> UserProfileResponse:
+    base = {
+        "id": "507f1f77bcf86cd799439011",
+        "email": "u@example.com",
+        "email_verified": True,
+        "plan": "free",
+        "password_set": True,
+        "auth_providers": [],
+    }
+    base.update(overrides)
+    return UserProfileResponse(**base)
+
+
+class TestAuthTimestampsCarryUtcOffset:
+    def test_onboarded_at_naive_is_stamped_utc(self):
+        d = _profile(onboarded_at=_NAIVE).model_dump()
+        assert d["onboarded_at"] == _WIRE
+
+    def test_onboarded_at_aware_keeps_instant(self):
+        d = _profile(onboarded_at=_AWARE).model_dump()
+        assert d["onboarded_at"] == _WIRE
+
+    def test_onboarded_at_none_stays_null(self):
+        d = _profile().model_dump()
+        assert d["onboarded_at"] is None
+
+    def test_provider_linked_at_naive_is_stamped_utc(self):
+        info = AuthProviderInfo(provider="google", linked_at=_NAIVE)
+        assert info.model_dump()["linked_at"] == _WIRE
+
+    def test_provider_linked_at_none_stays_null(self):
+        info = AuthProviderInfo(provider="google")
+        assert info.model_dump()["linked_at"] is None
+
+    def test_oauth_provider_detail_linked_at_naive_is_stamped_utc(self):
+        detail = OAuthProviderDetail(provider="google", linked_at=_NAIVE)
+        assert detail.model_dump()["linked_at"] == _WIRE
+
+    def test_onboarding_complete_naive_and_aware_match_exactly(self):
+        # First call stamps an aware datetime, the idempotent repeat echoes
+        # the naive Mongo read-back — the wire form must be identical.
+        first = OnboardingCompleteResponse(success=True, onboarded_at=_AWARE)
+        repeat = OnboardingCompleteResponse(success=True, onboarded_at=_NAIVE)
+        assert (
+            first.model_dump()["onboarded_at"]
+            == repeat.model_dump()["onboarded_at"]
+            == _WIRE
+        )

--- a/tests/unit/schemas/dto/test_custom_domain.py
+++ b/tests/unit/schemas/dto/test_custom_domain.py
@@ -74,6 +74,18 @@ class TestCustomDomainResponse:
         assert r.status == DomainStatus.ACTIVE
         assert r.verification_method == VerificationMethod.CF_HTTP_DCV
 
+    def test_timestamps_serialize_with_explicit_utc_offset(self):
+        # Wire regression guard for the move to the shared UtcDatetime
+        # type: naive Mongo read-backs are stamped UTC and the textual
+        # form stays `+00:00`, exactly as the old field_serializer emitted.
+        r = CustomDomainResponse.from_doc(
+            _doc(created_at=datetime(2025, 1, 1), updated_at=datetime(2025, 1, 2))
+        )
+        dumped = r.model_dump()
+        assert dumped["created_at"] == "2025-01-01T00:00:00+00:00"
+        assert dumped["updated_at"] == "2025-01-02T00:00:00+00:00"
+        assert dumped["last_verified_at"] is None
+
 
 class TestCustomDomainListResponse:
     def test_paginated_shape(self):


### PR DESCRIPTION
## The bug

The app's PyMongo client is not `tz_aware`, so every datetime read back from Mongo is naive. The auth response DTOs serialized those values as-is, producing ISO strings with no UTC offset, for example `2026-07-13T09:00:00`. JavaScript's `Date` parser treats offsetless ISO strings as local time, so any dashboard viewer outside UTC saw these timestamps silently shifted by their own UTC offset, up to 14 hours.

On top of that, `POST /auth/onboarding/complete` was inconsistent with itself: the first completion returned a freshly stamped aware datetime (`...Z`), while idempotent repeat calls echoed the naive Mongo read-back with no offset. The same field flipped wire format between calls.

## The fix

The UTC-stamping serializer pattern already existed, duplicated verbatim, in the custom-domain and app-grant response DTOs. This PR promotes it to a single shared `UtcDatetime` annotated type in `schemas/dto/base.py` (a `PlainSerializer` that stamps naive values as UTC and emits `isoformat()`, so the wire form is `...+00:00`) and applies it to the affected auth fields:

- `UserProfileResponse.onboarded_at`, returned by `POST /auth/login`, `POST /auth/register`, `GET /auth/me`, `POST /auth/device/token`
- `AuthProviderInfo.linked_at` (inside the same profile payloads)
- `OAuthProviderDetail.linked_at`, returned by `GET /oauth/providers`
- `OnboardingCompleteResponse.onboarded_at`, returned by `POST /auth/onboarding/complete`

The onboarding endpoint now emits an identical format on first and repeat calls, since both paths flow through the same serializer. No route code changed.

The two DTOs that already had the hand-rolled serializer (`custom_domain.py`, `app_grant.py`) were refactored onto the shared type. That is a pure cleanup: the output is byte-identical (`+00:00` form), and their existing tests, including the integration tests that pin the exact wire strings, pass unchanged.

## Blast radius

These fields are dashboard-internal wire (plus the device-auth profile payload). The Next frontend already tolerates both aware and naive forms, so no compat window is needed. Shipped public formats (unix-epoch fields, legacy display strings, JWT claims) are untouched, and the Mongo client's `tz_aware` setting is unchanged.

## Tests

- New DTO unit tests pin that each affected field serializes with an explicit UTC offset for naive input, keeps the instant for aware input, and passes `null` through.
- New integration tests pin that `POST /auth/onboarding/complete` emits `+00:00` on the first call and that a repeat call echoing a naive stored value produces the exact same wire format.
- A regression test pins that the refactored custom-domain DTO still emits the exact `+00:00` strings it did before.
- Full affected suite (auth, oauth, onboarding, device auth, custom domains, apps DTO and route tests): 361 passed. `ruff check` and `ruff format --check` clean.
