### PR TITLE
feat: persist created_via on shortened urls

### DIFF
--- a/middleware/logging.py
+++ b/middleware/logging.py
@@ -7,7 +7,6 @@ request_id without explicit parameter passing.
 
 from __future__ import annotations
 
-import re
 import time
 import uuid
 
@@ -17,6 +16,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from infrastructure.logging import get_logger, hash_ip
+from shared.client_tag import parse_client_tag
 from shared.ip_utils import get_client_ip
 
 log = get_logger("spoo.request")
@@ -24,18 +24,10 @@ log = get_logger("spoo.request")
 # Paths to skip detailed logging (high-volume, low-value)
 _SKIP_PATHS = frozenset({"/health", "/favicon.ico"})
 
-# X-Spoo-Client value: "<slug>" or "<slug>/<version>", e.g. "snap/2.1.0".
-# First-party clients send dashboard/landing/snap/raycast/cli/bot; anything
-# not matching the shape is treated as absent rather than rejected.
-_CLIENT_TAG_RE = re.compile(r"^([a-z0-9_-]{1,32})(?:/([A-Za-z0-9._-]{1,16}))?$")
-
 
 def _client_tag(request: Request) -> tuple[str | None, str | None]:
     """Parse the X-Spoo-Client header into (client, client_version)."""
-    match = _CLIENT_TAG_RE.match(request.headers.get("x-spoo-client", "").strip())
-    if match is None:
-        return None, None
-    return match.group(1), match.group(2)
+    return parse_client_tag(request.headers.get("x-spoo-client"))
 
 
 def _auth_kind(request: Request) -> str:

--- a/routes/api_v1/shorten.py
+++ b/routes/api_v1/shorten.py
@@ -30,6 +30,7 @@ from middleware.rate_limiter import Limits, dynamic_limit, limiter
 from schemas.dto.requests.url import AliasCheckQuery, CreateUrlRequest
 from schemas.dto.responses.url import AliasCheckResponse, UrlResponse
 from services.feature_flag_service import GEO_TARGETING_FLAG, META_TAGS_FLAG
+from shared.client_tag import CLIENT_TAG_HEADER, parse_client_tag
 from shared.ip_utils import get_client_ip
 
 router = APIRouter(tags=["URL Shortening"])
