### PR TITLE
feat(analytics): add device and UTM click dimensions

### DIFF
--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -246,6 +246,11 @@ async def redirect_url(
             cf_city=cf_city,
             resolved_country=resolved_country,
             geo_matched=geo_matched,
+            # Raw capture only — ClickEvent sanitises and bounds these
+            # structurally, same as the password-hash strip.
+            utm_source=request.query_params.get("utm_source"),
+            utm_medium=request.query_params.get("utm_medium"),
+            utm_campaign=request.query_params.get("utm_campaign"),
             redirect_ms=int((time.perf_counter() - start_time) * 1000),
         )
         try:

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -145,7 +145,8 @@ STATS_DEVICE_DESC = (
     "**Method 2: Individual Filter Parameter**\n\n"
     "Comma-separated device types. Alternative to using the `filters` JSON "
     "parameter.\n\n"
-    "**Values:** `mobile`, `tablet`, `desktop`, `unknown`.\n\n"
+    "**Values:** `mobile`, `tablet`, `desktop`, `unknown`. `unknown` also "
+    "matches clicks recorded before device tracking existed.\n\n"
     "**Note:** Both `filters` JSON and individual parameters can be combined."
 )
 

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -41,10 +41,15 @@ STATS_GROUP_BY_DESC = (
     "- `time` — group by time buckets (day/week/month, auto-selected based on range)\n"
     "- `browser` — group by browser name (e.g., Chrome, Firefox, Safari)\n"
     "- `os` — group by operating system (e.g., Windows, macOS, Linux)\n"
+    "- `device` — group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n"
     "- `country` — group by country\n"
     "- `city` — group by city\n"
     "- `referrer` — group by referrer URL\n"
-    "- `short_code` — group by URL alias (only with `scope=all`)\n\n"
+    "- `short_code` — group by URL alias (only with `scope=all`)\n"
+    "- `utm_source` — group by the `utm_source` tag on the short link "
+    "(untagged clicks appear as `(none)`)\n"
+    "- `utm_medium` — group by the `utm_medium` tag\n"
+    "- `utm_campaign` — group by the `utm_campaign` tag\n\n"
     "Multiple dimensions can be combined: `time,browser` returns time series "
     "broken down by browser."
 )
@@ -69,11 +74,14 @@ STATS_FILTERS_DESC = (
     "**Available filter dimensions:**\n\n"
     "- `browser` — Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n"
     "- `os` — Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n"
+    "- `device` — Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n"
     "- `country` — Filter by country name (e.g., United States, Canada, Germany)\n"
     "- `city` — Filter by city name (e.g., New York, London, Mumbai)\n"
     "- `referrer` — Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n"
     "- `short_code` — Filter by URL alias (e.g., mylink, promo2024) — "
-    "**not allowed** with `scope=anon`\n\n"
+    "**not allowed** with `scope=anon`\n"
+    "- `utm_source` / `utm_medium` / `utm_campaign` — Filter by campaign tags; "
+    "`(none)` matches untagged clicks\n\n"
     "**Value format:** Array of strings for each dimension.\n\n"
     "**Important:** Filter values are case-sensitive. Use exact capitalization "
     "as stored in the database.\n\n"
@@ -130,6 +138,23 @@ STATS_REFERRER_DESC = (
     "parameter.\n\n"
     "**Important:** Values are case-sensitive. Include the full URL including "
     "protocol.\n\n"
+    "**Note:** Both `filters` JSON and individual parameters can be combined."
+)
+
+STATS_DEVICE_DESC = (
+    "**Method 2: Individual Filter Parameter**\n\n"
+    "Comma-separated device types. Alternative to using the `filters` JSON "
+    "parameter.\n\n"
+    "**Values:** `mobile`, `tablet`, `desktop`, `unknown`.\n\n"
+    "**Note:** Both `filters` JSON and individual parameters can be combined."
+)
+
+STATS_UTM_DESC = (
+    "**Method 2: Individual Filter Parameter**\n\n"
+    "Comma-separated campaign tag values. Alternative to using the `filters` "
+    "JSON parameter.\n\n"
+    "**Important:** Values are case-sensitive. `(none)` matches clicks with "
+    "no tag.\n\n"
     "**Note:** Both `filters` JSON and individual parameters can be combined."
 )
 

--- a/schemas/dto/requests/stats.py
+++ b/schemas/dto/requests/stats.py
@@ -25,6 +25,7 @@ from schemas.dto.requests._descriptions import (
     STATS_BROWSER_DESC,
     STATS_CITY_DESC,
     STATS_COUNTRY_DESC,
+    STATS_DEVICE_DESC,
     STATS_END_DATE_DESC,
     STATS_FILTERS_DESC,
     STATS_GROUP_BY_DESC,
@@ -35,6 +36,7 @@ from schemas.dto.requests._descriptions import (
     STATS_SHORT_CODE_DESC,
     STATS_START_DATE_DESC,
     STATS_TIMEZONE_DESC,
+    STATS_UTM_DESC,
 )
 from schemas.enums.stats import (
     ALLOWED_EXPORT_FORMATS,
@@ -128,6 +130,12 @@ class StatsQuery(RequestBase):
         description=STATS_OS_DESC,
         examples=["Windows,macOS"],
     )
+    device: str | None = Field(
+        default=None,
+        max_length=200,
+        description=STATS_DEVICE_DESC,
+        examples=["mobile,desktop"],
+    )
     country: str | None = Field(
         default=None,
         max_length=1000,
@@ -145,6 +153,24 @@ class StatsQuery(RequestBase):
         max_length=2000,
         description=STATS_REFERRER_DESC,
         examples=["https://google.com,https://twitter.com"],
+    )
+    utm_source: str | None = Field(
+        default=None,
+        max_length=1000,
+        description=STATS_UTM_DESC,
+        examples=["newsletter,twitter"],
+    )
+    utm_medium: str | None = Field(
+        default=None,
+        max_length=1000,
+        description=STATS_UTM_DESC,
+        examples=["email,social"],
+    )
+    utm_campaign: str | None = Field(
+        default=None,
+        max_length=1000,
+        description=STATS_UTM_DESC,
+        examples=["summer-launch"],
     )
 
     # --- Parsed/validated results (private — not exposed as query params) ---
@@ -201,7 +227,18 @@ class StatsQuery(RequestBase):
                         parsed_filters[key] = _parse_comma_separated(value)
 
         # Individual dimension filter params
-        for dim in ("browser", "os", "country", "city", "referrer", "short_code"):
+        for dim in (
+            "browser",
+            "os",
+            "device",
+            "country",
+            "city",
+            "referrer",
+            "short_code",
+            "utm_source",
+            "utm_medium",
+            "utm_campaign",
+        ):
             raw = getattr(self, dim, None)
             if raw:
                 # short_code filter is blocked when scope=anon (bypass prevention)

--- a/schemas/dto/responses/public_stats.py
+++ b/schemas/dto/responses/public_stats.py
@@ -49,6 +49,6 @@ class PublicStatsResponse(ResponseBase):
             "The modern stats wire shape (same as GET /api/v1/stats): "
             "summary, metrics keyed '{metric}_by_{dimension}', time_range, "
             "time_bucket_info, computed_metrics. v1 links carry a "
-            "'clicks_by_bots' dimension and no 'city'; v2 the reverse."
+            "'clicks_by_bots' dimension and no 'city'/'device'; v2 the reverse."
         ),
     )

