### PR TITLE
feat: carry resolved identity into request_completed logs

### DIFF
--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -152,6 +152,16 @@ async def get_current_user(
                 key_id=str(key.id),
                 key_prefix=key.token_prefix,
             )
+            # Contextvars bound here don't reach the middleware's own
+            # request_completed log call (BaseHTTPMiddleware runs the
+            # handler in a child task), so the identity is also stashed
+            # on request.state, which is shared via the ASGI scope.
+            request.state.auth_ctx = {
+                "user_id": str(key.user_id),
+                "auth_method": "api_key",
+                "key_id": str(key.id),
+                "key_prefix": key.token_prefix,
+            }
             return CurrentUser(
                 user_id=key.user_id,
                 email_verified=email_verified,
@@ -206,6 +216,11 @@ async def get_current_user(
                 else []
             )
         structlog.contextvars.bind_contextvars(user_id=str(user_id), auth_method="jwt")
+        # Same request.state stash as the API-key path — see comment there.
+        auth_ctx = {"user_id": str(user_id), "auth_method": "jwt"}
+        if claims.get("app_id") is not None:
+            auth_ctx["app_id"] = claims["app_id"]
+        request.state.auth_ctx = auth_ctx
         return CurrentUser(
             user_id=user_id,
             email_verified=email_verified,

--- a/middleware/logging.py
+++ b/middleware/logging.py
@@ -138,6 +138,12 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
                 if status >= 500
                 else (log.warning if status >= 400 else log.info)
             )
+            # Identity resolved by the auth dependency. It arrives via
+            # request.state because contextvars bound inside the handler's
+            # task don't propagate back to this dispatch context. Absent
+            # for anonymous requests and for requests rejected before auth
+            # runs (e.g. rate-limited 429s).
+            auth_ctx = getattr(request.state, "auth_ctx", None) or {}
             log_fn(
                 "request_completed",
                 status_code=status,
@@ -146,6 +152,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
                 content_type=response.headers.get("content-type"),
                 cache_status=response.headers.get("cf-cache-status"),
                 slow=duration_ms > 500,
+                **auth_ctx,
             )
 
         return response

--- a/tests/unit/middleware/test_logging.py
+++ b/tests/unit/middleware/test_logging.py
@@ -106,3 +106,57 @@ def test_auth_kind_bearer_beats_cookie():
 
 def test_auth_kind_anonymous():
     assert _auth_kind(_request()) == "anonymous"
+
+
+# ── request_completed identity via request.state.auth_ctx ───────────────────
+
+
+def _logged_kwargs(mock_log) -> dict:
+    for name in ("info", "warning", "error"):
+        calls = getattr(mock_log, name).call_args_list
+        for call in calls:
+            if call.args and call.args[0] == "request_completed":
+                return call.kwargs
+    raise AssertionError("request_completed was not logged")
+
+
+def _run_app(set_auth_ctx: bool):
+    from unittest.mock import patch
+
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from middleware.logging import RequestLoggingMiddleware
+
+    async def endpoint(request):
+        if set_auth_ctx:
+            request.state.auth_ctx = {
+                "user_id": "u1",
+                "auth_method": "api_key",
+                "key_id": "k1",
+                "key_prefix": "abcd1234",
+            }
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/x", endpoint)])
+    app.add_middleware(RequestLoggingMiddleware)
+
+    with patch("middleware.logging.log") as mock_log:
+        TestClient(app).get("/x")
+        return _logged_kwargs(mock_log)
+
+
+def test_request_completed_includes_auth_ctx():
+    kwargs = _run_app(set_auth_ctx=True)
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["auth_method"] == "api_key"
+    assert kwargs["key_id"] == "k1"
+    assert kwargs["key_prefix"] == "abcd1234"
+
+
+def test_request_completed_anonymous_has_no_identity_fields():
+    kwargs = _run_app(set_auth_ctx=False)
+    assert "user_id" not in kwargs
+    assert "auth_method" not in kwargs


### PR DESCRIPTION
Stacked on #266 (which stacks on #265).

## What

The auth dependency stashes the resolved identity (`user_id`, `auth_method`, and for API keys `key_id`/`key_prefix`, for app tokens `app_id`) on `request.state`; the request logging middleware merges it into the `request_completed` event.

## Why

`request_completed` currently carries no identity at all. The auth dependency binds structlog contextvars, but `BaseHTTPMiddleware` runs the downstream handler in a child task, so those bindings never propagate back to the middleware's dispatch context where `request_completed` is emitted. Service events get identity, the request log does not. `request.state` rides the shared ASGI scope, so it crosses that boundary.

## Performance and security

No extra queries or allocations beyond a small dict on authenticated requests. Fields match exactly what service-layer logs already carry; nothing new is exposed. Anonymous requests and requests rejected before auth runs (rate-limited 429s) are unchanged.

Unit tests cover both the authenticated and anonymous shapes of the event.