@@ -116,7 +117,10 @@ async def shorten_v1(
         base_url = settings.app_url
         scoped_domain = None
 
-    doc = await url_service.create(body, owner_id, client_ip, domain=scoped_domain)
+    created_via, _ = parse_client_tag(request.headers.get(CLIENT_TAG_HEADER))
+    doc = await url_service.create(
+        body, owner_id, client_ip, domain=scoped_domain, created_via=created_via
+    )
     return UrlResponse.from_doc(doc, base_url)
 
 

--- a/routes/api_v1/shorten.py
+++ b/routes/api_v1/shorten.py
@@ -30,7 +30,7 @@ from middleware.rate_limiter import Limits, dynamic_limit, limiter
 from schemas.dto.requests.url import AliasCheckQuery, CreateUrlRequest
 from schemas.dto.responses.url import AliasCheckResponse, UrlResponse
 from services.feature_flag_service import GEO_TARGETING_FLAG, META_TAGS_FLAG
-from shared.client_tag import CLIENT_TAG_HEADER, parse_client_tag
+from shared.client_tag import CLIENT_TAG_HEADER, first_party_client
 from shared.ip_utils import get_client_ip
 
 router = APIRouter(tags=["URL Shortening"])
@@ -117,7 +117,7 @@ async def shorten_v1(
         base_url = settings.app_url
         scoped_domain = None
 
-    created_via, _ = parse_client_tag(request.headers.get(CLIENT_TAG_HEADER))
+    created_via = first_party_client(request.headers.get(CLIENT_TAG_HEADER))
     doc = await url_service.create(
         body, owner_id, client_ip, domain=scoped_domain, created_via=created_via
     )

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -166,6 +166,9 @@ class UrlV2Doc(MongoBaseModel):
 
     created_at: datetime
     creation_ip: str | None = None
+    # First-party client that created the link (validated X-Spoo-Client
+    # slug, e.g. "dashboard", "snap"). None for untagged/legacy creations.
+    created_via: str | None = None
     long_url: str
     password: str | None = None
     block_bots: bool | None = None

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -166,8 +166,9 @@ class UrlV2Doc(MongoBaseModel):
 
     created_at: datetime
     creation_ip: str | None = None
-    # First-party client that created the link (validated X-Spoo-Client
-    # slug, e.g. "dashboard", "snap"). None for untagged/legacy creations.
+    # First-party client that created the link (X-Spoo-Client slug from
+    # FIRST_PARTY_CLIENTS, e.g. "dashboard", "snap"). None for untagged,
+    # unknown-client, and legacy creations.
     created_via: str | None = None
     long_url: str
     password: str | None = None

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -739,6 +739,7 @@ class UrlService:
         client_ip: str,
         *,
         domain: str | None = None,
+        created_via: str | None = None,
     ) -> UrlV2Doc:
         """
         Create a new shortened URL.
@@ -746,6 +747,10 @@ class UrlService:
         ``domain`` scopes the new URL to a tenant. None or omitted defaults to
         the system default. Callers MUST validate domain ownership + ACTIVE
         status before calling — service treats the value as opaque.
+
+        ``created_via`` is the parsed X-Spoo-Client slug (see
+        shared.client_tag) — callers pass the validated value, never the
+        raw header.
 
         Raises:
             ValidationError: URL is invalid, blocked, or field validation fails.
@@ -842,6 +847,7 @@ class UrlService:
             domain=target_domain,
             created_at=now,
             creation_ip=client_ip,
+            created_via=created_via,
             long_url=request.long_url,
             password=password_hash,
             block_bots=request.block_bots,

--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -15,6 +15,14 @@ CLIENT_TAG_HEADER = "X-Spoo-Client"
 
 _CLIENT_TAG_RE = re.compile(r"^([a-z0-9_-]{1,32})(?:/([A-Za-z0-9._-]{1,16}))?$")
 
+# Slugs sent by first-party clients. Logging accepts any shape-valid slug
+# (a new client shows up in queries without a deploy); durable persistence
+# (created_via) accepts only members, so arbitrary header values can never
+# become permanent, unfilterable document history.
+FIRST_PARTY_CLIENTS = frozenset(
+    {"dashboard", "landing", "snap", "raycast", "cli", "bot"}
+)
+
 
 def parse_client_tag(raw: str | None) -> tuple[str | None, str | None]:
     """Parse an X-Spoo-Client value into ``(client, client_version)``."""
@@ -22,3 +30,13 @@ def parse_client_tag(raw: str | None) -> tuple[str | None, str | None]:
     if match is None:
         return None, None
     return match.group(1), match.group(2)
+
+
+def first_party_client(raw: str | None) -> str | None:
+    """The parsed client slug if it names a first-party client, else None.
+
+    Use this for values that get persisted; use ``parse_client_tag`` where
+    unknown-but-well-formed slugs should still be visible (logging).
+    """
+    client, _ = parse_client_tag(raw)
+    return client if client in FIRST_PARTY_CLIENTS else None

--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -1,0 +1,24 @@
+"""
+X-Spoo-Client header parsing — shared by the logging middleware and routes.
+
+First-party clients identify themselves with ``X-Spoo-Client: <slug>`` or
+``<slug>/<version>`` (e.g. ``snap/2.1.0``). Values that do not match the
+shape are treated as absent, never rejected — the header is advisory
+telemetry, not an auth surface.
+"""
+
+from __future__ import annotations
+
+import re
+
+CLIENT_TAG_HEADER = "X-Spoo-Client"
+
+_CLIENT_TAG_RE = re.compile(r"^([a-z0-9_-]{1,32})(?:/([A-Za-z0-9._-]{1,16}))?$")
+
+
+def parse_client_tag(raw: str | None) -> tuple[str | None, str | None]:
+    """Parse an X-Spoo-Client value into ``(client, client_version)``."""
+    match = _CLIENT_TAG_RE.match((raw or "").strip())
+    if match is None:
+        return None, None
+    return match.group(1), match.group(2)

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -522,6 +522,46 @@ class TestUrlServiceCreate:
         url_repo.insert.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_create_persists_created_via(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(long_url="https://example.com")
+        result = await svc.create(
+            req, owner_id=USER_OID, client_ip="1.2.3.4", created_via="snap"
+        )
+
+        assert result.created_via == "snap"
+        inserted = url_repo.insert.call_args.args[0]
+        assert inserted["created_via"] == "snap"
+
+    @pytest.mark.asyncio
+    async def test_create_defaults_created_via_to_none(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(long_url="https://example.com")
+        result = await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        assert result.created_via is None
+
+    @pytest.mark.asyncio
     async def test_create_with_custom_alias_checks_v2_uniqueness(self):
         url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
         svc = make_service(

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -35,3 +35,23 @@ def test_parse_valid(value, expected):
 )
 def test_parse_invalid_is_absent(value):
     assert parse_client_tag(value) == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("dashboard", "dashboard"),
+        ("snap/2.1.0", "snap"),
+        ("cli", "cli"),
+        # well-formed but not first-party: logged, never persisted
+        ("whatever", None),
+        ("curl/8.0", None),
+        (None, None),
+        ("", None),
+        ("Dashboard", None),
+    ],
+)
+def test_first_party_client(value, expected):
+    from shared.client_tag import first_party_client
+
+    assert first_party_client(value) == expected

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -1,0 +1,37 @@
+"""Unit tests for shared/client_tag.py — X-Spoo-Client parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.client_tag import parse_client_tag
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("dashboard", ("dashboard", None)),
+        ("snap/2.1.0", ("snap", "2.1.0")),
+        ("cli/0.3.0-beta.1", ("cli", "0.3.0-beta.1")),
+        (" raycast ", ("raycast", None)),
+    ],
+)
+def test_parse_valid(value, expected):
+    assert parse_client_tag(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "Dashboard",
+        "a" * 33,
+        "snap/" + "1" * 17,
+        "snap/2.1.0/extra",
+        "sn ap",
+        "snap;DROP",
+    ],
+)
+def test_parse_invalid_is_absent(value):
+    assert parse_client_tag(value) == (None, None)


### PR DESCRIPTION
Stacked on #267 (chain: #265 -> #266 -> #267 -> this).

## What

- `UrlV2Doc` gains a `created_via` field storing the validated `X-Spoo-Client` slug (`dashboard`, `landing`, `snap`, `raycast`, `cli`, `bot`) at creation time. Null for untagged creations.
- The header parser moves from the logging middleware to `shared/client_tag.py` so the middleware and the shorten route share one implementation.
- `POST /api/v1/shorten` parses the header and passes the slug into `UrlService.create` as an explicit parameter.

## Why

Log-based attribution expires with log retention. Persisting provenance on the document makes "where did this link come from" queryable forever, supports per-client counts straight from Mongo, and leaves room for a created-via hint in the dashboard later.

## Security and performance

The stored value is never the raw header: it must match `^[a-z0-9_-]{1,32}$` or it is dropped to null, so arbitrary header content cannot reach the database. No extra queries; one nullable field on insert. The field is not exposed on any public response DTO.

## Notes

- Legacy routes are untouched; legacy clients never send the header.
- Existing documents read as null, no migration needed.