--- a/schemas/enums/stats.py
+++ b/schemas/enums/stats.py
@@ -24,10 +24,14 @@ class StatsDimension(str, Enum):
     TIME = "time"
     BROWSER = "browser"
     OS = "os"
+    DEVICE = "device"
     COUNTRY = "country"
     CITY = "city"
     REFERRER = "referrer"
     SHORT_CODE = "short_code"
+    UTM_SOURCE = "utm_source"
+    UTM_MEDIUM = "utm_medium"
+    UTM_CAMPAIGN = "utm_campaign"
 
 
 class StatsMetric(str, Enum):
@@ -53,10 +57,14 @@ ALLOWED_FILTERS = frozenset(
     {
         StatsDimension.BROWSER,
         StatsDimension.OS,
+        StatsDimension.DEVICE,
         StatsDimension.COUNTRY,
         StatsDimension.CITY,
         StatsDimension.REFERRER,
         StatsDimension.SHORT_CODE,
+        StatsDimension.UTM_SOURCE,
+        StatsDimension.UTM_MEDIUM,
+        StatsDimension.UTM_CAMPAIGN,
     }
 )
 ALLOWED_EXPORT_FORMATS = frozenset(ExportFormat)

--- a/schemas/models/click.py
+++ b/schemas/models/click.py
@@ -51,3 +51,12 @@ class ClickDoc(MongoBaseModel):
     redirect_ms: int
     referrer: str | None = None  # sanitised referrer domain, nullable
     bot_name: str | None = None  # nullable
+    # Nullable like meta.domain: clicks recorded before these fields existed
+    # keep their original shape forever (time-series buckets can't be
+    # backfilled). device is "mobile" | "tablet" | "desktop" | "unknown".
+    device: str | None = None
+    # UTM tags captured from the short link's own query string, sanitised
+    # at event construction (services.click.events).
+    utm_source: str | None = None
+    utm_medium: str | None = None
+    utm_campaign: str | None = None

--- a/services/click/consumers/stats.py
+++ b/services/click/consumers/stats.py
@@ -46,6 +46,9 @@ class StatsClickConsumer:
                 user_agent=event.user_agent,
                 referrer=event.referrer,
                 cf_city=event.cf_city,
