### PR TITLE
fix(auth): standardize error shapes on refresh and device revoke

### DIFF
--- a/routes/api_v1/keys.py
+++ b/routes/api_v1/keys.py
@@ -124,7 +124,8 @@ async def list_api_keys(
     authenticated user. The full token value is **never** returned in this
     endpoint for security reasons — only the `token_prefix` is shown.
 
-    **Authentication**: Required — JWT Bearer or API key with appropriate scope.
+    **Authentication**: Required — JWT Bearer only (API keys cannot be used to
+    manage API keys).
 
     **Rate Limits**: 60/min
     """
@@ -168,7 +169,8 @@ async def delete_api_key(
     revoked (soft delete). Revoked keys stop working immediately but remain
     visible in the key list for audit purposes.
 
-    **Authentication**: Required — JWT Bearer or API key.
+    **Authentication**: Required — JWT Bearer only (API keys cannot be used to
+    manage API keys).
 
     **Rate Limits**: 30/min
 

--- a/routes/auth/device.py
+++ b/routes/auth/device.py
@@ -28,7 +28,12 @@ from dependencies import (
     UserRepo,
     fetch_user_profile,
 )
-from errors import AuthenticationError
+from errors import (
+    AuthenticationError,
+    ForbiddenError,
+    NotFoundError,
+    ValidationError,
+)
 from infrastructure.logging import get_logger
 from infrastructure.templates import templates
 from middleware.openapi import ERROR_RESPONSES, PUBLIC_SECURITY
@@ -330,15 +335,15 @@ async def revoke_app(
     which cannot be sent by cross-origin form submissions.
     """
     if request.headers.get(_CSRF_HEADER_NAME) != _CSRF_HEADER_VALUE:
-        return JSONResponse({"error": "invalid request"}, status_code=403)
+        raise ForbiddenError("invalid request")
 
     app_id = app_id.strip()
     if not app_id or len(app_id) > APP_ID_MAX_LEN:
-        return JSONResponse({"error": "app_id is required"}, status_code=400)
+        raise ValidationError("app_id is required")
 
     revoked = await grant_repo.revoke(user.user_id, app_id)
     if not revoked:
-        return JSONResponse({"error": "no active grant found"}, status_code=404)
+        raise NotFoundError("no active grant found")
 
     # Invalidate device auth tokens bound to this app via the public service method
     await device_auth_service.revoke_device_tokens(user.user_id, app_id=app_id)

--- a/routes/auth/routes.py
+++ b/routes/auth/routes.py
@@ -191,7 +191,7 @@ async def refresh(
     refresh_token_str = request.cookies.get("refresh_token")
     if not refresh_token_str:
         resp = JSONResponse(
-            {"error": "missing refresh token", "code": "AUTHENTICATION_ERROR"},
+            AuthenticationError("missing refresh token").to_dict(),
             status_code=401,
         )
         clear_auth_cookies(resp, jwt_cfg)
@@ -202,10 +202,7 @@ async def refresh(
     except AuthenticationError as exc:
         log.info("token_refresh_failed", error=str(exc))
         resp = JSONResponse(
-            {
-                "error": "invalid or expired refresh token",
-                "code": "AUTHENTICATION_ERROR",
-            },
+            AuthenticationError("invalid or expired refresh token").to_dict(),
             status_code=401,
         )
         clear_auth_cookies(resp, jwt_cfg)

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -229,6 +229,10 @@ def test_refresh_missing_cookie_clears_cookies_returns_401():
     with TestClient(app, raise_server_exceptions=False) as client:
         resp = client.post("/auth/refresh")  # no refresh_token cookie
     assert resp.status_code == 401
+    assert resp.json() == {
+        "error": "missing refresh token",
+        "code": "authentication_error",
+    }
     # Both cookie clearing headers should be present
     set_cookie_headers = resp.headers.get_list("set-cookie")
     cookie_names = [h.split("=")[0] for h in set_cookie_headers]
@@ -249,6 +253,10 @@ def test_refresh_expired_token_clears_cookies_returns_401():
         client.cookies.set("refresh_token", "expired.jwt")
         resp = client.post("/auth/refresh")
     assert resp.status_code == 401
+    assert resp.json() == {
+        "error": "invalid or expired refresh token",
+        "code": "authentication_error",
+    }
     set_cookie_headers = resp.headers.get_list("set-cookie")
     cookie_names = [h.split("=")[0] for h in set_cookie_headers]
     assert "access_token" in cookie_names

--- a/tests/integration/test_device_auth.py
+++ b/tests/integration/test_device_auth.py
@@ -446,6 +446,7 @@ def test_revoke_without_csrf_header_rejected(
     )
     resp = c.post("/auth/device/revoke", data={"app_id": "spoo-snap"})
     assert resp.status_code == 403
+    assert resp.json() == {"error": "invalid request", "code": "forbidden"}
 
 
 def test_revoke_success(
@@ -491,6 +492,7 @@ def test_revoke_no_grant_returns_404(
         headers={"X-Requested-With": "fetch"},
     )
     assert resp.status_code == 404
+    assert resp.json() == {"error": "no active grant found", "code": "not_found"}
 
 
 # ── POST /auth/device/refresh ─────────────────────────────────────────────────


### PR DESCRIPTION
## What was inconsistent

Three auth surfaces drifted from the standard `{"error", "code"}` shape that `AppError.to_dict()` and the global error handler emit everywhere else:

- `POST /auth/refresh` returned hand-built 401 bodies with an uppercase `"code": "AUTHENTICATION_ERROR"`, while `AuthenticationError` serializes as `authentication_error` everywhere else.
- `POST /auth/device/revoke` returned bare `{"error": ...}` bodies with no `code` field for its 403, 400, and 404 failures.
- `GET /api/v1/keys` and `DELETE /api/v1/keys/{key_id}` docstrings claimed API-key auth is accepted, but both use the JWT-only dependency (API keys cannot manage API keys, by design).

## What changed

- Refresh failures now build their bodies via `AuthenticationError(...).to_dict()`, so the code is lowercase `authentication_error`. The handler still returns a `JSONResponse` directly because it must clear both auth cookies on failure, which the global exception handler cannot do. Status 401 and both messages are unchanged.
- Device revoke now raises `ForbiddenError` (403), `ValidationError` (400), and `NotFoundError` (404) and lets the global handler serialize them; `/auth/` paths always negotiate to JSON. The 200 success shape is unchanged.
- Keys endpoint docstrings now state JWT Bearer only, matching the actual dependency and the POST endpoint's wording. No dependency changes.
- Tests updated to pin the new bodies; the full auth, device, and keys modules pass (148 tests).

## Notes

- Legacy v1 error keys (`UrlError`, `PasswordError`, `EmojiError`) are intentionally untouched; that shape is the shipped public contract.
- Grepped all sibling repos for consumers of the uppercase `AUTHENTICATION_ERROR` string: no frontend or client code matches it, only copies of this backend. Frontends branch on the 401 status, so no coordinated change is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that API key management endpoints require JWT Bearer authentication and do not accept API keys.

* **Bug Fixes**
  * Standardized authentication and device-revocation error responses with structured error details.
  * Preserved appropriate status codes and token-clearing behavior for refresh-token failures.

* **Tests**
  * Expanded integration coverage for refresh-token and device-revocation error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->