### PR TITLE
feat: api key last_used_at and failed auth logging

### DIFF
--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -24,6 +24,7 @@ from repositories.api_key_repository import ApiKeyRepository
 from repositories.user_repository import UserRepository
 from schemas.dto.requests.api_key import ApiKeyScope
 from schemas.models.api_key import ApiKeyDoc
+from shared.datetime_utils import as_aware_utc
 
 log = get_logger(__name__)
 
@@ -96,9 +97,8 @@ async def get_current_user(
             except Exception:
                 return None
 
-            # Failed attempts log the display prefix only (same 8 chars the
-            # dashboard shows) — enough to identify the credential, useless
-            # for recovering it. Volume is bounded by the rate limiter.
+            # Failure logs carry the display prefix only — never hashes or
+            # raw key material.
             if key is None:
                 log.warning("api_key_auth_failed", reason="unknown", key_prefix=raw[:8])
                 return None
@@ -113,21 +113,16 @@ async def get_current_user(
                 return None
 
             now = datetime.now(timezone.utc)
-            if key.expires_at:
-                exp = (
-                    key.expires_at.replace(tzinfo=timezone.utc)
-                    if key.expires_at.tzinfo is None
-                    else key.expires_at
+            exp = as_aware_utc(key.expires_at)
+            if exp is not None and exp <= now:
+                log.warning(
+                    "api_key_auth_failed",
+                    reason="expired",
+                    key_prefix=key.token_prefix,
+                    key_id=str(key.id),
+                    user_id=str(key.user_id),
                 )
-                if exp <= now:
-                    log.warning(
-                        "api_key_auth_failed",
-                        reason="expired",
-                        key_prefix=key.token_prefix,
-                        key_id=str(key.id),
-                        user_id=str(key.user_id),
-                    )
-                    return None
+                return None
 
             try:
                 user = await UserRepository(db["users"]).find_by_id(key.user_id)
@@ -136,9 +131,7 @@ async def get_current_user(
 
             # Best-effort last-used stamp — debounced so a busy key costs at
             # most one extra write per hour, and never fails the request.
-            last_used = key.last_used_at
-            if last_used is not None and last_used.tzinfo is None:
-                last_used = last_used.replace(tzinfo=timezone.utc)
+            last_used = as_aware_utc(key.last_used_at)
             if last_used is None or now - last_used > _LAST_USED_DEBOUNCE:
                 try:
                     await key_repo.touch_last_used(key.id)

--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -8,7 +8,7 @@ Resolves the current user from JWT or API key, and provides guards
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
 import jwt as pyjwt
@@ -26,6 +26,10 @@ from schemas.dto.requests.api_key import ApiKeyScope
 from schemas.models.api_key import ApiKeyDoc
 
 log = get_logger(__name__)
+
+# last_used_at is stamped at most once per key per debounce window, keeping
+# the hot auth path effectively read-only.
+_LAST_USED_DEBOUNCE = timedelta(hours=1)
 
 
 @dataclass
@@ -86,12 +90,26 @@ async def get_current_user(
         if token.startswith("spoo_"):
             raw = token[len("spoo_") :]
             token_hash = hash_token(raw)
+            key_repo = ApiKeyRepository(db["api-keys"])
             try:
-                key = await ApiKeyRepository(db["api-keys"]).find_by_hash(token_hash)
+                key = await key_repo.find_by_hash(token_hash)
             except Exception:
                 return None
 
-            if key is None or key.revoked:
+            # Failed attempts log the display prefix only (same 8 chars the
+            # dashboard shows) — enough to identify the credential, useless
+            # for recovering it. Volume is bounded by the rate limiter.
+            if key is None:
+                log.warning("api_key_auth_failed", reason="unknown", key_prefix=raw[:8])
+                return None
+            if key.revoked:
+                log.warning(
+                    "api_key_auth_failed",
+                    reason="revoked",
+                    key_prefix=key.token_prefix,
+                    key_id=str(key.id),
+                    user_id=str(key.user_id),
+                )
                 return None
 
             now = datetime.now(timezone.utc)
@@ -102,12 +120,30 @@ async def get_current_user(
                     else key.expires_at
                 )
                 if exp <= now:
+                    log.warning(
+                        "api_key_auth_failed",
+                        reason="expired",
+                        key_prefix=key.token_prefix,
+                        key_id=str(key.id),
+                        user_id=str(key.user_id),
+                    )
                     return None
 
             try:
                 user = await UserRepository(db["users"]).find_by_id(key.user_id)
             except Exception:
                 return None
+
+            # Best-effort last-used stamp — debounced so a busy key costs at
+            # most one extra write per hour, and never fails the request.
+            last_used = key.last_used_at
+            if last_used is not None and last_used.tzinfo is None:
+                last_used = last_used.replace(tzinfo=timezone.utc)
+            if last_used is None or now - last_used > _LAST_USED_DEBOUNCE:
+                try:
+                    await key_repo.touch_last_used(key.id)
+                except Exception:
+                    log.warning("api_key_touch_last_used_failed", key_id=str(key.id))
 
             email_verified = user.email_verified if user else False
             structlog.contextvars.bind_contextvars(

--- a/repositories/api_key_repository.py
+++ b/repositories/api_key_repository.py
@@ -7,6 +7,8 @@ Errors are handled by BaseRepository.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from bson import ObjectId
 from pymongo.errors import PyMongoError
 
@@ -55,6 +57,13 @@ class ApiKeyRepository(BaseRepository[ApiKeyDoc]):
         return await self._update(
             {"_id": key_id, "user_id": user_id},
             {"$set": {"revoked": True}},
+        )
+
+    async def touch_last_used(self, key_id: ObjectId) -> None:
+        """Stamp last_used_at on a key. Callers debounce and treat as best-effort."""
+        await self._update(
+            {"_id": key_id},
+            {"$set": {"last_used_at": datetime.now(timezone.utc)}},
         )
 
     async def count_by_user(self, user_id: ObjectId) -> int:

--- a/routes/api_v1/keys.py
+++ b/routes/api_v1/keys.py
@@ -144,6 +144,7 @@ async def list_api_keys(
                 expires_at=to_unix_timestamp(k.expires_at),
                 revoked=k.revoked,
                 token_prefix=k.token_prefix,
+                last_used_at=to_unix_timestamp(k.last_used_at),
             )
             for k in keys
         ]

--- a/schemas/dto/responses/api_key.py
+++ b/schemas/dto/responses/api_key.py
@@ -52,6 +52,14 @@ class ApiKeyResponse(ResponseBase):
         description="First characters of the token for identification",
         examples=["spoo_abc1"],
     )
+    last_used_at: int | None = Field(
+        default=None,
+        description=(
+            "Last time this key authenticated a request, as Unix timestamp. "
+            "Null if the key has never been used. Updated at most once per hour."
+        ),
+        examples=[1704067200],
+    )
 
 
 class ApiKeyCreatedResponse(ApiKeyResponse):

--- a/schemas/models/api_key.py
+++ b/schemas/models/api_key.py
@@ -27,3 +27,6 @@ class ApiKeyDoc(MongoBaseModel):
     expires_at: datetime | None = None
     created_at: datetime | None = None
     revoked: bool = False
+    # Stamped on successful auth, debounced to at most one write per hour —
+    # accurate enough for "is this key still in use", cheap on the hot path.
+    last_used_at: datetime | None = None

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -574,7 +574,7 @@ class TestRequireKeysAccess:
 class TestApiKeyHygiene:
     """last_used_at stamping (debounced, best-effort) and failed-auth logging."""
 
-    def _mocks(self, key_doc):
+    def _mocks(self):
         settings_patch = patch(
             "dependencies.auth.get_settings", return_value=make_settings()
         )
@@ -594,7 +594,7 @@ class TestApiKeyHygiene:
     @pytest.mark.asyncio
     async def test_touch_called_when_never_used(self):
         key_doc = make_key_doc(last_used_at=None)
-        sp, kp, up = self._mocks(key_doc)
+        sp, kp, up = self._mocks()
         with sp, kp as MockKeyRepo, up as MockUserRepo:
             result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
             MockKeyRepo.return_value.touch_last_used.assert_awaited_once_with(KEY_OID)
@@ -604,7 +604,7 @@ class TestApiKeyHygiene:
     async def test_touch_debounced_when_recently_used(self):
         recent = datetime.now(timezone.utc) - timedelta(minutes=5)
         key_doc = make_key_doc(last_used_at=recent)
-        sp, kp, up = self._mocks(key_doc)
+        sp, kp, up = self._mocks()
         with sp, kp as MockKeyRepo, up as MockUserRepo:
             result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
             MockKeyRepo.return_value.touch_last_used.assert_not_awaited()
@@ -614,7 +614,7 @@ class TestApiKeyHygiene:
     async def test_touch_called_when_stale(self):
         stale = datetime.now(timezone.utc) - timedelta(hours=2)
         key_doc = make_key_doc(last_used_at=stale)
-        sp, kp, up = self._mocks(key_doc)
+        sp, kp, up = self._mocks()
         with sp, kp as MockKeyRepo, up as MockUserRepo:
             result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
             MockKeyRepo.return_value.touch_last_used.assert_awaited_once_with(KEY_OID)
@@ -626,7 +626,7 @@ class TestApiKeyHygiene:
         # must still debounce instead of raising on aware/naive subtraction.
         recent_naive = datetime.now(timezone.utc).replace(tzinfo=None)
         key_doc = make_key_doc(last_used_at=recent_naive)
-        sp, kp, up = self._mocks(key_doc)
+        sp, kp, up = self._mocks()
         with sp, kp as MockKeyRepo, up as MockUserRepo:
             result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
             MockKeyRepo.return_value.touch_last_used.assert_not_awaited()
@@ -635,7 +635,7 @@ class TestApiKeyHygiene:
     @pytest.mark.asyncio
     async def test_touch_failure_does_not_fail_auth(self):
         key_doc = make_key_doc(last_used_at=None)
-        sp, kp, up = self._mocks(key_doc)
+        sp, kp, up = self._mocks()
         with sp, kp as MockKeyRepo, up as MockUserRepo:
             MockKeyRepo.return_value.find_by_hash = AsyncMock(return_value=key_doc)
             MockKeyRepo.return_value.touch_last_used = AsyncMock(

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -58,7 +58,9 @@ def make_request(auth_header: str = "", cookies: dict | None = None):
     return req
 
 
-def make_key_doc(revoked: bool = False, expires_at=None, scopes=None):
+def make_key_doc(
+    revoked: bool = False, expires_at=None, scopes=None, last_used_at=None
+):
     return ApiKeyDoc.from_mongo(
         {
             "_id": KEY_OID,
@@ -70,6 +72,7 @@ def make_key_doc(revoked: bool = False, expires_at=None, scopes=None):
             "revoked": revoked,
             "expires_at": expires_at,
             "created_at": datetime.now(timezone.utc),
+            "last_used_at": last_used_at,
         }
     )
 
@@ -563,3 +566,144 @@ class TestRequireKeysAccess:
         )
         with pytest.raises(ForbiddenError):
             await require_keys_access(user)
+
+
+# ── TestApiKeyHygiene ────────────────────────────────────────────────────────
+
+
+class TestApiKeyHygiene:
+    """last_used_at stamping (debounced, best-effort) and failed-auth logging."""
+
+    def _mocks(self, key_doc):
+        settings_patch = patch(
+            "dependencies.auth.get_settings", return_value=make_settings()
+        )
+        key_repo_patch = patch("dependencies.auth.ApiKeyRepository")
+        user_repo_patch = patch("dependencies.auth.UserRepository")
+        return settings_patch, key_repo_patch, user_repo_patch
+
+    async def _auth(self, key_doc, MockKeyRepo, MockUserRepo):
+        MockKeyRepo.return_value.find_by_hash = AsyncMock(return_value=key_doc)
+        MockKeyRepo.return_value.touch_last_used = AsyncMock()
+        MockUserRepo.return_value.find_by_id = AsyncMock(
+            return_value=MagicMock(email_verified=True, email="o@e.com")
+        )
+        req = make_request(auth_header="Bearer spoo_testrawtoken123")
+        return await get_current_user(req, db=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_touch_called_when_never_used(self):
+        key_doc = make_key_doc(last_used_at=None)
+        sp, kp, up = self._mocks(key_doc)
+        with sp, kp as MockKeyRepo, up as MockUserRepo:
+            result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
+            MockKeyRepo.return_value.touch_last_used.assert_awaited_once_with(KEY_OID)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_touch_debounced_when_recently_used(self):
+        recent = datetime.now(timezone.utc) - timedelta(minutes=5)
+        key_doc = make_key_doc(last_used_at=recent)
+        sp, kp, up = self._mocks(key_doc)
+        with sp, kp as MockKeyRepo, up as MockUserRepo:
+            result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
+            MockKeyRepo.return_value.touch_last_used.assert_not_awaited()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_touch_called_when_stale(self):
+        stale = datetime.now(timezone.utc) - timedelta(hours=2)
+        key_doc = make_key_doc(last_used_at=stale)
+        sp, kp, up = self._mocks(key_doc)
+        with sp, kp as MockKeyRepo, up as MockUserRepo:
+            result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
+            MockKeyRepo.return_value.touch_last_used.assert_awaited_once_with(KEY_OID)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_naive_last_used_treated_as_utc(self):
+        # Mongo round-trips datetimes as naive UTC; a recent naive stamp
+        # must still debounce instead of raising on aware/naive subtraction.
+        recent_naive = datetime.now(timezone.utc).replace(tzinfo=None)
+        key_doc = make_key_doc(last_used_at=recent_naive)
+        sp, kp, up = self._mocks(key_doc)
+        with sp, kp as MockKeyRepo, up as MockUserRepo:
+            result = await self._auth(key_doc, MockKeyRepo, MockUserRepo)
+            MockKeyRepo.return_value.touch_last_used.assert_not_awaited()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_touch_failure_does_not_fail_auth(self):
+        key_doc = make_key_doc(last_used_at=None)
+        sp, kp, up = self._mocks(key_doc)
+        with sp, kp as MockKeyRepo, up as MockUserRepo:
+            MockKeyRepo.return_value.find_by_hash = AsyncMock(return_value=key_doc)
+            MockKeyRepo.return_value.touch_last_used = AsyncMock(
+                side_effect=RuntimeError("mongo down")
+            )
+            MockUserRepo.return_value.find_by_id = AsyncMock(
+                return_value=MagicMock(email_verified=True, email="o@e.com")
+            )
+            req = make_request(auth_header="Bearer spoo_testrawtoken123")
+            result = await get_current_user(req, db=MagicMock())
+        assert result is not None
+        assert result.user_id == USER_OID
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_logs_prefix_only(self):
+        with (
+            patch("dependencies.auth.get_settings", return_value=make_settings()),
+            patch("dependencies.auth.ApiKeyRepository") as MockKeyRepo,
+            patch("dependencies.auth.log") as mock_log,
+        ):
+            MockKeyRepo.return_value.find_by_hash = AsyncMock(return_value=None)
+            req = make_request(auth_header="Bearer spoo_notfoundtoken99")
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is None
+        mock_log.warning.assert_called_once_with(
+            "api_key_auth_failed", reason="unknown", key_prefix="notfound"
+        )
+
+    @pytest.mark.asyncio
+    async def test_revoked_key_logs_reason(self):
+        key_doc = make_key_doc(revoked=True)
+        with (
+            patch("dependencies.auth.get_settings", return_value=make_settings()),
+            patch("dependencies.auth.ApiKeyRepository") as MockKeyRepo,
+            patch("dependencies.auth.log") as mock_log,
+        ):
+            MockKeyRepo.return_value.find_by_hash = AsyncMock(return_value=key_doc)
+            req = make_request(auth_header="Bearer spoo_testrawtoken123")
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is None
+        mock_log.warning.assert_called_once_with(
+            "api_key_auth_failed",
+            reason="revoked",
+            key_prefix="abcd1234",
+            key_id=str(KEY_OID),
+            user_id=str(USER_OID),
+        )
+
+    @pytest.mark.asyncio
+    async def test_expired_key_logs_reason(self):
+        expired = datetime.now(timezone.utc) - timedelta(days=1)
+        key_doc = make_key_doc(expires_at=expired)
+        with (
+            patch("dependencies.auth.get_settings", return_value=make_settings()),
+            patch("dependencies.auth.ApiKeyRepository") as MockKeyRepo,
+            patch("dependencies.auth.log") as mock_log,
+        ):
+            MockKeyRepo.return_value.find_by_hash = AsyncMock(return_value=key_doc)
+            req = make_request(auth_header="Bearer spoo_testrawtoken123")
+            result = await get_current_user(req, db=MagicMock())
+
+        assert result is None
+        mock_log.warning.assert_called_once_with(
+            "api_key_auth_failed",
+            reason="expired",
+            key_prefix="abcd1234",
+            key_id=str(KEY_OID),
+            user_id=str(USER_OID),
+        )


### PR DESCRIPTION
Stacked on #265.

## What

- `last_used_at` on API key documents, stamped on successful auth and returned by `GET /api/v1/keys` as a Unix timestamp (null when never used).
- Failed API key auth is now logged as `api_key_auth_failed` with a reason (`unknown`, `revoked`, `expired`).

## Performance

The stamp is debounced: it only writes when the stored value is missing or older than one hour, so a key making 100k requests a day costs about 24 single-document writes. The write is best-effort inside a try/except; a failed or slow stamp can never fail or block authentication. The hot path stays read-only otherwise.

## Security

Failure logs carry the display prefix only (the same 8 characters the dashboard shows), never hashes or raw material. Volume is bounded upstream by the rate limiter. Revoked and expired entries include `key_id` and `user_id` so a revoked key still being retried by a forgotten script is visible and attributable.

## Notes

- `last_used_at` gives the dashboard a "never used / last used N days ago" signal, which is the piece that makes revoking old keys feel safe.
- Existing key documents simply read as null until first use after deploy.
- Unit tests cover the debounce window, naive datetime handling from Mongo, stamp failure tolerance, and all three failure reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key listings now show when each key was last used, or indicate that it has never been used.
  * API key usage timestamps are recorded automatically after successful authentication.

* **Bug Fixes**
  * Authentication remains successful even if updating usage metadata fails.
  * Improved handling of UTC timestamps and clearer diagnostics for invalid, revoked, or expired API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->