+                utm_source=event.utm_source,
+                utm_medium=event.utm_medium,
+                utm_campaign=event.utm_campaign,
             )
         except ValidationError:
             log.info(

--- a/services/click/events.py
+++ b/services/click/events.py
@@ -20,6 +20,7 @@ introspection and future multi-event streams.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import Any
 
@@ -36,6 +37,12 @@ STREAM_FIELD_TYPE = "type"
 STREAM_FIELD_DATA = "__data__"
 EVENT_TYPE_CLICK = "click.recorded"
 _WIRE_VERSION = "1"
+
+# UTM values are visitor-controlled query-string input — bound their size so
+# a crafted link can't bloat stream payloads, and strip control characters
+# before they reach Mongo/logs.
+_UTM_MAX_LEN = 100
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 class ClickEvent(BaseModel):
@@ -59,8 +66,23 @@ class ClickEvent(BaseModel):
     # Defaults keep pre-existing stream payloads decodable.
     resolved_country: str | None = None
     geo_matched: bool = False
+    # Campaign tags from the short link's query string. Defaults keep
+    # pre-existing stream payloads decodable.
+    utm_source: str | None = None
+    utm_medium: str | None = None
+    utm_campaign: str | None = None
     redirect_ms: int
     enqueued_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @field_validator("utm_source", "utm_medium", "utm_campaign")
+    @classmethod
+    def _sanitize_utm(cls, value: str | None) -> str | None:
+        """Enforced structurally (like the password-hash strip below) so
+        every producer inherits the bound instead of remembering it."""
+        if value is None:
+            return None
+        value = _CONTROL_CHARS_RE.sub("", value).strip()[:_UTM_MAX_LEN]
+        return value or None
 
     @field_validator("url")
     @classmethod

--- a/services/click/handlers.py
+++ b/services/click/handlers.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 
 import tldextract
 from bson import ObjectId
+from ua_parser import Result
 from ua_parser import parse as ua_parse
 
 from errors import ForbiddenError, ValidationError
@@ -30,6 +31,40 @@ from services.click.protocol import ClickContext
 log = get_logger(__name__)
 
 _tld_extractor = tldextract.TLDExtract(cache_dir=None)
+
+_DESKTOP_OS_FAMILIES = frozenset(
+    {"Windows", "Mac OS X", "Linux", "Chrome OS", "Ubuntu", "Fedora"}
+)
+_MOBILE_OS_FAMILIES = frozenset({"Windows Phone", "KaiOS", "Firefox OS"})
+
+
+def classify_device(ua: Result, user_agent: str) -> str:
+    """Bucket a parsed UA into ``mobile`` / ``tablet`` / ``desktop`` / ``unknown``.
+
+    ua-parser reports device family/brand/model but deliberately no type;
+    this is the token fallback chain Matomo's DeviceDetector itself uses
+    when its model regexes don't decide. The signals survive Chrome's UA
+    reduction (the "Mobile" token and OS family are preserved; the device
+    model is frozen to "K"). Known, accepted limit: iPad Safari sends a
+    Mac UA since iPadOS 13 and lands in ``desktop`` — indistinguishable
+    server-side, counted the same way by GA4/Adobe/Matomo.
+    """
+    os_family = ua.os.family if ua.os else ""
+    device_family = ua.device.family if ua.device else ""
+    if os_family == "iOS":
+        return "tablet" if "iPad" in device_family else "mobile"
+    if os_family == "Android":
+        # Chrome on Android carries "Mobile" on phones only; tablets omit it
+        return "mobile" if "Mobile" in user_agent else "tablet"
+    if os_family in _DESKTOP_OS_FAMILIES:
+        return "desktop"
+    if os_family in _MOBILE_OS_FAMILIES:
+        return "mobile"
+    if device_family == "Generic Smartphone":
+        return "mobile"
+    if device_family == "Generic Tablet":
+        return "tablet"
+    return "unknown"
 
 
 class V2ClickHandler:
@@ -85,6 +120,7 @@ class V2ClickHandler:
 
         os_name = ua.os.family
         browser = ua.user_agent.family
+        device = classify_device(ua, user_agent)
 
         # Referrer sanitization (v2 style)
         sanitized_referrer: str | None = None
@@ -139,6 +175,10 @@ class V2ClickHandler:
             redirect_ms=redirect_ms,
             referrer=sanitized_referrer,
             bot_name=bot_name,
+            device=device,
+            utm_source=context.utm_source,
+            utm_medium=context.utm_medium,
+            utm_campaign=context.utm_campaign,
         )
 
         await self._click_repo.insert(click_doc.to_mongo())
@@ -153,6 +193,7 @@ class V2ClickHandler:
                 city=city or "Unknown",
                 browser=browser,
                 os=os_name,
+                device=device,
                 is_bot=is_bot,
                 bot_name=bot_name,
                 referrer_domain=sanitized_referrer,

--- a/services/click/protocol.py
+++ b/services/click/protocol.py
@@ -21,6 +21,11 @@ class ClickContext:
     referrer: str | None
     is_emoji: bool = False
     cf_city: str | None = None
+    # Campaign tags from the short link's query string (already sanitised
+    # by ClickEvent). Recorded by the v2 handler; legacy ignores them.
+    utm_source: str | None = None
+    utm_medium: str | None = None
+    utm_campaign: str | None = None
 
 
 class ClickHandler(Protocol):

--- a/services/click/service.py
+++ b/services/click/service.py
@@ -37,6 +37,9 @@ class ClickService:
         user_agent: str,
         referrer: str | None,
         cf_city: str | None = None,
+        utm_source: str | None = None,
+        utm_medium: str | None = None,
+        utm_campaign: str | None = None,
     ) -> None:
         """
         Dispatch click tracking to the appropriate handler.
@@ -58,5 +61,8 @@ class ClickService:
             referrer=referrer,
             is_emoji=is_emoji,
             cf_city=cf_city,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            utm_campaign=utm_campaign,
         )
         await handler.handle(context)

--- a/services/click/sinks/inline.py
+++ b/services/click/sinks/inline.py
@@ -27,4 +27,7 @@ class InlineSink:
             user_agent=event.user_agent,
             referrer=event.referrer,
             cf_city=event.cf_city,
+            utm_source=event.utm_source,
+            utm_medium=event.utm_medium,
+            utm_campaign=event.utm_campaign,
         )

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -56,9 +56,11 @@ log = get_logger(__name__)
 _PublicDoc = UrlV2Doc | LegacyUrlDoc
 
 # Dimensions are FIXED per generation (no group_by on the wire). v1 never
-# emits city (not stored); v2 never emits bots (tracked per-click, not as
-# a dimension the public page shows).
-_V2_GROUP_BY = ["time", "browser", "os", "country", "city", "referrer"]
+# emits city or device (not stored); v2 never emits bots (tracked
+# per-click, not as a dimension the public page shows). utm_* dimensions
+# are deliberately absent from BOTH: campaign tagging is the owner's
+# marketing data, never public.
+_V2_GROUP_BY = ["time", "browser", "os", "device", "country", "city", "referrer"]
 _V1_GROUP_BY = ["time", "browser", "os", "country", "referrer"]
 _METRICS = ["clicks", "unique_clicks"]
 

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -62,6 +62,16 @@ _TIMEZONE_ALIASES: dict[str, str] = {
 # this set instead.
 _KNOWN_TIMEZONES: frozenset[str] = frozenset(available_timezones())
 
+# Dimensions whose aggregation output maps null/missing to a sentinel value
+# ("Direct" referrers, "(none)" for untagged utm clicks). Filtering by the
+# sentinel must match those null/missing documents too.
+_NULL_SENTINEL_FILTERS: dict[StatsDimension, str] = {
+    StatsDimension.REFERRER: "Direct",
+    StatsDimension.UTM_SOURCE: "(none)",
+    StatsDimension.UTM_MEDIUM: "(none)",
+    StatsDimension.UTM_CAMPAIGN: "(none)",
+}
+
 
 class StatsService:
     """Analytics query service.
@@ -153,7 +163,10 @@ class StatsService:
         # Time range
         query["clicked_at"] = {"$gte": start_date, "$lte": end_date}
 
-        # Dimension filters
+        # Dimension filters. Null-sentinel dimensions build $or groups;
+        # multiple groups must nest under $and (a second bare "$or" key
+        # would overwrite the first).
+        or_groups: list[list[dict[str, Any]]] = []
         for dimension, values in filters.items():
             if not values:
                 continue
@@ -169,25 +182,25 @@ class StatsService:
                     )
                     continue
                 query["meta.short_code"] = {"$in": values}
-            elif dimension == StatsDimension.REFERRER:
-                # "Direct" means null/missing referrer
-                if "Direct" in values:
-                    non_direct = [v for v in values if v != "Direct"]
-                    if non_direct:
-                        query["$or"] = [
-                            {"referrer": {"$in": non_direct}},
-                            {"referrer": {"$in": [None, ""]}},
-                            {"referrer": {"$exists": False}},
-                        ]
-                    else:
-                        query["$or"] = [
-                            {"referrer": {"$in": [None, ""]}},
-                            {"referrer": {"$exists": False}},
-                        ]
+            elif dimension in _NULL_SENTINEL_FILTERS:
+                sentinel = _NULL_SENTINEL_FILTERS[dimension]
+                if sentinel in values:
+                    non_null = [v for v in values if v != sentinel]
+                    clauses: list[dict[str, Any]] = []
+                    if non_null:
+                        clauses.append({dimension: {"$in": non_null}})
+                    clauses.append({dimension: {"$in": [None, ""]}})
+                    clauses.append({dimension: {"$exists": False}})
+                    or_groups.append(clauses)
                 else:
-                    query["referrer"] = {"$in": values}
+                    query[dimension] = {"$in": values}
             else:
                 query[dimension] = {"$in": values}
+
+        if len(or_groups) == 1:
+            query["$or"] = or_groups[0]
+        elif or_groups:
+            query["$and"] = [{"$or": group} for group in or_groups]
 
         return query
 

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -63,10 +63,14 @@ _TIMEZONE_ALIASES: dict[str, str] = {
 _KNOWN_TIMEZONES: frozenset[str] = frozenset(available_timezones())
 
 # Dimensions whose aggregation output maps null/missing to a sentinel value
-# ("Direct" referrers, "(none)" for untagged utm clicks). Filtering by the
-# sentinel must match those null/missing documents too.
+# ("Direct" referrers, "(none)" for untagged utm clicks, "unknown" for
+# clicks that predate device tracking). Filtering by the sentinel must
+# match those null/missing documents too. Note "unknown" is ALSO a real
+# stored value (the classifier's fallback) — the filter branch keeps the
+# sentinel in its stored-value $in for exactly that reason.
 _NULL_SENTINEL_FILTERS: dict[StatsDimension, str] = {
     StatsDimension.REFERRER: "Direct",
+    StatsDimension.DEVICE: "unknown",
     StatsDimension.UTM_SOURCE: "(none)",
     StatsDimension.UTM_MEDIUM: "(none)",
     StatsDimension.UTM_CAMPAIGN: "(none)",
@@ -182,18 +186,21 @@ class StatsService:
                     )
                     continue
                 query["meta.short_code"] = {"$in": values}
-            elif dimension in _NULL_SENTINEL_FILTERS:
-                sentinel = _NULL_SENTINEL_FILTERS[dimension]
-                if sentinel in values:
-                    non_null = [v for v in values if v != sentinel]
-                    clauses: list[dict[str, Any]] = []
-                    if non_null:
-                        clauses.append({dimension: {"$in": non_null}})
-                    clauses.append({dimension: {"$in": [None, ""]}})
-                    clauses.append({dimension: {"$exists": False}})
-                    or_groups.append(clauses)
-                else:
-                    query[dimension] = {"$in": values}
+            elif (
+                dimension in _NULL_SENTINEL_FILTERS
+                and _NULL_SENTINEL_FILTERS[dimension] in values
+            ):
+                # The stored-value $in keeps the sentinel: for device,
+                # "unknown" is also a real stored value; for referrer/utm
+                # the extra literal matches nothing (and if a visitor ever
+                # sends the literal, group-by merges it with null anyway).
+                or_groups.append(
+                    [
+                        {dimension: {"$in": values}},
+                        {dimension: {"$in": [None, ""]}},
+                        {dimension: {"$exists": False}},
+                    ]
+                )
             else:
                 query[dimension] = {"$in": values}
 

--- a/shared/aggregation_strategies.py
+++ b/shared/aggregation_strategies.py
@@ -269,6 +269,17 @@ class AggregationStrategyFactory:
         "short_code": lambda: FieldAggregationStrategy(
             "$meta.short_code", "short_code", 100
         ),
+        # "(none)" = untagged clicks (and clicks recorded before the utm
+        # fields existed) — the campaign analogue of referrer's "Direct".
+        "utm_source": lambda: FieldAggregationStrategy(
+            "$utm_source", "utm_source", 50, default="(none)"
+        ),
+        "utm_medium": lambda: FieldAggregationStrategy(
+            "$utm_medium", "utm_medium", 50, default="(none)"
+        ),
+        "utm_campaign": lambda: FieldAggregationStrategy(
+            "$utm_campaign", "utm_campaign", 50, default="(none)"
+        ),
     }
 
     @classmethod

--- a/shared/aggregation_strategies.py
+++ b/shared/aggregation_strategies.py
@@ -258,7 +258,12 @@ class AggregationStrategyFactory:
     _FIELD_STRATEGIES: ClassVar[dict[str, Callable[[], AggregationStrategy]]] = {
         "browser": lambda: FieldAggregationStrategy("$browser", "browser", 20),
         "os": lambda: FieldAggregationStrategy("$os", "os", 20),
-        "device": lambda: FieldAggregationStrategy("$device", "device", 20),
+        # default matches the classifier's own fallback value so clicks
+        # recorded before device tracking existed merge into the same
+        # "unknown" bucket instead of a separate synthetic "Unknown".
+        "device": lambda: FieldAggregationStrategy(
+            "$device", "device", 20, default="unknown"
+        ),
         "country": lambda: FieldAggregationStrategy(
             "$country", "country", 50, transform_fn=convert_country_name
         ),

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -651,7 +651,15 @@ def test_v2_wire_scopes_match_by_url_id_not_short_code():
         {"country": "DE", "clicks": 10, "clicks_percentage": 100.0}
     ]
     assert stats["summary"]["total_clicks"] == 10
-    assert stats["group_by"] == ["time", "browser", "os", "country", "city", "referrer"]
+    assert stats["group_by"] == [
+        "time",
+        "browser",
+        "os",
+        "device",
+        "country",
+        "city",
+        "referrer",
+    ]
 
     # The $match is scoped by meta.url_id — never meta.short_code — so a
     # same-alias link on a custom domain can never bleed in.

--- a/tests/integration/test_redirect.py
+++ b/tests/integration/test_redirect.py
@@ -59,6 +59,57 @@ def test_redirect_v2_active_url():
     assert resp.headers["Location"] == url_data.long_url
 
 
+def test_redirect_captures_utm_params_on_click_event():
+    """utm_* query params on the short link ride the emitted ClickEvent
+    (sanitised at event construction)."""
+    url_data = _make_cache_data(schema_version="v2")
+    mock_url_svc = AsyncMock()
+    mock_url_svc.resolve = AsyncMock(return_value=(url_data, "v2"))
+    mock_click_sink = AsyncMock()
+
+    app = build_test_app(
+        redirect_router,
+        overrides={
+            get_url_service: lambda: mock_url_svc,
+            get_click_sink: lambda: mock_click_sink,
+        },
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(
+        "/abc123?utm_source=newsletter&utm_medium=email&utm_campaign=%20launch%20",
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    event = mock_click_sink.emit.call_args[0][0]
+    assert event.utm_source == "newsletter"
+    assert event.utm_medium == "email"
+    assert event.utm_campaign == "launch"  # whitespace stripped
+
+
+def test_redirect_without_utm_params_emits_none():
+    url_data = _make_cache_data(schema_version="v2")
+    mock_url_svc = AsyncMock()
+    mock_url_svc.resolve = AsyncMock(return_value=(url_data, "v2"))
+    mock_click_sink = AsyncMock()
+
+    app = build_test_app(
+        redirect_router,
+        overrides={
+            get_url_service: lambda: mock_url_svc,
+            get_click_sink: lambda: mock_click_sink,
+        },
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/abc123", follow_redirects=False)
+
+    assert resp.status_code == 302
+    event = mock_click_sink.emit.call_args[0][0]
+    assert event.utm_source is None
+    assert event.utm_medium is None
+    assert event.utm_campaign is None
+
+
 def test_redirect_v1_active_url():
     """GET /{code} for an active v1 URL -> 302."""
     url_data = _make_cache_data(schema_version="v1", alias="xYz789")

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -36,7 +36,39 @@ class TestStatsQuery:
 
     def test_invalid_group_by_rejected(self):
         with pytest.raises(ValidationError):
-            StatsQuery.model_validate({"group_by": "time,device"})
+            StatsQuery.model_validate({"group_by": "time,language"})
+
+    def test_device_and_utm_dimensions_accepted_in_group_by(self):
+        q = StatsQuery.model_validate(
+            {"group_by": "device,utm_source,utm_medium,utm_campaign"}
+        )
+        assert q.parsed_group_by == [
+            "device",
+            "utm_source",
+            "utm_medium",
+            "utm_campaign",
+        ]
+
+    def test_device_and_utm_filter_params_parsed(self):
+        q = StatsQuery.model_validate(
+            {
+                "device": "mobile,desktop",
+                "utm_source": "newsletter",
+                "utm_medium": "email,social",
+                "utm_campaign": "launch",
+            }
+        )
+        assert q.parsed_filters["device"] == ["mobile", "desktop"]
+        assert q.parsed_filters["utm_source"] == ["newsletter"]
+        assert q.parsed_filters["utm_medium"] == ["email", "social"]
+        assert q.parsed_filters["utm_campaign"] == ["launch"]
+
+    def test_device_and_utm_accepted_in_filters_json(self):
+        q = StatsQuery.model_validate(
+            {"filters": json.dumps({"device": ["mobile"], "utm_source": ["(none)"]})}
+        )
+        assert q.parsed_filters["device"] == ["mobile"]
+        assert q.parsed_filters["utm_source"] == ["(none)"]
 
     def test_comma_separated_metrics(self):
         assert StatsQuery.model_validate(

--- a/tests/unit/services/test_click_consumers.py
+++ b/tests/unit/services/test_click_consumers.py
@@ -43,6 +43,9 @@ class TestStatsClickConsumer:
             user_agent=event.user_agent,
             referrer=event.referrer,
             cf_city=event.cf_city,
+            utm_source=event.utm_source,
+            utm_medium=event.utm_medium,
+            utm_campaign=event.utm_campaign,
         )
 
     async def test_drops_undecodable_payload_without_raising(self):

--- a/tests/unit/services/test_click_events.py
+++ b/tests/unit/services/test_click_events.py
@@ -133,3 +133,53 @@ class TestGeoDecisionFields:
         restored = from_stream_fields(fields)
         assert restored.resolved_country is None
         assert restored.geo_matched is False
+
+
+class TestUtmSanitization:
+    """UTM values are visitor-controlled input — the bound is structural,
+    enforced at event construction like the password-hash strip."""
+
+    def test_defaults_when_not_stamped(self):
+        event = make_event()
+        assert event.utm_source is None
+        assert event.utm_medium is None
+        assert event.utm_campaign is None
+
+    def test_stamped_values_round_trip_through_stream(self):
+        event = make_event(
+            utm_source="newsletter", utm_medium="email", utm_campaign="launch"
+        )
+        restored = from_stream_fields(to_stream_fields(event))
+        assert restored.utm_source == "newsletter"
+        assert restored.utm_medium == "email"
+        assert restored.utm_campaign == "launch"
+
+    def test_control_characters_stripped(self):
+        event = make_event(utm_source="news\x00let\x1fter\x7f")
+        assert event.utm_source == "newsletter"
+
+    def test_value_truncated_to_bound(self):
+        event = make_event(utm_campaign="x" * 500)
+        assert len(event.utm_campaign) == 100
+
+    def test_whitespace_only_becomes_none(self):
+        event = make_event(utm_medium="   ")
+        assert event.utm_medium is None
+
+    def test_empty_string_becomes_none(self):
+        event = make_event(utm_source="")
+        assert event.utm_source is None
+
+    def test_pre_utm_stream_payload_still_parses(self):
+        import json as _json
+
+        fields = to_stream_fields(make_event())
+        data = _json.loads(fields[STREAM_FIELD_DATA])
+        for key in ("utm_source", "utm_medium", "utm_campaign"):
+            data.pop(key, None)
+        fields[STREAM_FIELD_DATA] = _json.dumps(data)
+
+        restored = from_stream_fields(fields)
+        assert restored.utm_source is None
+        assert restored.utm_medium is None
+        assert restored.utm_campaign is None

--- a/tests/unit/services/test_click_service.py
+++ b/tests/unit/services/test_click_service.py
@@ -20,11 +20,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from bson import ObjectId
+from ua_parser import parse as ua_parse
 
 from errors import ForbiddenError, ValidationError
 from infrastructure.cache.url_cache import UrlCacheData
 from schemas.models.base import ANONYMOUS_OWNER_ID
 from services.click import ClickService, LegacyClickHandler, V2ClickHandler
+from services.click.handlers import classify_device
 from services.click.protocol import ClickContext
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -150,6 +152,9 @@ def make_context(
     referrer: str | None = None,
     is_emoji: bool = False,
     cf_city: str | None = None,
+    utm_source: str | None = None,
+    utm_medium: str | None = None,
+    utm_campaign: str | None = None,
 ) -> ClickContext:
     return ClickContext(
         url_data=url_data,
@@ -160,7 +165,71 @@ def make_context(
         referrer=referrer,
         is_emoji=is_emoji,
         cf_city=cf_city,
+        utm_source=utm_source,
+        utm_medium=utm_medium,
+        utm_campaign=utm_campaign,
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestClassifyDevice
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestClassifyDevice:
+    @pytest.mark.parametrize(
+        ("user_agent", "expected"),
+        [
+            # iPhone Safari
+            (
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 "
+                "Mobile/15E148 Safari/604.1",
+                "mobile",
+            ),
+            # iPad with the pre-iPadOS-13 (non-desktop-mode) UA
+            (
+                "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 "
+                "Mobile/15E148 Safari/604.1",
+                "tablet",
+            ),
+            # Chrome on Android phone, post-UA-reduction (model frozen to "K")
+            (
+                "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36",
+                "mobile",
+            ),
+            # Chrome on Android tablet — no "Mobile" token
+            (
+                "Mozilla/5.0 (Linux; Android 13; SM-X906C) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+                "tablet",
+            ),
+            # Windows desktop
+            (NORMAL_UA, "desktop"),
+            # macOS desktop — also where iPad Safari lands since iPadOS 13
+            # (desktop-mode UA is byte-identical to a real Mac; accepted)
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 "
+                "Safari/605.1.15",
+                "desktop",
+            ),
+            # Linux desktop
+            (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+                "desktop",
+            ),
+        ],
+    )
+    def test_buckets_representative_uas(self, user_agent: str, expected: str):
+        assert classify_device(ua_parse(user_agent), user_agent) == expected
+
+    def test_unrecognized_ua_is_unknown(self):
+        ua = "SomeExoticClient/1.0"
+        assert classify_device(ua_parse(ua), ua) == "unknown"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -194,6 +263,50 @@ class TestV2ClickHandler:
         assert doc["meta"]["short_code"] == ALIAS
         assert doc["ip_address"] == CLIENT_IP
         assert doc["country"] == "United States"
+
+    @pytest.mark.asyncio
+    async def test_device_recorded_in_click_doc(self):
+        d = make_deps()
+        handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
+        url_data = make_v2_cache()
+
+        await handler.handle(make_context(url_data))  # NORMAL_UA is Windows
+
+        doc = d.click_repo.insert.call_args[0][0]
+        assert doc["device"] == "desktop"
+
+    @pytest.mark.asyncio
+    async def test_utm_tags_recorded_in_click_doc(self):
+        d = make_deps()
+        handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
+        url_data = make_v2_cache()
+
+        await handler.handle(
+            make_context(
+                url_data,
+                utm_source="newsletter",
+                utm_medium="email",
+                utm_campaign="launch",
+            )
+        )
+
+        doc = d.click_repo.insert.call_args[0][0]
+        assert doc["utm_source"] == "newsletter"
+        assert doc["utm_medium"] == "email"
+        assert doc["utm_campaign"] == "launch"
+
+    @pytest.mark.asyncio
+    async def test_utm_tags_default_to_none(self):
+        d = make_deps()
+        handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
+        url_data = make_v2_cache()
+
+        await handler.handle(make_context(url_data))
+
+        doc = d.click_repo.insert.call_args[0][0]
+        assert doc["utm_source"] is None
+        assert doc["utm_medium"] is None
+        assert doc["utm_campaign"] is None
 
     @pytest.mark.asyncio
     async def test_meta_carries_domain_from_cache(self):

--- a/tests/unit/services/test_click_sinks.py
+++ b/tests/unit/services/test_click_sinks.py
@@ -29,6 +29,9 @@ def assert_track_click_matches_event(
         user_agent=event.user_agent,
         referrer=event.referrer,
         cf_city=event.cf_city,
+        utm_source=event.utm_source,
+        utm_medium=event.utm_medium,
+        utm_campaign=event.utm_campaign,
     )
 
 

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -530,6 +530,7 @@ class TestClickQueryBuilding:
             "all", OWNER_ID, None, START, NOW, {"utm_source": ["(none)"]}
         )
         assert q["$or"] == [
+            {"utm_source": {"$in": ["(none)"]}},
             {"utm_source": {"$in": [None, ""]}},
             {"utm_source": {"$exists": False}},
         ]
@@ -541,7 +542,7 @@ class TestClickQueryBuilding:
             "all", OWNER_ID, None, START, NOW, {"utm_medium": ["(none)", "email"]}
         )
         assert q["$or"] == [
-            {"utm_medium": {"$in": ["email"]}},
+            {"utm_medium": {"$in": ["(none)", "email"]}},
             {"utm_medium": {"$in": [None, ""]}},
             {"utm_medium": {"$exists": False}},
         ]
@@ -571,3 +572,40 @@ class TestClickQueryBuilding:
         )
         assert q["device"] == {"$in": ["mobile", "tablet"]}
         assert "$in" not in str(q.get("meta.short_code", ""))
+
+    def test_device_unknown_matches_stored_and_missing(self):
+        """ "unknown" is BOTH a stored value (classifier fallback) and the
+        sentinel for pre-device-tracking clicks — the filter must match
+        both, or it disagrees with what group-by shows."""
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"device": ["unknown"]}
+        )
+        assert q["$or"] == [
+            {"device": {"$in": ["unknown"]}},
+            {"device": {"$in": [None, ""]}},
+            {"device": {"$exists": False}},
+        ]
+
+    def test_device_groupby_and_filter_agree_on_missing_docs(self):
+        """The invariant: a click doc with no device field lands in the
+        same "unknown" bucket for group-by (aggregation $ifNull default),
+        for filtering (null-sentinel map), and for new writes (classifier
+        fallback). If any of the three drifts, widget counts and filter
+        counts stop agreeing."""
+        from services.click.handlers import classify_device
+        from services.stats_service import _NULL_SENTINEL_FILTERS
+        from shared.aggregation_strategies import AggregationStrategyFactory
+
+        pipeline = AggregationStrategyFactory.get("device").build_pipeline({})
+        group_expr = pipeline[1]["$group"]["_id"]
+        assert group_expr == {"$ifNull": ["$device", "unknown"]}
+
+        from ua_parser import parse as ua_parse
+
+        classifier_fallback = classify_device(
+            ua_parse("SomeExoticClient/1.0"), "SomeExoticClient/1.0"
+        )
+        assert classifier_fallback == "unknown"
+        assert _NULL_SENTINEL_FILTERS["device"] == "unknown"

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -512,4 +512,62 @@ class TestClickQueryBuilding:
         )
         # meta.short_code must remain the locked value, not the filter value
         assert q["meta.short_code"] == "locked"
+
+    def test_plain_utm_filter_added(self):
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"utm_source": ["newsletter"]}
+        )
+        assert q["utm_source"] == {"$in": ["newsletter"]}
+
+    def test_utm_none_sentinel_matches_missing_field(self):
+        """ "(none)" must match null/missing utm values, like referrer's
+        "Direct"."""
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"utm_source": ["(none)"]}
+        )
+        assert q["$or"] == [
+            {"utm_source": {"$in": [None, ""]}},
+            {"utm_source": {"$exists": False}},
+        ]
+
+    def test_utm_sentinel_mixed_with_values(self):
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"utm_medium": ["(none)", "email"]}
+        )
+        assert q["$or"] == [
+            {"utm_medium": {"$in": ["email"]}},
+            {"utm_medium": {"$in": [None, ""]}},
+            {"utm_medium": {"$exists": False}},
+        ]
+
+    def test_two_null_sentinel_filters_nest_under_and(self):
+        """Two $or groups must combine under $and — a second bare "$or"
+        key would silently overwrite the first."""
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all",
+            OWNER_ID,
+            None,
+            START,
+            NOW,
+            {"referrer": ["Direct"], "utm_source": ["(none)"]},
+        )
+        assert "$or" not in q
+        assert len(q["$and"]) == 2
+        assert all("$or" in group for group in q["$and"])
+
+    def test_device_filter_added(self):
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"device": ["mobile", "tablet"]}
+        )
+        assert q["device"] == {"$in": ["mobile", "tablet"]}
         assert "$in" not in str(q.get("meta.short_code", ""))

--- a/tests/unit/shared/test_aggregation_strategies.py
+++ b/tests/unit/shared/test_aggregation_strategies.py
@@ -143,9 +143,14 @@ def test_referrer_pipeline_uses_direct_as_null_fallback():
     [
         ("browser", "Unknown"),
         ("os", "Unknown"),
-        ("device", "Unknown"),
+        # lowercase: must equal the classifier's own fallback so missing
+        # docs and classified-unknown docs share one bucket
+        ("device", "unknown"),
         ("country", "Unknown"),
         ("city", "Unknown"),
+        ("utm_source", "(none)"),
+        ("utm_medium", "(none)"),
+        ("utm_campaign", "(none)"),
     ],
 )
 def test_pipeline_uses_unknown_as_null_fallback(strategy_name, expected_null_fallback):

--- a/tests/unit/shared/test_aggregation_strategies.py
+++ b/tests/unit/shared/test_aggregation_strategies.py
@@ -55,6 +55,9 @@ def test_factory_get_available_strategies():
         "city",
         "referrer",
         "short_code",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
     }
 
 


### PR DESCRIPTION
Adds four new dimensions to v2 click analytics: **device**, **utm_source**, **utm_medium**, and **utm_campaign**.

## What changed

**Capture (hot path):** the redirect route now reads `utm_source`, `utm_medium` and `utm_campaign` from the short link's query string and stamps them on the `ClickEvent`. That is the only hot-path addition: three query param reads. Sanitization (control char strip, 100 char cap, empty to null) is enforced structurally by a `ClickEvent` field validator, following the same pattern as the password hash strip, so every producer inherits the bound.

**Derivation (click handler / worker):** device classification runs next to the existing UA parse in `V2ClickHandler`, so both the inline sink and the stream consumer get it with no extra parsing cost. `classify_device()` buckets into `mobile` / `tablet` / `desktop` / `unknown` using the OS family plus the Android `Mobile` token. This is the same fallback chain Matomo's DeviceDetector uses when its model regexes don't decide, and it is the approach used across the industry (ua-parser-js `device.type`, PostHog's hand rolled classifier). The signals are the ones Chrome's UA reduction deliberately preserved, so the classification is stable going forward.

**Persistence:** four new nullable fields on `ClickDoc`, same pattern as `meta.domain`: old time-series buckets keep their shape, missing values read as unknown/untagged. Legacy v1/emoji analytics are untouched.

**Stats API:** all four are now valid `group_by` dimensions and filters (both the `filters` JSON and dedicated query params). Untagged clicks aggregate under `(none)` for the UTM dimensions, mirroring referrer's `Direct`. Filtering by `(none)` matches null/missing documents; since more than one null-sentinel filter can now appear in a single query, the previous bare `$or` handling was generalized to nest multiple groups under `$and` (a second bare `$or` key would have overwritten the first). Exports (CSV/XLSX/JSON/XML) pick the new dimensions up automatically since they iterate the metrics dict.

**Public stats:** `device` joins the fixed v2 dimension set on the public per-link payload (additive key, existing consumers are unaffected). The UTM dimensions are deliberately excluded from the public payload: campaign tagging is the link owner's marketing data.

## Known limits (accepted, industry-wide)

- iPad Safari has sent a byte-identical Mac UA since iPadOS 13, so those visits land in `desktop`. This is not distinguishable server side; GA4, Adobe and Matomo count it the same way.
- Windows tablets report a stock desktop UA and land in `desktop`.

## Tests

- `classify_device` unit tests over representative UAs, including post-reduction Android (`Android 10; K`), Android tablet (no `Mobile` token), and iPad desktop mode
- UTM sanitization tests on `ClickEvent` (control chars, truncation, whitespace, pre-existing stream payload compat)
- Handler tests asserting the new `ClickDoc` fields
- Query builder tests for the `(none)` sentinel, mixed values, and the multi-group `$and` nesting
- Route-level tests asserting UTM params ride the emitted event
- Full suite green: 2667 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device classification for click analytics and public statistics.
  * Added UTM source/medium/campaign capture through redirects into click tracking.
  * Stats can now group and filter by device and UTM parameters.
* **Documentation**
  * Updated stats API descriptions and public stats dimension rules to reflect device and UTM support.
* **Bug Fixes**
  * Improved handling of “none”/missing-value filters so queries combine correctly across multiple dimensions.
  * Ensured UTM values are sanitized and stored consistently (including safe defaults when absent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->