### PR TITLE
feat: webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,3 +131,17 @@ GITHUB_REPO="" # org/repo format
 # CLICK_EVENTS_HOT_WINDOW_SECONDS="60"
 # CLICK_EVENTS_WORKER_GROUPS='["stats", "hotness"]'  # groups THIS worker hosts
 # REDIS_QUEUE_PASSWORD=""                        # compose-level (prod redis-queue)
+
+# ── Webhooks (optional — off by default) ──────────────────────────────────────
+# Real-time event deliveries to subscriber URLs (Standard Webhooks spec).
+# Needs only Mongo to run: with the click pipeline's queue Redis present,
+# events ride streams and the worker delivers; without it, dispatch happens
+# in-process and the app runs the delivery loop itself — no extra services.
+# Access is feature-flag gated per user on top of this master switch.
+# WEBHOOKS_ENABLED="false"
+# WEBHOOKS_RUNTIME="auto"                        # auto | worker | embedded | off
+# WEBHOOKS_MAX_ENDPOINTS="5"                     # per user
+# WEBHOOKS_DELIVERY_TIMEOUT_SECONDS="15"
+# WEBHOOKS_MAX_CONSECUTIVE_FAILURES="10"         # exhausted deliveries → auto-disable
+# WEBHOOKS_DELIVERY_LOG_TTL_DAYS="30"            # events + delivery log retention
+# WEBHOOKS_MAX_PENDING_PER_ENDPOINT="1000"       # backlog cap; beyond = drop+count

--- a/app.py
+++ b/app.py
@@ -195,7 +195,7 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
                     detail="JWT_SECRET is shorter than 32 characters — consider using RS256 keys or a longer secret.",
                 )
 
-        # Embedded webhook delivery executor (TRD §5): the Mongo-only claim
+        # Embedded webhook delivery executor: the Mongo-only claim
         # loop runs here when no worker consumes — inline-rung deployments
         # keep retries/auto-disable without any extra process.
         webhook_executor_task: asyncio.Task | None = None

--- a/app.py
+++ b/app.py
@@ -5,9 +5,10 @@ create_app() is the single entry point for building the app.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 import redis.asyncio as aioredis
 import sentry_sdk
@@ -141,7 +142,10 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         )
 
         await ensure_system_default_domain(app.state.db, settings.system_default_domain)
-        await ensure_indexes(app.state.db)
+        await ensure_indexes(
+            app.state.db,
+            webhook_log_ttl_seconds=settings.webhooks.delivery_log_ttl_seconds,
+        )
 
         # App registry for the consent/apps system
         app.state.app_registry = load_app_registry()
@@ -191,9 +195,23 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
                     detail="JWT_SECRET is shorter than 32 characters — consider using RS256 keys or a longer secret.",
                 )
 
+        # Embedded webhook delivery executor (TRD §5): the Mongo-only claim
+        # loop runs here when no worker consumes — inline-rung deployments
+        # keep retries/auto-disable without any extra process.
+        webhook_executor_task: asyncio.Task | None = None
+        if getattr(app.state, "webhook_executor_embedded", False):
+            webhook_executor_task = asyncio.create_task(
+                app.state.webhook_executor.run(), name="webhook-delivery-executor"
+            )
+            log.info("webhook_executor_embedded_started")
+
         yield
 
         # ── Shutdown ─────────────────────────────────────────────────────────
+        if webhook_executor_task is not None:
+            webhook_executor_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await webhook_executor_task
         await mongo_client.close()
         if redis_client is not None:
             await redis_client.aclose()

--- a/app.py
+++ b/app.py
@@ -210,8 +210,10 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         # ── Shutdown ─────────────────────────────────────────────────────────
         if webhook_executor_task is not None:
             webhook_executor_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await webhook_executor_task
+            # Bounded: a delivery attempt mid-flight has a 15s HTTP timeout;
+            # don't let a pathological one hold the whole app shutdown.
+            with suppress(asyncio.CancelledError, asyncio.TimeoutError, TimeoutError):
+                await asyncio.wait_for(webhook_executor_task, timeout=10)
         await mongo_client.close()
         if redis_client is not None:
             await redis_client.aclose()

--- a/axiom/dashboards/spoo-webhooks.json
+++ b/axiom/dashboards/spoo-webhooks.json
@@ -1,0 +1,122 @@
+{
+  "name": "spoo · webhooks",
+  "description": "Webhook dispatch, delivery health, and endpoint lifecycle. Refresh 60s.",
+  "owner": "X-AXIOM-EVERYONE",
+  "datasets": ["spoo-prod"],
+  "refreshTime": 60,
+  "schemaVersion": 2,
+  "timeWindowStart": "qr-now-6h",
+  "timeWindowEnd": "qr-now",
+  "charts": [
+    {
+      "id": "stat-dispatched",
+      "name": "Events dispatched (6h)",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_dispatched\"\n| summarize total = count()\n| project total"
+      }
+    },
+    {
+      "id": "stat-delivered",
+      "name": "Deliveries succeeded (6h)",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivered\" and is_test != true\n| summarize total = count()\n| project total"
+      }
+    },
+    {
+      "id": "stat-delivery-success-rate",
+      "name": "Delivery success rate %",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event in (\"webhook_delivered\", \"webhook_delivery_attempt_failed\")\n| summarize total = count(), ok = countif(event == \"webhook_delivered\")\n| project rate = round(100.0 * ok / total, 2)"
+      }
+    },
+    {
+      "id": "stat-p95-delivery",
+      "name": "p95 delivery (ms)",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivered\"\n| summarize p95 = percentile(duration_ms, 95)\n| project p95"
+      }
+    },
+    {
+      "id": "ts-dispatch-by-type",
+      "name": "Dispatched by event type",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_dispatched\"\n| summarize count() by bin_auto(_time), event_type"
+      }
+    },
+    {
+      "id": "ts-delivery-outcomes",
+      "name": "Delivery attempts: ok vs failed",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event in (\"webhook_delivered\", \"webhook_delivery_attempt_failed\")\n| summarize count() by bin_auto(_time), event"
+      }
+    },
+    {
+      "id": "ts-attempt-failures-by-status",
+      "name": "Failed attempts by status code",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivery_attempt_failed\"\n| extend code = coalesce(tostring(status_code), \"transport\")\n| summarize count() by bin_auto(_time), code"
+      }
+    },
+    {
+      "id": "ts-endpoints-disabled",
+      "name": "Endpoints auto-disabled (ALERT SIGNAL)",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_endpoint_disabled\"\n| summarize count() by bin_auto(_time), reason"
+      }
+    },
+    {
+      "id": "ts-drops-over-cap",
+      "name": "Deliveries dropped over pending cap",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivery_dropped_over_cap\"\n| summarize count() by bin_auto(_time), event_type"
+      }
+    },
+    {
+      "id": "ts-pipeline-degradation",
+      "name": "Pipeline degradation (sink fallback / executor errors)",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event in (\"domain_event_sink_fallback\", \"webhook_executor_tick_failed\", \"domain_event_inline_dispatch_failed\", \"webhook_click_fanout_failed\")\n| summarize count() by bin_auto(_time), event"
+      }
+    },
+    {
+      "id": "table-slowest-endpoints",
+      "name": "Slowest endpoints (p95 ms)",
+      "type": "Table",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivered\"\n| summarize p95 = percentile(duration_ms, 95), deliveries = count() by endpoint_id\n| sort by p95 desc\n| take 10"
+      }
+    },
+    {
+      "id": "table-failing-endpoints",
+      "name": "Failing endpoints (attempts)",
+      "type": "Table",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivery_attempt_failed\"\n| summarize failures = count(), last_error = arg_max(_time, error) by endpoint_id\n| sort by failures desc\n| take 10"
+      }
+    }
+  ],
+  "layout": [
+    { "i": "stat-dispatched", "x": 0, "y": 0, "w": 3, "h": 2 },
+    { "i": "stat-delivered", "x": 3, "y": 0, "w": 3, "h": 2 },
+    { "i": "stat-delivery-success-rate", "x": 6, "y": 0, "w": 3, "h": 2 },
+    { "i": "stat-p95-delivery", "x": 9, "y": 0, "w": 3, "h": 2 },
+    { "i": "ts-dispatch-by-type", "x": 0, "y": 2, "w": 6, "h": 4 },
+    { "i": "ts-delivery-outcomes", "x": 6, "y": 2, "w": 6, "h": 4 },
+    { "i": "ts-attempt-failures-by-status", "x": 0, "y": 6, "w": 6, "h": 4 },
+    { "i": "ts-endpoints-disabled", "x": 6, "y": 6, "w": 6, "h": 4 },
+    { "i": "ts-drops-over-cap", "x": 0, "y": 10, "w": 6, "h": 4 },
+    { "i": "ts-pipeline-degradation", "x": 6, "y": 10, "w": 6, "h": 4 },
+    { "i": "table-slowest-endpoints", "x": 0, "y": 14, "w": 6, "h": 4 },
+    { "i": "table-failing-endpoints", "x": 6, "y": 14, "w": 6, "h": 4 }
+  ]
+}

--- a/config.py
+++ b/config.py
@@ -645,6 +645,10 @@ class AppSettings(BaseSettings):
             self.meta_tags = MetaTagsSettings()
         if self.webhooks is None:
             self.webhooks = WebhookSettings()
+        if self.webhooks.enabled and not self.secret_key:
+            # Signing secrets are encrypted with a key derived from
+            # SECRET_KEY; an empty master would mean a predictable key.
+            raise ValueError("SECRET_KEY must be set when WEBHOOKS_ENABLED=true")
 
         # The DCV mock makes domain verification succeed unconditionally —
         # in production that would let anyone claim any domain. Refuse to

--- a/config.py
+++ b/config.py
@@ -401,6 +401,50 @@ class MetaTagsSettings(BaseSettings):
     fetch_user_agent: str = "spoo.me-og-validator/1.0 (+https://spoo.me)"
 
 
+class WebhookSettings(BaseSettings):
+    """Webhooks system (TRD: thoughts/webhooks-system-trd.md).
+
+    Fully opt-in: ``enabled=False`` wires the NullSink and mounts nothing.
+    Fact transport rides the click pipeline's queue Redis when present and
+    degrades to inline dispatch without it; the delivery executor needs
+    only Mongo, so ``runtime`` chooses where it lives:
+
+      auto     — worker when the worker process mounts it, else embedded
+      worker   — only the click worker runs consumers + executor
+      embedded — the app process runs them as lifespan tasks
+      off      — dispatch still records nothing is running (dev/debug)
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="ignore",
+        env_prefix="WEBHOOKS_",
+    )
+
+    enabled: bool = False
+    runtime: Literal["auto", "worker", "embedded", "off"] = "auto"
+
+    max_endpoints: int = Field(default=5, ge=1)
+    delivery_timeout_seconds: float = Field(default=15.0, gt=0)
+    max_payload_bytes: int = Field(default=20_480, ge=1024)
+    max_consecutive_failures: int = Field(default=10, ge=1)
+    # Governs BOTH webhook-events and webhook-deliveries TTL indexes — a
+    # delivery must never outlive its event.
+    delivery_log_ttl_days: int = Field(default=30, ge=1)
+    # D13: dispatch-side pending cap per endpoint; beyond it deliveries are
+    # dropped-and-counted (surfaced as dropped_since_last).
+    max_pending_per_endpoint: int = Field(default=1000, ge=10)
+    executor_poll_seconds: float = Field(default=1.0, gt=0)
+    executor_lease_seconds: int = Field(default=60, ge=10)
+    # D16: owner→subscription-count cache in front of the matcher.
+    matcher_cache_ttl_seconds: int = Field(default=60, ge=5)
+    domain_stream_maxlen: int = Field(default=100_000, ge=1000)
+
+    @property
+    def delivery_log_ttl_seconds(self) -> int:
+        return self.delivery_log_ttl_days * 86_400
+
+
 class AppSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
@@ -559,6 +603,7 @@ class AppSettings(BaseSettings):
     edge_cache: EdgeCacheSettings | None = None
     r2: R2StorageSettings | None = None
     meta_tags: MetaTagsSettings | None = None
+    webhooks: WebhookSettings | None = None
 
     @model_validator(mode="after")
     def _populate_sub_configs_and_secret(self) -> AppSettings:
@@ -598,6 +643,8 @@ class AppSettings(BaseSettings):
             self.r2 = R2StorageSettings()
         if self.meta_tags is None:
             self.meta_tags = MetaTagsSettings()
+        if self.webhooks is None:
+            self.webhooks = WebhookSettings()
 
         # The DCV mock makes domain verification succeed unconditionally —
         # in production that would let anyone claim any domain. Refuse to

--- a/config.py
+++ b/config.py
@@ -402,7 +402,7 @@ class MetaTagsSettings(BaseSettings):
 
 
 class WebhookSettings(BaseSettings):
-    """Webhooks system (TRD: thoughts/webhooks-system-trd.md).
+    """Webhooks system — real-time event deliveries to subscriber URLs.
 
     Fully opt-in: ``enabled=False`` wires the NullSink and mounts nothing.
     Fact transport rides the click pipeline's queue Redis when present and
@@ -431,12 +431,12 @@ class WebhookSettings(BaseSettings):
     # Governs BOTH webhook-events and webhook-deliveries TTL indexes — a
     # delivery must never outlive its event.
     delivery_log_ttl_days: int = Field(default=30, ge=1)
-    # D13: dispatch-side pending cap per endpoint; beyond it deliveries are
+    # Dispatch-side pending cap per endpoint; beyond it deliveries are
     # dropped-and-counted (surfaced as dropped_since_last).
     max_pending_per_endpoint: int = Field(default=1000, ge=10)
     executor_poll_seconds: float = Field(default=1.0, gt=0)
     executor_lease_seconds: int = Field(default=60, ge=10)
-    # D16: owner→subscription-count cache in front of the matcher.
+    # Owner→subscription-count cache in front of the matcher.
     matcher_cache_ttl_seconds: int = Field(default=60, ge=5)
     domain_stream_maxlen: int = Field(default=100_000, ge=1000)
 

--- a/dependencies/__init__.py
+++ b/dependencies/__init__.py
@@ -73,6 +73,7 @@ from dependencies.services import (
     UrlSvc,
     UserRepo,
     VerificationSvc,
+    WebhookSvc,
     fetch_user_profile,
     get_api_key_service,
     get_app_grant_repo,
@@ -94,6 +95,7 @@ from dependencies.services import (
     get_url_service,
     get_user_repo,
     get_verification_service,
+    get_webhook_service,
 )
 
 __all__ = [
@@ -141,6 +143,7 @@ __all__ = [
     "UserRepo",
     "VerificationSvc",
     "VerifiedUser",
+    "WebhookSvc",
     "check_api_key_scope",
     "check_credential_scopes",
     # services (getters)
@@ -175,6 +178,7 @@ __all__ = [
     "get_url_service",
     "get_user_repo",
     "get_verification_service",
+    "get_webhook_service",
     "optional_scopes",
     "optional_scopes_verified",
     "require_auth",

--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -277,6 +277,15 @@ DOMAIN_READ_SCOPES: set[str] = {
     ApiKeyScope.DOMAINS_READ,
     ApiKeyScope.ADMIN_ALL,
 }
+WEBHOOKS_MANAGE_SCOPES: set[str] = {
+    ApiKeyScope.WEBHOOKS_MANAGE,
+    ApiKeyScope.ADMIN_ALL,
+}
+WEBHOOKS_READ_SCOPES: set[str] = {
+    ApiKeyScope.WEBHOOKS_MANAGE,
+    ApiKeyScope.WEBHOOKS_READ,
+    ApiKeyScope.ADMIN_ALL,
+}
 # Deliberately NOT satisfied by admin:all: API keys can hold admin:all but
 # must never manage keys, and app tokens declare keys:manage explicitly.
 KEYS_MANAGE_SCOPES: set[str] = {ApiKeyScope.KEYS_MANAGE}

--- a/dependencies/services.py
+++ b/dependencies/services.py
@@ -37,6 +37,7 @@ from services.public_stats_service import PublicStatsService
 from services.report_intake_service import ReportIntakeService
 from services.stats_service import StatsService
 from services.url_service import UrlService
+from services.webhooks.service import WebhookService
 
 
 def get_url_service(request: Request) -> UrlService:
@@ -139,6 +140,10 @@ def get_report_intake_service(request: Request) -> ReportIntakeService:
     return request.app.state.report_intake_service
 
 
+def get_webhook_service(request: Request) -> WebhookService:
+    return request.app.state.webhook_service
+
+
 # ── Annotated type aliases — Depends shortcuts for route signatures ──────────
 
 UrlSvc = Annotated[UrlService, Depends(get_url_service)]
@@ -165,3 +170,4 @@ FeatureFlagSvc = Annotated[FeatureFlagService, Depends(get_feature_flag_service)
 CustomDomainSvc = Annotated[CustomDomainService, Depends(get_custom_domain_service)]
 PublicPreviewSvc = Annotated[PublicPreviewService, Depends(get_public_preview_service)]
 ReportIntakeSvc = Annotated[ReportIntakeService, Depends(get_report_intake_service)]
+WebhookSvc = Annotated[WebhookService, Depends(get_webhook_service)]

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -448,10 +448,13 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         feature_flag_repo, feature_flag_cache
     )
 
-    # Inline rung also needs the click feed: wrap the inline click sink so
-    # link.clicked dispatch happens at emit time. Stream
-    # deployments get this from the worker's `webhooks` group instead.
-    if isinstance(app.state.domain_event_sink, InlineDomainEventSink):
+    # Whenever clicks are tracked inline, link.clicked webhooks must fan
+    # out at emit time — the worker's stream group only sees clicks that
+    # ride the stream. Keying on the CLICK sink (not the domain sink)
+    # covers both the Mongo-only rung AND the queue-Redis-present-but-
+    # CLICK_EVENTS_SINK=inline combination, which would otherwise leave
+    # click webhooks silently unfired.
+    if wh_settings.enabled and isinstance(app.state.click_sink, InlineSink):
         app.state.click_sink = WebhookFanoutClickSink(
             app.state.click_sink,
             webhook_dispatcher,

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -39,6 +39,9 @@ from repositories.report_repository import (
 from repositories.token_repository import TokenRepository
 from repositories.url_repository import UrlRepository
 from repositories.user_repository import UserRepository
+from repositories.webhook_delivery_repository import WebhookDeliveryRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from repositories.webhook_event_repository import WebhookEventRepository
 from schemas.enums.domain_status import VerificationMethod
 from services.api_key_service import ApiKeyService
 from services.auth.credentials import CredentialService
@@ -53,6 +56,11 @@ from services.click.sinks import InlineSink, RedisStreamSink
 from services.contact_service import ContactService
 from services.custom_domain_service import CustomDomainService
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
+from services.events.sinks import (
+    InlineDomainEventSink,
+    NullDomainEventSink,
+    StreamDomainEventSink,
+)
 from services.export.formatters import default_formatters
 from services.export.service import ExportService
 from services.feature_flag_service import FeatureFlagService
@@ -69,6 +77,15 @@ from services.stats_service import StatsService
 from services.tenant_resolver import CachedMongoTenantResolver
 from services.token_factory import TokenFactory
 from services.url_service import UrlService
+from services.webhooks import (
+    DeliveryExecutor,
+    OwnerSubscriptionCache,
+    SubscriptionMatcher,
+    WebhookDispatcher,
+    WebhookService,
+)
+from services.webhooks.consumers import WebhookFanoutClickSink
+from services.webhooks.renderers import default_renderers
 
 log = get_logger(__name__)
 
@@ -196,6 +213,70 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     else:
         meta_image_sink = NullMetaImageSink()
 
+    # ── Webhooks system ──────────────────────────────────────────────
+    # Built BEFORE the services so producers receive the sink at
+    # construction. Transport degrades along the opt-in ladder (TRD §5):
+    # queue Redis present → stream sink (the click worker consumes),
+    # absent → inline dispatch at emit time. The delivery executor is
+    # Mongo-only and runs embedded in this process when the runtime
+    # resolves to "embedded" (see app.py lifespan).
+    wh_settings = settings.webhooks
+    queue_redis_for_webhooks = getattr(app.state, "queue_redis", None)
+    webhook_event_repo = WebhookEventRepository(db["webhook-events"])
+    webhook_endpoint_repo = WebhookEndpointRepository(db["webhook-endpoints"])
+    webhook_delivery_repo = WebhookDeliveryRepository(db["webhook-deliveries"])
+    webhook_owner_cache = OwnerSubscriptionCache(
+        redis_client, ttl_seconds=wh_settings.matcher_cache_ttl_seconds
+    )
+    webhook_dispatcher = WebhookDispatcher(
+        SubscriptionMatcher(webhook_endpoint_repo, webhook_owner_cache),
+        webhook_event_repo,
+        webhook_delivery_repo,
+        webhook_endpoint_repo,
+        max_pending_per_endpoint=wh_settings.max_pending_per_endpoint,
+    )
+    webhook_executor = DeliveryExecutor(
+        webhook_delivery_repo,
+        webhook_endpoint_repo,
+        webhook_event_repo,
+        default_renderers(),
+        master_secret=settings.secret_key,
+        delivery_timeout=wh_settings.delivery_timeout_seconds,
+        max_payload_bytes=wh_settings.max_payload_bytes,
+        max_consecutive_failures=wh_settings.max_consecutive_failures,
+        poll_interval=wh_settings.executor_poll_seconds,
+        lease_seconds=wh_settings.executor_lease_seconds,
+    )
+    if not wh_settings.enabled:
+        app.state.domain_event_sink = NullDomainEventSink()
+    elif queue_redis_for_webhooks is not None:
+        app.state.domain_event_sink = StreamDomainEventSink(
+            queue_redis_for_webhooks,
+            fallback=InlineDomainEventSink(webhook_dispatcher),
+            maxlen=wh_settings.domain_stream_maxlen,
+        )
+        log.info("webhooks_stream_sink_enabled")
+    else:
+        app.state.domain_event_sink = InlineDomainEventSink(webhook_dispatcher)
+        log.info("webhooks_inline_sink_enabled")
+    # Embedded runtime: the executor lives in this process when webhooks
+    # are on and either explicitly requested or (auto) no worker consumes —
+    # i.e. the inline rung. app.py starts/cancels the task.
+    app.state.webhook_executor = webhook_executor
+    app.state.webhook_executor_embedded = wh_settings.enabled and (
+        wh_settings.runtime == "embedded"
+        or (wh_settings.runtime == "auto" and queue_redis_for_webhooks is None)
+    )
+    app.state.webhook_service = WebhookService(
+        webhook_endpoint_repo,
+        webhook_delivery_repo,
+        webhook_event_repo,
+        webhook_executor,
+        webhook_owner_cache,
+        master_secret=settings.secret_key,
+        max_endpoints=wh_settings.max_endpoints,
+    )
+
     # ── Services ─────────────────────────────────────────────────────────
     app.state.url_service = UrlService(
         url_repo,
@@ -217,6 +298,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         meta_image_max_bytes=r2.upload_max_bytes,
         meta_image_sink=meta_image_sink,
         meta_key_secret=settings.secret_key,
+        events=app.state.domain_event_sink,
     )
     app.state.bulk_url_service = BulkUrlService(
         url_repo,
@@ -357,6 +439,17 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         feature_flag_repo, feature_flag_cache
     )
 
+    # Inline rung also needs the click feed: wrap the inline click sink so
+    # link.clicked dispatch happens at emit time (TRD §5). Stream
+    # deployments get this from the worker's `webhooks` group instead.
+    if isinstance(app.state.domain_event_sink, InlineDomainEventSink):
+        app.state.click_sink = WebhookFanoutClickSink(
+            app.state.click_sink,
+            webhook_dispatcher,
+            app.state.geoip,
+            settings.system_default_domain,
+        )
+
     # ── Custom-domains feature ───────────────────────────────────────
     # Wired unconditionally so the data plumbing is in place even when the
     # master flag is off. Mutations short-circuit inside the service via
@@ -451,4 +544,5 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         if cd_settings.cf_zone_id and not cd_settings.mock_dcv
         else None,
         url_service=app.state.url_service,
+        events=app.state.domain_event_sink,
     )

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -309,6 +309,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         kv=edge_kv_client,
         system_default_domain=settings.system_default_domain,
         og_ttl_seconds=edge.og_ttl_seconds,
+        events=app.state.domain_event_sink,
     )
     app.state.stats_service = StatsService(
         click_repo,

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -552,5 +552,4 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         if cd_settings.cf_zone_id and not cd_settings.mock_dcv
         else None,
         url_service=app.state.url_service,
-        events=app.state.domain_event_sink,
     )

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -97,16 +97,18 @@ def build_click_service(
     emoji_repo: EmojiUrlRepository,
     geoip,
     url_cache: UrlCache,
+    events=None,
 ) -> ClickService:
     """Compose the click pipeline (schema handler registry).
 
     Single source of truth for the schema→handler mapping, shared by the
     web app (inline sink) and the click worker (stats consumer) so both
-    processes always run identical tracking logic.
+    processes always run identical tracking logic. ``events`` is the
+    domain-event sink for link.expired (max-clicks branch); None = off.
     """
     return ClickService(
         {
-            "v2": V2ClickHandler(click_repo, url_repo, geoip, url_cache),
+            "v2": V2ClickHandler(click_repo, url_repo, geoip, url_cache, events=events),
             "v1": LegacyClickHandler(legacy_repo, emoji_repo, geoip),
         }
     )
@@ -215,7 +217,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
 
     # ── Webhooks system ──────────────────────────────────────────────
     # Built BEFORE the services so producers receive the sink at
-    # construction. Transport degrades along the opt-in ladder (TRD §5):
+    # construction. Transport degrades with available infrastructure:
     # queue Redis present → stream sink (the click worker consumes),
     # absent → inline dispatch at emit time. The delivery executor is
     # Mongo-only and runs embedded in this process when the runtime
@@ -401,7 +403,13 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     )
 
     app.state.click_service = build_click_service(
-        click_repo, url_repo, legacy_repo, emoji_repo, app.state.geoip, url_cache
+        click_repo,
+        url_repo,
+        legacy_repo,
+        emoji_repo,
+        app.state.geoip,
+        url_cache,
+        events=app.state.domain_event_sink,
     )
 
     # ── Click event sink ─────────────────────────────────────────────
@@ -440,7 +448,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     )
 
     # Inline rung also needs the click feed: wrap the inline click sink so
-    # link.clicked dispatch happens at emit time (TRD §5). Stream
+    # link.clicked dispatch happens at emit time. Stream
     # deployments get this from the worker's `webhooks` group instead.
     if isinstance(app.state.domain_event_sink, InlineDomainEventSink):
         app.state.click_sink = WebhookFanoutClickSink(

--- a/infrastructure/crypto.py
+++ b/infrastructure/crypto.py
@@ -64,3 +64,32 @@ def pkce_s256_challenge(code_verifier: str) -> str:
     """
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _derive_aes_key(master: str, domain: str) -> bytes:
+    """32-byte AES key from the app master secret, domain-separated so two
+    features deriving from the same master can never share a key."""
+    return hashlib.sha256(f"{domain}:{master}".encode()).digest()
+
+
+def encrypt_secret(plaintext: str, master: str, *, domain: str) -> str:
+    """AES-GCM encrypt-at-rest for secrets the server must READ BACK
+    (webhook signing secrets — the server signs, so hash-only storage is
+    impossible). Output: base64(nonce || ciphertext)."""
+    import os as _os
+
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    nonce = _os.urandom(12)
+    ct = AESGCM(_derive_aes_key(master, domain)).encrypt(
+        nonce, plaintext.encode(), None
+    )
+    return base64.b64encode(nonce + ct).decode()
+
+
+def decrypt_secret(token: str, master: str, *, domain: str) -> str:
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    raw = base64.b64decode(token)
+    plain = AESGCM(_derive_aes_key(master, domain)).decrypt(raw[:12], raw[12:], None)
+    return plain.decode()

--- a/infrastructure/safe_fetch.py
+++ b/infrastructure/safe_fetch.py
@@ -248,6 +248,20 @@ class PostResult:
     status_code: int | None
     error: str | None
     body_snippet: str | None  # first 256 bytes, for the delivery log
+    # Parsed integer Retry-After, when the receiver sent one (429/503 flow
+    # control). HTTP-date form is not parsed — callers fall back to their
+    # own delay.
+    retry_after_seconds: float | None = None
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value.strip())
+    except ValueError:
+        return None
+    return seconds if seconds >= 0 else None
 
 
 async def post_public(
@@ -295,7 +309,12 @@ async def post_public(
                 except (asyncio.TimeoutError, TimeoutError):
                     buf = bytearray()
                 snippet = bytes(buf).decode("utf-8", errors="replace") if buf else None
-                return PostResult(resp.status_code, None, snippet)
+                return PostResult(
+                    resp.status_code,
+                    None,
+                    snippet,
+                    _parse_retry_after(resp.headers.get("retry-after")),
+                )
             finally:
                 await resp.aclose()
     except (httpx.TimeoutException, httpx.TransportError) as exc:

--- a/infrastructure/safe_fetch.py
+++ b/infrastructure/safe_fetch.py
@@ -59,10 +59,19 @@ class FetchedBody:
     final_url: str
 
 
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
 def _is_public(ip: str) -> bool:
     addr = ipaddress.ip_address(ip)
-    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
-        addr = addr.ipv4_mapped
+    if isinstance(addr, ipaddress.IPv6Address):
+        if addr.ipv4_mapped:
+            addr = addr.ipv4_mapped
+        # NAT64 (RFC 6052) reports is_global=True, but on a NAT64/DNS64
+        # host 64:ff9b::7f00:1 reaches 127.0.0.1 — reject the whole
+        # prefix; a translation address is never a legitimate target.
+        elif addr in _NAT64_PREFIX:
+            return False
     # is_global (not a flag union) catches CGNAT 100.64.0.0/10 and
     # transitional ranges the union missed; exclude multicast, which is
     # is_global=True but must never be a fetch target.
@@ -260,7 +269,9 @@ async def post_public(
         if parsed.scheme != "https":
             return PostResult(None, "non-https URL", None)
         ip = await _resolve_public_ip(parsed.host)
-    except FetchHardError as exc:
+    except (FetchHardError, FetchTransientError, httpx.InvalidURL) as exc:
+        # Transient DNS failures included: delivery outcomes are DATA for
+        # the retry ladder, never exceptions that skip attempt recording.
         return PostResult(None, str(exc), None)
 
     pinned = parsed.copy_with(host=_bracket(ip))

--- a/infrastructure/safe_fetch.py
+++ b/infrastructure/safe_fetch.py
@@ -228,3 +228,74 @@ async def fetch_public_image(
         max_redirects=max_redirects,
         user_agent=user_agent,
     )
+
+
+@dataclass(frozen=True)
+class PostResult:
+    """Outcome of a webhook-style POST. Status outcomes are DATA here
+    (the delivery executor owns retry policy) — only SSRF violations and
+    transport errors surface as fields, never exceptions."""
+
+    status_code: int | None
+    error: str | None
+    body_snippet: str | None  # first 256 bytes, for the delivery log
+
+
+async def post_public(
+    url: str,
+    body: str,
+    *,
+    headers: dict[str, str],
+    timeout: float = 15.0,
+    snippet_bytes: int = 256,
+) -> PostResult:
+    """POST *body* to *url* with the same SSRF guards as fetch_public.
+
+    No redirects are followed — a redirect defeats IP pinning, so it is
+    reported as an error outcome. Never raises: webhook delivery failure
+    is a recorded fact, not an exception path.
+    """
+    try:
+        parsed = httpx.URL(url)
+        if parsed.scheme != "https":
+            return PostResult(None, "non-https URL", None)
+        ip = await _resolve_public_ip(parsed.host)
+    except FetchHardError as exc:
+        return PostResult(None, str(exc), None)
+
+    pinned = parsed.copy_with(host=_bracket(ip))
+    try:
+        async with httpx.AsyncClient(follow_redirects=False, timeout=timeout) as client:
+            request = client.build_request(
+                "POST",
+                pinned,
+                content=body.encode(),
+                headers={"Host": parsed.host, **headers},
+                extensions={"sni_hostname": parsed.host},
+            )
+            resp = await client.send(request, stream=True)
+            try:
+                if resp.status_code in _REDIRECT_STATUSES:
+                    return PostResult(resp.status_code, "redirect not followed", None)
+                try:
+                    buf = await asyncio.wait_for(
+                        _read_body(resp, snippet_bytes, True), timeout=timeout
+                    )
+                except (asyncio.TimeoutError, TimeoutError):
+                    buf = bytearray()
+                snippet = bytes(buf).decode("utf-8", errors="replace") if buf else None
+                return PostResult(resp.status_code, None, snippet)
+            finally:
+                await resp.aclose()
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        return PostResult(None, f"{type(exc).__name__}: {exc}", None)
+
+
+async def validate_public_https_url(url: str) -> None:
+    """Creation-time gate for user-registered outbound URLs (webhook
+    endpoints): https + all resolved addresses public. Raises
+    FetchHardError with a user-safe message otherwise."""
+    parsed = httpx.URL(url)
+    if parsed.scheme != "https":
+        raise FetchHardError("URL must be https")
+    await _resolve_public_ip(parsed.host)

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -133,7 +133,7 @@ class Limits:
     REPORTS_AUTHED = "30 per minute; 500 per day"
     REPORTS_ANON = "5 per minute; 40 per day"
 
-    # Webhooks (TRD §16). Creates are tight (each one is an outbound-call
+    # Webhooks. Creates are tight (each one is an outbound-call
     # authorization); test sends bounded because each is a real signed POST
     # from our servers; the catalog is public documentation-as-API.
     WEBHOOK_CREATE = "10 per hour"

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -133,6 +133,16 @@ class Limits:
     REPORTS_AUTHED = "30 per minute; 500 per day"
     REPORTS_ANON = "5 per minute; 40 per day"
 
+    # Webhooks (TRD §16). Creates are tight (each one is an outbound-call
+    # authorization); test sends bounded because each is a real signed POST
+    # from our servers; the catalog is public documentation-as-API.
+    WEBHOOK_CREATE = "10 per hour"
+    WEBHOOK_READ = "60 per minute"
+    WEBHOOK_WRITE = "30 per minute"
+    WEBHOOK_TEST = "10 per minute"
+    WEBHOOK_RETRY = "30 per minute"
+    WEBHOOK_EVENT_TYPES = "60 per minute"
+
     # URL shortener (legacy endpoint)
     SHORTEN_LEGACY = "100 per minute"
 

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -188,7 +188,13 @@ async def _ensure_ttl_index(col, expire_after_seconds: int) -> None:
     except OperationFailure as e:
         if getattr(e, "code", None) != 85:  # IndexOptionsConflict
             raise
-        await col.drop_index("ttl_created_at")
+        try:
+            await col.drop_index("ttl_created_at")
+        except OperationFailure as drop_err:
+            # Code 27 = IndexNotFound: a racing instance (rolling deploy)
+            # already dropped it — recreating below is still correct.
+            if getattr(drop_err, "code", None) != 27:
+                raise
         await col.create_index(
             [("created_at", 1)],
             expireAfterSeconds=expire_after_seconds,

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -148,7 +148,7 @@ async def ensure_indexes(
     # ── webhooks ───────────────────────────────────────────────────────
     # webhook-events: the fact stored once (deliveries reference it).
     # Both TTLs ride the same value so a delivery can never outlive its
-    # event (TRD §11.4) — changing WEBHOOKS_DELIVERY_LOG_TTL_DAYS requires
+    # event — changing WEBHOOKS_DELIVERY_LOG_TTL_DAYS requires
     # the drop-recreate below because Mongo rejects expireAfterSeconds
     # changes on an existing TTL index.
     webhook_events_col = db["webhook-events"]

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -14,7 +14,9 @@ from infrastructure.logging import get_logger
 log = get_logger(__name__)
 
 
-async def ensure_indexes(db: AsyncDatabase) -> None:
+async def ensure_indexes(
+    db: AsyncDatabase, *, webhook_log_ttl_seconds: int = 2_592_000
+) -> None:
     users_col = db["users"]
     urls_v2_col = db["urlsV2"]
     clicks_col = db["clicks"]
@@ -143,4 +145,53 @@ async def ensure_indexes(db: AsyncDatabase) -> None:
     await custom_domains_col.create_index([("owner_id", 1), ("created_at", -1)])
     await custom_domains_col.create_index([("status", 1), ("last_verified_at", 1)])
 
+    # ── webhooks ───────────────────────────────────────────────────────
+    # webhook-events: the fact stored once (deliveries reference it).
+    # Both TTLs ride the same value so a delivery can never outlive its
+    # event (TRD §11.4) — changing WEBHOOKS_DELIVERY_LOG_TTL_DAYS requires
+    # the drop-recreate below because Mongo rejects expireAfterSeconds
+    # changes on an existing TTL index.
+    webhook_events_col = db["webhook-events"]
+    await webhook_events_col.create_index([("event_id", 1)], unique=True)
+    await webhook_events_col.create_index([("owner_id", 1), ("created_at", -1)])
+    await _ensure_ttl_index(webhook_events_col, webhook_log_ttl_seconds)
+
+    webhook_endpoints_col = db["webhook-endpoints"]
+    await webhook_endpoints_col.create_index([("user_id", 1), ("status", 1)])
+    await webhook_endpoints_col.create_index(
+        [("user_id", 1), ("events", 1), ("status", 1)], name="ix_matcher"
+    )
+
+    webhook_deliveries_col = db["webhook-deliveries"]
+    # THE claim index — the executor's whole query shape.
+    await webhook_deliveries_col.create_index(
+        [("status", 1), ("next_attempt_at", 1)], name="ix_claim"
+    )
+    await webhook_deliveries_col.create_index([("endpoint_id", 1), ("created_at", -1)])
+    await webhook_deliveries_col.create_index([("endpoint_id", 1), ("status", 1)])
+    await webhook_deliveries_col.create_index([("user_id", 1), ("created_at", -1)])
+    await webhook_deliveries_col.create_index([("webhook_id", 1)], unique=True)
+    await _ensure_ttl_index(webhook_deliveries_col, webhook_log_ttl_seconds)
+
     log.info("mongodb_indexes_ensured")
+
+
+async def _ensure_ttl_index(col, expire_after_seconds: int) -> None:
+    """Create the created_at TTL index, recreating it when the configured
+    TTL changed (Mongo rejects expireAfterSeconds edits in create_index)."""
+    try:
+        await col.create_index(
+            [("created_at", 1)],
+            expireAfterSeconds=expire_after_seconds,
+            name="ttl_created_at",
+        )
+    except OperationFailure as e:
+        if getattr(e, "code", None) != 85:  # IndexOptionsConflict
+            raise
+        await col.drop_index("ttl_created_at")
+        await col.create_index(
+            [("created_at", 1)],
+            expireAfterSeconds=expire_after_seconds,
+            name="ttl_created_at",
+        )
+        log.info("webhook_ttl_index_recreated", collection=col.name)

--- a/repositories/webhook_delivery_repository.py
+++ b/repositories/webhook_delivery_repository.py
@@ -3,7 +3,7 @@
 Owns the executor's claim semantics: ``claim_due`` is an atomic
 ``find_one_and_update`` (claim = lease via ``claimed_until``), which is
 what makes N concurrent executors safe with no scheduler infrastructure
-beyond Mongo itself (TRD §14). The claim query is stateless over
+beyond Mongo itself. The claim query is stateless over
 ``next_attempt_at``, so process restarts self-heal on the first loop.
 """
 
@@ -87,7 +87,7 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
         return WebhookDeliveryDoc.from_mongo(doc)
 
     async def set_rendered_body(self, delivery_id: ObjectId, body: str) -> None:
-        """First attempt only — the body is frozen across retries (D15)."""
+        """First attempt only — the body is frozen across retries."""
         await self._update(
             {"_id": delivery_id, "rendered_body": None},
             {"$set": {"rendered_body": body}},

--- a/repositories/webhook_delivery_repository.py
+++ b/repositories/webhook_delivery_repository.py
@@ -1,0 +1,143 @@
+"""Repository for the ``webhook-deliveries`` collection.
+
+Owns the executor's claim semantics: ``claim_due`` is an atomic
+``find_one_and_update`` (claim = lease via ``claimed_until``), which is
+what makes N concurrent executors safe with no scheduler infrastructure
+beyond Mongo itself (TRD §14). The claim query is stateless over
+``next_attempt_at``, so process restarts self-heal on the first loop.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from bson import ObjectId
+from pymongo import ReturnDocument
+
+from repositories.base import BaseRepository
+from schemas.enums.webhook import DeliveryStatus
+from schemas.models.webhook import DeliveryAttempt, WebhookDeliveryDoc
+
+
+class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
+    async def insert_many_rows(self, rows: list[dict]) -> None:
+        if not rows:
+            return
+        await self._col.insert_many(rows)
+
+    async def insert_row(self, row: dict) -> ObjectId:
+        return await self._insert(row)
+
+    async def find_by_id(self, delivery_id: ObjectId) -> WebhookDeliveryDoc | None:
+        return await self._find_one({"_id": delivery_id})
+
+    async def find_owned(
+        self, delivery_id: ObjectId, user_id: ObjectId
+    ) -> WebhookDeliveryDoc | None:
+        return await self._find_one({"_id": delivery_id, "user_id": user_id})
+
+    async def count_pending(self, endpoint_id: ObjectId) -> int:
+        return await self._count(
+            {"endpoint_id": endpoint_id, "status": DeliveryStatus.PENDING.value}
+        )
+
+    async def list_by_endpoint(
+        self,
+        endpoint_id: ObjectId,
+        *,
+        page: int,
+        page_size: int,
+        status: DeliveryStatus | None = None,
+    ) -> tuple[list[WebhookDeliveryDoc], int]:
+        query: dict = {"endpoint_id": endpoint_id}
+        if status is not None:
+            query["status"] = status.value
+        total = await self._count(query)
+        cursor = (
+            self._col.find(query)
+            .sort("created_at", -1)
+            .skip((page - 1) * page_size)
+            .limit(page_size)
+        )
+        docs = await cursor.to_list(length=page_size)
+        return [WebhookDeliveryDoc.from_mongo(d) for d in docs], total
+
+    # ── Executor surface ─────────────────────────────────────────────────
+
+    async def claim_due(self, *, lease_seconds: int = 60) -> WebhookDeliveryDoc | None:
+        """Atomically claim one due delivery, or None when nothing is due.
+
+        A crashed executor's claim expires with its lease — rows are never
+        stranded.
+        """
+        now = datetime.now(timezone.utc)
+        doc = await self._col.find_one_and_update(
+            {
+                "status": DeliveryStatus.PENDING.value,
+                "next_attempt_at": {"$lte": now},
+                "$or": [
+                    {"claimed_until": None},
+                    {"claimed_until": {"$lte": now}},
+                ],
+            },
+            {"$set": {"claimed_until": now + timedelta(seconds=lease_seconds)}},
+            sort=[("next_attempt_at", 1)],
+            return_document=ReturnDocument.AFTER,
+        )
+        return WebhookDeliveryDoc.from_mongo(doc)
+
+    async def set_rendered_body(self, delivery_id: ObjectId, body: str) -> None:
+        """First attempt only — the body is frozen across retries (D15)."""
+        await self._update(
+            {"_id": delivery_id, "rendered_body": None},
+            {"$set": {"rendered_body": body}},
+        )
+
+    async def record_attempt_and_reschedule(
+        self, delivery_id: ObjectId, attempt: DeliveryAttempt, next_attempt_at: datetime
+    ) -> None:
+        await self._update(
+            {"_id": delivery_id},
+            {
+                "$push": {"attempts": attempt.model_dump()},
+                "$inc": {"attempt_count": 1},
+                "$set": {"next_attempt_at": next_attempt_at, "claimed_until": None},
+            },
+        )
+
+    async def record_attempt_and_finish(
+        self, delivery_id: ObjectId, attempt: DeliveryAttempt, status: DeliveryStatus
+    ) -> None:
+        await self._update(
+            {"_id": delivery_id},
+            {
+                "$push": {"attempts": attempt.model_dump()},
+                "$inc": {"attempt_count": 1},
+                "$set": {
+                    "status": status.value,
+                    "completed_at": datetime.now(timezone.utc),
+                    "next_attempt_at": None,
+                    "claimed_until": None,
+                },
+            },
+        )
+
+    async def mark_failed(self, delivery_id: ObjectId, reason: str) -> None:
+        """Terminal failure without an HTTP attempt (endpoint inactive,
+        event row TTL-expired)."""
+        await self._update(
+            {"_id": delivery_id},
+            {
+                "$set": {
+                    "status": DeliveryStatus.FAILED.value,
+                    "completed_at": datetime.now(timezone.utc),
+                    "next_attempt_at": None,
+                    "claimed_until": None,
+                },
+                "$push": {
+                    "attempts": DeliveryAttempt(
+                        attempted_at=datetime.now(timezone.utc), error=reason
+                    ).model_dump()
+                },
+            },
+        )

--- a/repositories/webhook_delivery_repository.py
+++ b/repositories/webhook_delivery_repository.py
@@ -122,12 +122,27 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
             },
         )
 
+    async def defer(self, delivery_id: ObjectId, *, delay_seconds: int) -> None:
+        """Push a delivery back without recording an attempt — used while
+        its endpoint is paused. Not a retry: the ladder is untouched."""
+        await self._update(
+            {"_id": delivery_id},
+            {
+                "$set": {
+                    "next_attempt_at": datetime.now(timezone.utc)
+                    + timedelta(seconds=delay_seconds),
+                    "claimed_until": None,
+                }
+            },
+        )
+
     async def mark_failed(self, delivery_id: ObjectId, reason: str) -> None:
         """Terminal failure without an HTTP attempt (endpoint inactive,
         event row TTL-expired)."""
         await self._update(
             {"_id": delivery_id},
             {
+                "$inc": {"attempt_count": 1},
                 "$set": {
                     "status": DeliveryStatus.FAILED.value,
                     "completed_at": datetime.now(timezone.utc),

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -1,0 +1,111 @@
+"""Repository for the ``webhook-endpoints`` collection.
+
+Health counters are updated atomically here; the semantics that matter:
+``consecutive_failures`` counts EXHAUSTED deliveries (a delivery that ran
+out of retries), never individual attempts — one flaky night must not
+kill an endpoint. Success resets it and drains ``dropped_count`` (D13:
+the drained value is carried on the next delivery's envelope).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from repositories.base import BaseRepository
+from schemas.enums.webhook import EndpointDisabledReason, WebhookStatus
+from schemas.models.webhook import WebhookEndpointDoc
+
+
+class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
+    async def insert_endpoint(self, doc: WebhookEndpointDoc) -> ObjectId:
+        return await self._insert(doc.to_mongo())
+
+    async def find_by_id(self, endpoint_id: ObjectId) -> WebhookEndpointDoc | None:
+        return await self._find_one({"_id": endpoint_id})
+
+    async def find_owned(
+        self, endpoint_id: ObjectId, user_id: ObjectId
+    ) -> WebhookEndpointDoc | None:
+        return await self._find_one({"_id": endpoint_id, "user_id": user_id})
+
+    async def find_by_user(self, user_id: ObjectId) -> list[WebhookEndpointDoc]:
+        docs = await self._col.find({"user_id": user_id}).to_list(length=None)
+        return [WebhookEndpointDoc.from_mongo(d) for d in docs]
+
+    async def find_active_for_owner(
+        self, owner_id: ObjectId
+    ) -> list[WebhookEndpointDoc]:
+        docs = await self._col.find(
+            {"user_id": owner_id, "status": WebhookStatus.ACTIVE.value}
+        ).to_list(length=None)
+        return [WebhookEndpointDoc.from_mongo(d) for d in docs]
+
+    async def count_by_user(self, user_id: ObjectId) -> int:
+        return await self._count({"user_id": user_id})
+
+    async def count_active_for_owner(self, owner_id: ObjectId) -> int:
+        return await self._count(
+            {"user_id": owner_id, "status": WebhookStatus.ACTIVE.value}
+        )
+
+    async def update_fields(self, endpoint_id: ObjectId, fields: dict) -> bool:
+        fields["updated_at"] = datetime.now(timezone.utc)
+        return await self._update({"_id": endpoint_id}, {"$set": fields})
+
+    async def delete_endpoint(self, endpoint_id: ObjectId, user_id: ObjectId) -> bool:
+        return await self._delete({"_id": endpoint_id, "user_id": user_id})
+
+    # ── Health counters (executor/dispatcher side) ───────────────────────
+
+    async def record_success(self, endpoint_id: ObjectId) -> int:
+        """Reset failure streak, drain dropped_count. Returns the drained
+        dropped_count so the NEXT delivery can carry ``dropped_since_last``."""
+        now = datetime.now(timezone.utc)
+        doc = await self._col.find_one_and_update(
+            {"_id": endpoint_id},
+            {
+                "$set": {
+                    "consecutive_failures": 0,
+                    "dropped_count": 0,
+                    "last_delivery_at": now,
+                    "last_success_at": now,
+                },
+                "$inc": {"total_deliveries": 1, "total_successes": 1},
+            },
+            projection={"dropped_count": 1},
+        )
+        return int(doc.get("dropped_count", 0)) if doc else 0
+
+    async def record_exhausted(self, endpoint_id: ObjectId, reason: str) -> int:
+        """One delivery ran out of retries. Returns the new streak length."""
+        doc = await self._col.find_one_and_update(
+            {"_id": endpoint_id},
+            {
+                "$set": {
+                    "last_delivery_at": datetime.now(timezone.utc),
+                    "last_failure_reason": reason,
+                },
+                "$inc": {"total_deliveries": 1, "consecutive_failures": 1},
+            },
+            return_document=True,
+        )
+        return int(doc.get("consecutive_failures", 0)) if doc else 0
+
+    async def increment_dropped(self, endpoint_id: ObjectId) -> None:
+        await self._update({"_id": endpoint_id}, {"$inc": {"dropped_count": 1}})
+
+    async def disable(
+        self, endpoint_id: ObjectId, reason: EndpointDisabledReason
+    ) -> bool:
+        return await self._update(
+            {"_id": endpoint_id},
+            {
+                "$set": {
+                    "status": WebhookStatus.DISABLED.value,
+                    "disabled_reason": reason.value,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -72,7 +72,7 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
                     "last_delivery_at": now,
                     "last_success_at": now,
                 },
-                "$inc": {"total_deliveries": 1, "total_successes": 1},
+                "$inc": {"total_successes": 1},
             },
             projection={"dropped_count": 1},
         )
@@ -87,11 +87,17 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
                     "last_delivery_at": datetime.now(timezone.utc),
                     "last_failure_reason": reason,
                 },
-                "$inc": {"total_deliveries": 1, "consecutive_failures": 1},
+                "$inc": {"consecutive_failures": 1},
             },
             return_document=True,
         )
         return int(doc.get("consecutive_failures", 0)) if doc else 0
+
+    async def increment_deliveries(self, endpoint_id: ObjectId, by: int = 1) -> None:
+        """Counted at ENQUEUE, not at terminal state — "0 of 2" while two
+        deliveries are mid-ladder beats a "0 of 0" that contradicts the
+        visible delivery log. Success keeps its own counter."""
+        await self._update({"_id": endpoint_id}, {"$inc": {"total_deliveries": by}})
 
     async def increment_dropped(self, endpoint_id: ObjectId) -> None:
         await self._update({"_id": endpoint_id}, {"$inc": {"dropped_count": 1}})

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -3,8 +3,8 @@
 Health counters are updated atomically here; the semantics that matter:
 ``consecutive_failures`` counts EXHAUSTED deliveries (a delivery that ran
 out of retries), never individual attempts — one flaky night must not
-kill an endpoint. Success resets it and drains ``dropped_count`` (D13:
-the drained value is carried on the next delivery's envelope).
+kill an endpoint. Success resets it and drains ``dropped_count`` —
+the drained value is carried on the next delivery's envelope.
 """
 
 from __future__ import annotations

--- a/repositories/webhook_event_repository.py
+++ b/repositories/webhook_event_repository.py
@@ -1,6 +1,6 @@
 """Repository for the ``webhook-events`` collection — the fact, stored once.
 
-One row per occurrence regardless of fan-out (TRD D14). TTL-bounded via
+One row per occurrence regardless of fan-out. TTL-bounded via
 the ``created_at`` index; deliveries reference rows here by ``_id``.
 """
 

--- a/repositories/webhook_event_repository.py
+++ b/repositories/webhook_event_repository.py
@@ -1,0 +1,36 @@
+"""Repository for the ``webhook-events`` collection — the fact, stored once.
+
+One row per occurrence regardless of fan-out (TRD D14). TTL-bounded via
+the ``created_at`` index; deliveries reference rows here by ``_id``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from repositories.base import BaseRepository
+from schemas.models.webhook import WebhookEventDoc
+from services.events.contract import DomainEvent
+
+
+class WebhookEventRepository(BaseRepository[WebhookEventDoc]):
+    async def insert_event(
+        self, event: DomainEvent, *, is_test: bool = False
+    ) -> ObjectId:
+        return await self._insert(
+            {
+                "event_id": event.event_id,
+                "type": event.type,
+                "v": event.v,
+                "owner_id": ObjectId(event.owner_id),
+                "occurred_at": event.occurred_at,
+                "payload": event.data,
+                "is_test": is_test,
+                "created_at": datetime.now(timezone.utc),
+            }
+        )
+
+    async def find_by_oid(self, oid: ObjectId) -> WebhookEventDoc | None:
+        return await self._find_one({"_id": oid})

--- a/routes/api_v1/__init__.py
+++ b/routes/api_v1/__init__.py
@@ -18,6 +18,7 @@ from routes.api_v1 import (
     shorten,
     stats,
     urls,
+    webhooks,
 )
 
 router = APIRouter(prefix="/api/v1")
@@ -36,3 +37,4 @@ router.include_router(metadata.router)
 router.include_router(me.router)
 router.include_router(public_preview.router)
 router.include_router(reports.router)
+router.include_router(webhooks.router)

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -30,6 +30,7 @@ from dependencies.auth import (
     WEBHOOKS_MANAGE_SCOPES,
     WEBHOOKS_READ_SCOPES,
     CurrentUser,
+    JwtVerifiedUser,
     require_scopes_verified,
 )
 from errors import ValidationError
@@ -184,11 +185,14 @@ async def get_endpoint(
 async def reveal_secret(
     request: Request,
     endpoint_id: Annotated[str, Path()],
-    user: ManageUser,
+    user: JwtVerifiedUser,
     webhook_service: WebhookSvc,
 ) -> WebhookSecretResponse:
     """The full signing secret, for the endpoint owner. Secrets are stored
-    encrypted and readable on demand; treat the response like a password."""
+    encrypted and readable on demand; treat the response like a password.
+
+    **Authentication**: Interactive session only — API keys are refused,
+    like every operation that exposes or mints credential material."""
     secret = await webhook_service.reveal_secret(
         _oid(endpoint_id, "endpoint"), user.user_id
     )

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -9,7 +9,7 @@ POST   /api/v1/webhooks/{id}/test                        — send a sample event
 GET    /api/v1/webhooks/{id}/deliveries                  — delivery log
 POST   /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry — manual redelivery
 
-Gating (TRD §8): the `webhooks` feature flag is enforced on CREATE only —
+Gating: the `webhooks` feature flag is enforced on CREATE only —
 write-side gating; a user who loses the flag keeps managing (and pausing)
 what they already have, and stopping their deliveries is an explicit admin
 action. Flag failure is an honest 403, never a 404: the catalog endpoint

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -1,0 +1,294 @@
+"""
+POST   /api/v1/webhooks                                  — create endpoint (secret shown once)
+GET    /api/v1/webhooks                                  — list endpoints
+GET    /api/v1/webhooks/event-types                      — public event catalog
+GET    /api/v1/webhooks/{id}                             — endpoint detail
+PATCH  /api/v1/webhooks/{id}                             — update (url/events/scope/flavor/status)
+DELETE /api/v1/webhooks/{id}                             — delete
+POST   /api/v1/webhooks/{id}/test                        — send a sample event, synchronously
+GET    /api/v1/webhooks/{id}/deliveries                  — delivery log
+POST   /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry — manual redelivery
+
+Gating (TRD §8): the `webhooks` feature flag is enforced on CREATE only —
+write-side gating; a user who loses the flag keeps managing (and pausing)
+what they already have, and stopping their deliveries is an explicit admin
+action. Flag failure is an honest 403, never a 404: the catalog endpoint
+below is public documentation-as-API, so there is nothing to hide.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, Path, Query, Request
+
+from dependencies import FeatureFlagSvc, WebhookSvc
+from dependencies.auth import (
+    WEBHOOKS_MANAGE_SCOPES,
+    WEBHOOKS_READ_SCOPES,
+    CurrentUser,
+    require_scopes,
+    require_scopes_verified,
+)
+from errors import ValidationError
+from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
+from middleware.rate_limiter import Limits, limiter
+from schemas.dto.requests.webhook import (
+    CreateWebhookEndpointRequest,
+    TestWebhookRequest,
+    UpdateWebhookEndpointRequest,
+)
+from schemas.dto.responses.webhook import (
+    DeliveriesListResponse,
+    EventTypeInfoResponse,
+    EventTypesResponse,
+    WebhookDeliveryResponse,
+    WebhookEndpointCreatedResponse,
+    WebhookEndpointResponse,
+    WebhookEndpointsListResponse,
+)
+from schemas.enums.webhook import DeliveryStatus
+from services.feature_flag_service import WEBHOOKS_FLAG
+from services.webhooks.registry import EVENT_REGISTRY
+
+router = APIRouter(tags=["Webhooks"])
+
+ManageUser = Annotated[
+    CurrentUser, Depends(require_scopes_verified(WEBHOOKS_MANAGE_SCOPES))
+]
+ReadUser = Annotated[CurrentUser, Depends(require_scopes(WEBHOOKS_READ_SCOPES))]
+
+
+def _oid(value: str, what: str) -> ObjectId:
+    if not ObjectId.is_valid(value):
+        raise ValidationError(f"Invalid {what} id")
+    return ObjectId(value)
+
+
+@router.get(
+    "/webhooks/event-types",
+    operation_id="listWebhookEventTypes",
+    summary="List Webhook Event Types",
+)
+@limiter.limit(Limits.WEBHOOK_EVENT_TYPES)
+async def list_event_types(request: Request) -> EventTypesResponse:
+    """The public webhook event catalog — documentation as API.
+
+    Every subscribable event type with its category, firing frequency, and
+    an exact sample payload (the same fixture test sends deliver).
+
+    **Authentication**: None.
+    """
+    return EventTypesResponse(
+        event_types=[
+            EventTypeInfoResponse(
+                type=spec.name,
+                category=spec.category,
+                description=spec.description,
+                frequency=spec.frequency,
+                sample=spec.sample(),
+            )
+            for spec in EVENT_REGISTRY.values()
+        ]
+    )
+
+
+@router.post(
+    "/webhooks",
+    status_code=201,
+    responses=AUTH_RESPONSES,
+    operation_id="createWebhookEndpoint",
+    summary="Create Webhook Endpoint",
+)
+@limiter.limit(Limits.WEBHOOK_CREATE)
+async def create_endpoint(
+    request: Request,
+    body: CreateWebhookEndpointRequest,
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+    flag_svc: FeatureFlagSvc,
+) -> WebhookEndpointCreatedResponse:
+    """Register an HTTPS endpoint to receive event deliveries.
+
+    The `signing_secret` is returned **only in this response** — store it;
+    it is what your server uses to verify `webhook-signature` headers
+    (Standard Webhooks, HMAC-SHA256).
+
+    **Authentication**: Required (verified email). Feature-flagged.
+
+    **Rate Limits**: 10/hour
+    """
+    await flag_svc.require(WEBHOOKS_FLAG, user)
+    doc, secret = await webhook_service.create_endpoint(
+        user.user_id,
+        url=body.url,
+        events=body.events,
+        description=body.description,
+        scope_links=body.scope_links,
+        flavor=body.flavor,
+    )
+    base = WebhookEndpointResponse.from_doc(doc)
+    return WebhookEndpointCreatedResponse(**base.model_dump(), signing_secret=secret)
+
+
+@router.get(
+    "/webhooks",
+    responses=AUTH_RESPONSES,
+    operation_id="listWebhookEndpoints",
+    summary="List Webhook Endpoints",
+)
+@limiter.limit(Limits.WEBHOOK_READ)
+async def list_endpoints(
+    request: Request,
+    user: ReadUser,
+    webhook_service: WebhookSvc,
+) -> WebhookEndpointsListResponse:
+    """List all webhook endpoints on the account (secrets never included)."""
+    docs = await webhook_service.list_endpoints(user.user_id)
+    return WebhookEndpointsListResponse(
+        endpoints=[WebhookEndpointResponse.from_doc(d) for d in docs]
+    )
+
+
+@router.get(
+    "/webhooks/{endpoint_id}",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="getWebhookEndpoint",
+    summary="Get Webhook Endpoint",
+)
+@limiter.limit(Limits.WEBHOOK_READ)
+async def get_endpoint(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    user: ReadUser,
+    webhook_service: WebhookSvc,
+) -> WebhookEndpointResponse:
+    doc = await webhook_service.get_endpoint(
+        _oid(endpoint_id, "endpoint"), user.user_id
+    )
+    return WebhookEndpointResponse.from_doc(doc)
+
+
+@router.patch(
+    "/webhooks/{endpoint_id}",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="updateWebhookEndpoint",
+    summary="Update Webhook Endpoint",
+)
+@limiter.limit(Limits.WEBHOOK_WRITE)
+async def update_endpoint(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    body: UpdateWebhookEndpointRequest,
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+) -> WebhookEndpointResponse:
+    """Update url, events, scope, flavor, description, or pause/resume.
+
+    A new `url` is re-checked (https + public address) before it takes
+    effect. `status` accepts `active`/`paused`; `disabled` is system-set —
+    re-activating a disabled endpoint clears its failure bookkeeping.
+    """
+    fields = body.model_dump(exclude_unset=True)
+    doc = await webhook_service.update_endpoint(
+        _oid(endpoint_id, "endpoint"), user.user_id, fields
+    )
+    return WebhookEndpointResponse.from_doc(doc)
+
+
+@router.delete(
+    "/webhooks/{endpoint_id}",
+    status_code=204,
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="deleteWebhookEndpoint",
+    summary="Delete Webhook Endpoint",
+)
+@limiter.limit(Limits.WEBHOOK_WRITE)
+async def delete_endpoint(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+) -> None:
+    await webhook_service.delete_endpoint(_oid(endpoint_id, "endpoint"), user.user_id)
+
+
+@router.post(
+    "/webhooks/{endpoint_id}/test",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="testWebhookEndpoint",
+    summary="Send Test Event",
+)
+@limiter.limit(Limits.WEBHOOK_TEST)
+async def test_endpoint(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    body: TestWebhookRequest,
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+) -> WebhookDeliveryResponse:
+    """Send a sample of any catalog event through the real pipeline —
+    rendered in the endpoint's flavor, signed with its real secret — and
+    return the delivery outcome synchronously."""
+    row = await webhook_service.send_test(
+        _oid(endpoint_id, "endpoint"), user.user_id, body.event_type
+    )
+    return WebhookDeliveryResponse.from_doc(row)
+
+
+@router.get(
+    "/webhooks/{endpoint_id}/deliveries",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="listWebhookDeliveries",
+    summary="List Webhook Deliveries",
+)
+@limiter.limit(Limits.WEBHOOK_READ)
+async def list_deliveries(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    user: ReadUser,
+    webhook_service: WebhookSvc,
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 25,
+    status: Annotated[DeliveryStatus | None, Query()] = None,
+) -> DeliveriesListResponse:
+    """The delivery log: what was sent, when, each attempt's outcome, and
+    the exact rendered body (30-day retention)."""
+    rows, total = await webhook_service.list_deliveries(
+        _oid(endpoint_id, "endpoint"),
+        user.user_id,
+        page=page,
+        page_size=page_size,
+        status=status,
+    )
+    return DeliveriesListResponse(
+        deliveries=[WebhookDeliveryResponse.from_doc(r) for r in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.post(
+    "/webhooks/{endpoint_id}/deliveries/{delivery_id}/retry",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="retryWebhookDelivery",
+    summary="Retry Delivery",
+)
+@limiter.limit(Limits.WEBHOOK_RETRY)
+async def retry_delivery(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    delivery_id: Annotated[str, Path()],
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+) -> WebhookDeliveryResponse:
+    """Redeliver a completed delivery: same `webhook-id`, same body, fresh
+    attempt — consumers dedup on `webhook-id`."""
+    row = await webhook_service.retry_delivery(
+        _oid(endpoint_id, "endpoint"),
+        _oid(delivery_id, "delivery"),
+        user.user_id,
+    )
+    return WebhookDeliveryResponse.from_doc(row)

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -48,6 +48,7 @@ from schemas.dto.responses.webhook import (
     WebhookEndpointCreatedResponse,
     WebhookEndpointResponse,
     WebhookEndpointsListResponse,
+    WebhookSecretResponse,
 )
 from schemas.enums.webhook import DeliveryStatus
 from services.feature_flag_service import WEBHOOKS_FLAG
@@ -171,6 +172,27 @@ async def get_endpoint(
         _oid(endpoint_id, "endpoint"), user.user_id
     )
     return WebhookEndpointResponse.from_doc(doc)
+
+
+@router.get(
+    "/webhooks/{endpoint_id}/secret",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="revealWebhookSecret",
+    summary="Reveal Signing Secret",
+)
+@limiter.limit(Limits.WEBHOOK_READ)
+async def reveal_secret(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+) -> WebhookSecretResponse:
+    """The full signing secret, for the endpoint owner. Secrets are stored
+    encrypted and readable on demand; treat the response like a password."""
+    secret = await webhook_service.reveal_secret(
+        _oid(endpoint_id, "endpoint"), user.user_id
+    )
+    return WebhookSecretResponse(signing_secret=secret)
 
 
 @router.patch(

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -9,11 +9,13 @@ POST   /api/v1/webhooks/{id}/test                        — send a sample event
 GET    /api/v1/webhooks/{id}/deliveries                  — delivery log
 POST   /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry — manual redelivery
 
-Gating: the `webhooks` feature flag is enforced on CREATE only —
-write-side gating; a user who loses the flag keeps managing (and pausing)
-what they already have, and stopping their deliveries is an explicit admin
-action. Flag failure is an honest 403, never a 404: the catalog endpoint
-below is public documentation-as-API, so there is nothing to hide.
+Gating: the `webhooks` feature flag is enforced on the operations that
+INITIATE something — create, test sends, manual retries. Passive
+management (list, get, patch, delete, delivery log) stays ungated so a
+user who loses the flag keeps managing and pausing what they already
+have; stopping their background deliveries is an explicit admin action.
+Flag failure is an honest 403, never a 404: the catalog endpoint below
+is public documentation-as-API, so there is nothing to hide.
 """
 
 from __future__ import annotations
@@ -28,7 +30,6 @@ from dependencies.auth import (
     WEBHOOKS_MANAGE_SCOPES,
     WEBHOOKS_READ_SCOPES,
     CurrentUser,
-    require_scopes,
     require_scopes_verified,
 )
 from errors import ValidationError
@@ -57,7 +58,9 @@ router = APIRouter(tags=["Webhooks"])
 ManageUser = Annotated[
     CurrentUser, Depends(require_scopes_verified(WEBHOOKS_MANAGE_SCOPES))
 ]
-ReadUser = Annotated[CurrentUser, Depends(require_scopes(WEBHOOKS_READ_SCOPES))]
+ReadUser = Annotated[
+    CurrentUser, Depends(require_scopes_verified(WEBHOOKS_READ_SCOPES))
+]
 
 
 def _oid(value: str, what: str) -> ObjectId:
@@ -227,10 +230,14 @@ async def test_endpoint(
     body: TestWebhookRequest,
     user: ManageUser,
     webhook_service: WebhookSvc,
+    flag_svc: FeatureFlagSvc,
 ) -> WebhookDeliveryResponse:
     """Send a sample of any catalog event through the real pipeline —
     rendered in the endpoint's flavor, signed with its real secret — and
     return the delivery outcome synchronously."""
+    # Test sends initiate outbound calls, so they carry the same flag gate
+    # as creation; passive management of existing endpoints does not.
+    await flag_svc.require(WEBHOOKS_FLAG, user)
     row = await webhook_service.send_test(
         _oid(endpoint_id, "endpoint"), user.user_id, body.event_type
     )
@@ -283,9 +290,11 @@ async def retry_delivery(
     delivery_id: Annotated[str, Path()],
     user: ManageUser,
     webhook_service: WebhookSvc,
+    flag_svc: FeatureFlagSvc,
 ) -> WebhookDeliveryResponse:
     """Redeliver a completed delivery: same `webhook-id`, same body, fresh
     attempt — consumers dedup on `webhook-id`."""
+    await flag_svc.require(WEBHOOKS_FLAG, user)
     row = await webhook_service.retry_delivery(
         _oid(endpoint_id, "endpoint"),
         _oid(delivery_id, "delivery"),

--- a/schemas/dto/requests/api_key.py
+++ b/schemas/dto/requests/api_key.py
@@ -23,6 +23,8 @@ class ApiKeyScope(str, Enum):
     DOMAINS_MANAGE = "domains:manage"
     DOMAINS_READ = "domains:read"
     REPORTS_CREATE = "reports:create"
+    WEBHOOKS_MANAGE = "webhooks:manage"
+    WEBHOOKS_READ = "webhooks:read"
     # Grantable only via app registry entries (device auth). API keys must
     # never carry it — a key that can mint keys defeats revocation.
     KEYS_MANAGE = "keys:manage"

--- a/schemas/dto/requests/webhook.py
+++ b/schemas/dto/requests/webhook.py
@@ -1,0 +1,73 @@
+"""Request DTOs for webhook endpoint management."""
+
+from __future__ import annotations
+
+from pydantic import Field, field_validator
+
+from schemas.dto.base import RequestBase
+from schemas.enums.webhook import WebhookFlavor, WebhookStatus
+
+
+class _WebhookFieldsMixin(RequestBase):
+    @field_validator("events", check_fields=False)
+    @classmethod
+    def _events_not_empty(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None and not v:
+            raise ValueError("events must contain at least one event type or pattern")
+        return v
+
+
+class CreateWebhookEndpointRequest(_WebhookFieldsMixin):
+    url: str = Field(
+        description="HTTPS URL that receives event deliveries.",
+        examples=["https://example.com/hooks/spoo"],
+        max_length=2048,
+    )
+    events: list[str] = Field(
+        description=(
+            "Event types or patterns to subscribe to. Supports `link.*`-style "
+            "category wildcards and `*` for everything."
+        ),
+        examples=[["link.clicked", "link.expired"]],
+        min_length=1,
+        max_length=32,
+    )
+    description: str | None = Field(default=None, max_length=256)
+    scope_links: list[str] | None = Field(
+        default=None,
+        description=(
+            "Link IDs to scope deliveries to. Omit (or null) for all links, "
+            "including ones created later."
+        ),
+        max_length=256,
+    )
+    flavor: WebhookFlavor = Field(
+        default=WebhookFlavor.RAW,
+        description="Payload presentation. `raw` is the documented contract.",
+    )
+
+
+class UpdateWebhookEndpointRequest(_WebhookFieldsMixin):
+    """All fields optional; only provided fields change. `scope_links: null`
+    is 'all links' — to keep an existing scope, omit the field."""
+
+    url: str | None = Field(default=None, max_length=2048)
+    events: list[str] | None = Field(default=None, min_length=1, max_length=32)
+    description: str | None = None
+    scope_links: list[str] | None = Field(default=None, max_length=256)
+    flavor: WebhookFlavor | None = None
+    status: WebhookStatus | None = Field(
+        default=None,
+        description="`active` or `paused`. `disabled` is system-set.",
+    )
+
+
+class TestWebhookRequest(RequestBase):
+    event_type: str = Field(
+        default="webhook.test",
+        description=(
+            "Any catalog event type — its documented sample payload is sent "
+            "through the real pipeline — or `webhook.test`."
+        ),
+        examples=["link.clicked"],
+    )

--- a/schemas/dto/requests/webhook.py
+++ b/schemas/dto/requests/webhook.py
@@ -53,7 +53,7 @@ class UpdateWebhookEndpointRequest(_WebhookFieldsMixin):
 
     url: str | None = Field(default=None, max_length=2048)
     events: list[str] | None = Field(default=None, min_length=1, max_length=32)
-    description: str | None = None
+    description: str | None = Field(default=None, max_length=256)
     scope_links: list[str] | None = Field(default=None, max_length=256)
     flavor: WebhookFlavor | None = None
     status: WebhookStatus | None = Field(

--- a/schemas/dto/responses/webhook.py
+++ b/schemas/dto/responses/webhook.py
@@ -1,0 +1,151 @@
+"""Response DTOs for webhook endpoints, deliveries, and the event catalog.
+
+The signing secret appears exactly once, in WebhookEndpointCreatedResponse.
+Every other shape exposes ``signing_secret_prefix`` only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from schemas.dto.base import ResponseBase
+from schemas.enums.webhook import DeliveryStatus, WebhookFlavor, WebhookStatus
+from schemas.models.webhook import (
+    DeliveryAttempt,
+    WebhookDeliveryDoc,
+    WebhookEndpointDoc,
+)
+
+
+class WebhookEndpointResponse(ResponseBase):
+    id: str
+    url: str
+    description: str | None = None
+    events: list[str]
+    scope_links: list[str] | None = Field(
+        default=None, description="Null means all links, including future ones."
+    )
+    flavor: WebhookFlavor
+    status: WebhookStatus
+    disabled_reason: str | None = None
+    signing_secret_prefix: str
+    consecutive_failures: int
+    total_deliveries: int
+    total_successes: int
+    last_delivery_at: int | None = None
+    last_success_at: int | None = None
+    last_failure_reason: str | None = None
+    created_at: int
+
+    @classmethod
+    def from_doc(cls, doc: WebhookEndpointDoc) -> WebhookEndpointResponse:
+        return cls(
+            id=str(doc.id),
+            url=doc.url,
+            description=doc.description,
+            events=doc.events,
+            scope_links=(
+                None
+                if doc.scope.links == "all"
+                else [str(oid) for oid in doc.scope.links]
+            ),
+            flavor=doc.flavor,
+            status=doc.status,
+            disabled_reason=(
+                doc.disabled_reason.value if doc.disabled_reason else None
+            ),
+            signing_secret_prefix=doc.signing_secret_prefix,
+            consecutive_failures=doc.consecutive_failures,
+            total_deliveries=doc.total_deliveries,
+            total_successes=doc.total_successes,
+            last_delivery_at=(
+                int(doc.last_delivery_at.timestamp()) if doc.last_delivery_at else None
+            ),
+            last_success_at=(
+                int(doc.last_success_at.timestamp()) if doc.last_success_at else None
+            ),
+            last_failure_reason=doc.last_failure_reason,
+            created_at=int(doc.created_at.timestamp()) if doc.created_at else 0,
+        )
+
+
+class WebhookEndpointCreatedResponse(WebhookEndpointResponse):
+    signing_secret: str = Field(
+        description=(
+            "The full signing secret — shown ONCE, never retrievable again. "
+            "Store it; you need it to verify webhook signatures."
+        )
+    )
+
+
+class WebhookEndpointsListResponse(ResponseBase):
+    endpoints: list[WebhookEndpointResponse]
+
+
+class DeliveryAttemptResponse(ResponseBase):
+    attempted_at: int
+    status_code: int | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    response_body: str | None = None
+
+    @classmethod
+    def from_model(cls, a: DeliveryAttempt) -> DeliveryAttemptResponse:
+        return cls(
+            attempted_at=int(a.attempted_at.timestamp()),
+            status_code=a.status_code,
+            duration_ms=a.duration_ms,
+            error=a.error,
+            response_body=a.response_body,
+        )
+
+
+class WebhookDeliveryResponse(ResponseBase):
+    id: str
+    webhook_id: str
+    event_type: str
+    is_test: bool
+    status: DeliveryStatus
+    attempt_count: int
+    attempts: list[DeliveryAttemptResponse]
+    next_attempt_at: int | None = None
+    rendered_body: str | None = None
+    created_at: int
+
+    @classmethod
+    def from_doc(cls, doc: WebhookDeliveryDoc) -> WebhookDeliveryResponse:
+        return cls(
+            id=str(doc.id),
+            webhook_id=doc.webhook_id,
+            event_type=doc.event_type,
+            is_test=doc.is_test,
+            status=doc.status,
+            attempt_count=doc.attempt_count,
+            attempts=[DeliveryAttemptResponse.from_model(a) for a in doc.attempts],
+            next_attempt_at=(
+                int(doc.next_attempt_at.timestamp()) if doc.next_attempt_at else None
+            ),
+            rendered_body=doc.rendered_body,
+            created_at=int(doc.created_at.timestamp()) if doc.created_at else 0,
+        )
+
+
+class DeliveriesListResponse(ResponseBase):
+    deliveries: list[WebhookDeliveryResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class EventTypeInfoResponse(ResponseBase):
+    type: str
+    category: str
+    description: str
+    frequency: str
+    sample: dict[str, Any]
+
+
+class EventTypesResponse(ResponseBase):
+    event_types: list[EventTypeInfoResponse]

--- a/schemas/dto/responses/webhook.py
+++ b/schemas/dto/responses/webhook.py
@@ -80,6 +80,12 @@ class WebhookEndpointCreatedResponse(WebhookEndpointResponse):
     )
 
 
+class WebhookSecretResponse(ResponseBase):
+    signing_secret: str = Field(
+        description="The full signing secret, revealed to the endpoint owner."
+    )
+
+
 class WebhookEndpointsListResponse(ResponseBase):
     endpoints: list[WebhookEndpointResponse]
 

--- a/schemas/enums/webhook.py
+++ b/schemas/enums/webhook.py
@@ -28,4 +28,7 @@ class WebhookFlavor(str, Enum):
 class EndpointDisabledReason(str, Enum):
     GONE = "gone"  # endpoint returned 410
     CONSECUTIVE_FAILURES = "consecutive_failures"
+    # Stored secret no longer decrypts (master key rotated) — every future
+    # delivery would fail identically, so the endpoint is disabled loudly.
+    SECRET_UNREADABLE = "secret_unreadable"
     ADMIN = "admin"

--- a/schemas/enums/webhook.py
+++ b/schemas/enums/webhook.py
@@ -1,0 +1,31 @@
+"""Webhook system enums."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class WebhookStatus(str, Enum):
+    ACTIVE = "active"
+    PAUSED = "paused"  # user-initiated
+    DISABLED = "disabled"  # system-disabled (410 or consecutive failures) or admin
+
+
+class DeliveryStatus(str, Enum):
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class WebhookFlavor(str, Enum):
+    """Presentation of the payload — never a second schema. ``raw`` is the
+    versioned contract; other flavors are lossy renderings of it."""
+
+    RAW = "raw"
+    # Phase 2: DISCORD = "discord"; SLACK = "slack"
+
+
+class EndpointDisabledReason(str, Enum):
+    GONE = "gone"  # endpoint returned 410
+    CONSECUTIVE_FAILURES = "consecutive_failures"
+    ADMIN = "admin"

--- a/schemas/enums/webhook.py
+++ b/schemas/enums/webhook.py
@@ -22,7 +22,8 @@ class WebhookFlavor(str, Enum):
     versioned contract; other flavors are lossy renderings of it."""
 
     RAW = "raw"
-    # Phase 2: DISCORD = "discord"; SLACK = "slack"
+    DISCORD = "discord"
+    SLACK = "slack"
 
 
 class EndpointDisabledReason(str, Enum):

--- a/schemas/models/webhook.py
+++ b/schemas/models/webhook.py
@@ -1,0 +1,121 @@
+"""Webhook document models.
+
+Three collections (TRD §11):
+- ``webhook-endpoints``  — subscriptions + signing material + health
+- ``webhook-events``     — the fact, stored ONCE per occurrence (D14)
+- ``webhook-deliveries`` — thin per-endpoint delivery state referencing the event
+
+The ``whsec_…`` signing secret is shown once at creation and stored
+AES-GCM encrypted (never plaintext, never hash-only — the server signs
+with it at delivery time, so it must be readable back).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from schemas.enums.webhook import (
+    DeliveryStatus,
+    EndpointDisabledReason,
+    WebhookFlavor,
+    WebhookStatus,
+)
+from schemas.models.base import MongoBaseModel, PyObjectId
+
+
+class WebhookScope(BaseModel):
+    """Subscription scope. ``links: "all"`` is the absence of a filter —
+    live, includes future links. Object (not a bare list) so ``groups``
+    slots in when Link Groups land. Stale link ids are inert."""
+
+    links: Literal["all"] | list[PyObjectId] = "all"
+
+    def matches_link(self, link_id: PyObjectId | None) -> bool:
+        if self.links == "all":
+            return True
+        return link_id is not None and link_id in self.links
+
+
+class WebhookEndpointDoc(MongoBaseModel):
+    """Document model for the ``webhook-endpoints`` collection."""
+
+    user_id: PyObjectId
+    url: str
+    description: str | None = None
+    events: list[str] = []  # noqa: RUF012 — patterns, stored verbatim; expanded at match time
+    scope: WebhookScope = WebhookScope()
+    flavor: WebhookFlavor = WebhookFlavor.RAW
+    status: WebhookStatus = WebhookStatus.ACTIVE
+    disabled_reason: EndpointDisabledReason | None = None
+
+    # AES-GCM encrypted at rest (infrastructure/crypto.py) — NOT hashed:
+    # the server SIGNS with this secret at delivery time, so it must be
+    # readable back. Prefix stored separately for display.
+    signing_secret_enc: str = ""
+    signing_secret_prefix: str = ""
+    previous_secret_enc: str | None = None
+    previous_secret_expires_at: datetime | None = None
+
+    # Health (denormalized; counters updated atomically by the repository).
+    # consecutive_failures counts EXHAUSTED deliveries, not attempts.
+    consecutive_failures: int = 0
+    dropped_count: int = 0  # D13 pending-cap drops since last successful delivery
+    total_deliveries: int = 0
+    total_successes: int = 0
+    last_delivery_at: datetime | None = None
+    last_success_at: datetime | None = None
+    last_failure_reason: str | None = None
+
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class WebhookEventDoc(MongoBaseModel):
+    """Document model for the ``webhook-events`` collection — one row per
+    fact regardless of fan-out (D14). TTL-bounded (§11.4)."""
+
+    event_id: str  # evt_…
+    type: str
+    v: int = 1
+    owner_id: PyObjectId
+    occurred_at: datetime
+    payload: dict[str, Any]
+    is_test: bool = False
+    created_at: datetime | None = None  # TTL anchor
+
+
+class DeliveryAttempt(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    attempted_at: datetime
+    status_code: int | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    response_body: str | None = None  # first 256 bytes
+
+
+class WebhookDeliveryDoc(MongoBaseModel):
+    """Document model for the ``webhook-deliveries`` collection.
+
+    Thin per-endpoint state: payload lives on the event row; the rendered
+    body is set at FIRST attempt (D15) and frozen across retries so
+    consumers can dedup on ``webhook_id`` against identical bytes."""
+
+    endpoint_id: PyObjectId
+    user_id: PyObjectId  # denormalized for owner queries
+    event_oid: PyObjectId  # -> webhook-events._id
+    event_type: str  # denormalized: delivery-log filtering without a join
+    webhook_id: str  # msg_… — STABLE across retries (consumer dedup key)
+    is_test: bool = False
+    rendered_body: str | None = None
+    dropped_since_last: int = 0
+    status: DeliveryStatus = DeliveryStatus.PENDING
+    attempts: list[DeliveryAttempt] = []  # noqa: RUF012
+    attempt_count: int = 0
+    next_attempt_at: datetime | None = None
+    claimed_until: datetime | None = None
+    created_at: datetime | None = None
+    completed_at: datetime | None = None

--- a/schemas/models/webhook.py
+++ b/schemas/models/webhook.py
@@ -1,8 +1,8 @@
 """Webhook document models.
 
-Three collections (TRD §11):
+Three collections:
 - ``webhook-endpoints``  — subscriptions + signing material + health
-- ``webhook-events``     — the fact, stored ONCE per occurrence (D14)
+- ``webhook-events``     — the fact, stored ONCE per occurrence
 - ``webhook-deliveries`` — thin per-endpoint delivery state referencing the event
 
 The ``whsec_…`` signing secret is shown once at creation and stored
@@ -62,7 +62,7 @@ class WebhookEndpointDoc(MongoBaseModel):
     # Health (denormalized; counters updated atomically by the repository).
     # consecutive_failures counts EXHAUSTED deliveries, not attempts.
     consecutive_failures: int = 0
-    dropped_count: int = 0  # D13 pending-cap drops since last successful delivery
+    dropped_count: int = 0  # pending-cap drops since last successful delivery
     total_deliveries: int = 0
     total_successes: int = 0
     last_delivery_at: datetime | None = None
@@ -75,7 +75,7 @@ class WebhookEndpointDoc(MongoBaseModel):
 
 class WebhookEventDoc(MongoBaseModel):
     """Document model for the ``webhook-events`` collection — one row per
-    fact regardless of fan-out (D14). TTL-bounded (§11.4)."""
+    fact regardless of fan-out — deliveries reference it. TTL-bounded."""
 
     event_id: str  # evt_…
     type: str
@@ -101,7 +101,7 @@ class WebhookDeliveryDoc(MongoBaseModel):
     """Document model for the ``webhook-deliveries`` collection.
 
     Thin per-endpoint state: payload lives on the event row; the rendered
-    body is set at FIRST attempt (D15) and frozen across retries so
+    body is set at FIRST attempt and frozen across retries so
     consumers can dedup on ``webhook_id`` against identical bytes."""
 
     endpoint_id: PyObjectId

--- a/services/bulk_url_service.py
+++ b/services/bulk_url_service.py
@@ -43,12 +43,16 @@ from schemas.dto.responses.bulk import (
 from schemas.models.url import UrlStatus, UrlV2Doc
 from services.edge_cache.contract import cache_key
 from services.edge_cache.og_writethrough import build_og_entry
+from services.events.contract import DomainEvent
+from services.events.sinks import NullDomainEventSink
+from services.webhooks.payloads import event_changes, link_owner_id, link_snapshot
 from shared.reserved_aliases import is_reserved_alias
 
 if TYPE_CHECKING:
     from infrastructure.cache.url_cache import UrlCache
     from infrastructure.cloudflare_kv import CloudflareKVClient
     from repositories.url_repository import UrlRepository
+    from services.events.protocol import DomainEventSink
     from services.url_service import UrlService
 
 log = get_logger(__name__)
@@ -129,6 +133,7 @@ class BulkUrlService:
         kv: CloudflareKVClient | None,
         system_default_domain: str,
         og_ttl_seconds: int = 86_400,
+        events: DomainEventSink | None = None,
     ) -> None:
         self._url_repo = url_repo
         self._url_cache = url_cache
@@ -139,6 +144,10 @@ class BulkUrlService:
         self._kv = kv
         self._system_default_domain = system_default_domain
         self._og_ttl_seconds = og_ttl_seconds
+        # Domain-event sink (webhooks backbone). Per-item emission: a bulk
+        # op is N facts, and subscribers must not be able to tell bulk
+        # from a loop — same contract _log_updated already keeps for logs.
+        self._events = events or NullDomainEventSink()
         self._inflight: set[asyncio.Task] = set()
 
     # ── shared stages ────────────────────────────────────────────────────
@@ -288,6 +297,7 @@ class BulkUrlService:
             batch.ok(doc.id, alias=doc.alias)
         await self._invalidate((doc.alias, doc.domain) for doc in docs)
         self._edge_flush(purge_keys=self._system_domain_keys(docs))
+        await self._emit_deleted(docs)
         for doc in docs:
             log.info(
                 "url_deleted",
@@ -360,6 +370,7 @@ class BulkUrlService:
             # branch); plain links just re-promote when hot again.
             self._edge_flush(put_entries=self._og_put_entries(changed, status=status))
         self._log_updated(changed, set_ops, owner_id)
+        await self._emit_updated(changed, set_ops)
         return batch.report(op="set_status", user_id=owner_id)
 
     async def bulk_set_expiry(
@@ -432,8 +443,10 @@ class BulkUrlService:
         )
         if plain:
             self._log_updated(plain, plain_ops, owner_id)
+            await self._emit_updated(plain, plain_ops)
         if reactivate:
             self._log_updated(reactivate, react_ops, owner_id)
+            await self._emit_updated(reactivate, react_ops)
         return batch.report(op="set_expiry", user_id=owner_id)
 
     async def bulk_move_domain(
@@ -549,6 +562,7 @@ class BulkUrlService:
                 put_entries=self._og_put_entries(moved, domain=target),
             )
             self._log_updated(moved, set_ops, owner_id)
+            await self._emit_updated(moved, set_ops)
             for doc in moved:
                 log.info(
                     "url_domain_moved",
@@ -603,6 +617,41 @@ class BulkUrlService:
         for doc in docs:
             batch.ok(doc.id, alias=doc.alias)
         return True
+
+    async def _emit_updated(self, docs: list[UrlV2Doc], set_ops: dict) -> None:
+        """One link.updated per changed item — post-state snapshot plus the
+        same changes map the single-item producer builds."""
+        for doc in docs:
+            owner = link_owner_id(doc)
+            if owner is None:
+                continue
+            merged = doc.model_dump(by_alias=True)
+            merged.update(set_ops)
+            merged["_id"] = doc.id
+            post_doc = UrlV2Doc.from_mongo(merged)
+            await self._events.emit(
+                DomainEvent(
+                    type="link.updated",
+                    owner_id=owner,
+                    data={
+                        "link": link_snapshot(post_doc),
+                        "changes": event_changes(doc, set_ops),
+                    },
+                )
+            )
+
+    async def _emit_deleted(self, docs: list[UrlV2Doc]) -> None:
+        for doc in docs:
+            owner = link_owner_id(doc)
+            if owner is None:
+                continue
+            await self._events.emit(
+                DomainEvent(
+                    type="link.deleted",
+                    owner_id=owner,
+                    data={"link": link_snapshot(doc)},
+                )
+            )
 
     def _log_updated(
         self, docs: list[UrlV2Doc], set_ops: dict, owner_id: ObjectId

--- a/services/click/handlers.py
+++ b/services/click/handlers.py
@@ -27,6 +27,7 @@ from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.click import ClickDoc, ClickMeta
 from services.click.bot_detection import get_bot_name, is_bot_request
 from services.click.protocol import ClickContext
+from services.events.protocol import DomainEventSink
 
 log = get_logger(__name__)
 
@@ -76,11 +77,14 @@ class V2ClickHandler:
         url_repo: UrlRepository,
         geoip: GeoIPService,
         url_cache: UrlCache,
+        events: DomainEventSink | None = None,
     ) -> None:
         self._click_repo = click_repo
         self._url_repo = url_repo
         self._geoip = geoip
         self._url_cache = url_cache
+        # Domain-event sink (webhooks backbone); None = feature off.
+        self._events = events
 
     async def handle(self, context: ClickContext) -> None:
         """
@@ -215,6 +219,23 @@ class V2ClickHandler:
                     max_clicks=url_data.max_clicks,
                 )
                 await self._url_cache.invalidate(short_code, url_data.domain)
+                await self._emit_expired(url_id)
+
+    async def _emit_expired(self, url_id: ObjectId) -> None:
+        """link.expired at discovery — the atomic expire above gates this
+        to once per link. Fetches the doc (rare branch) for the snapshot."""
+        if self._events is None:
+            return
+        # Function-local import: webhooks.payloads imports classify_device
+        # from this module, so a top-level import would be a cycle.
+        from services.webhooks.payloads import build_link_expired
+
+        doc = await self._url_repo.find_by_id(url_id)
+        if doc is None:
+            return
+        event = build_link_expired(doc, "max_clicks_reached")
+        if event is not None:
+            await self._events.emit(event)
 
 
 class LegacyClickHandler:

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -34,9 +34,6 @@ from schemas.enums.domain_status import DomainStatus, VerificationMethod
 from schemas.models.custom_domain import LEGAL_TRANSITIONS, CustomDomainDoc
 from services.dns_preflight import check_cname, uses_cloudflare_dns
 from services.edge_provisioner.protocol import EdgeProvisioner
-from services.events.contract import DomainEvent
-from services.events.protocol import DomainEventSink
-from services.events.sinks import NullDomainEventSink
 from services.registrar.protocol import HostnameRegistrar
 from services.tenant_resolver.protocol import TenantResolver
 from services.verifiers.protocol import DomainVerifier, VerificationResult
@@ -74,7 +71,6 @@ class CustomDomainService:
         redis_client: aioredis.Redis | None = None,
         preflight_cname_target: str | None = None,
         url_service: UrlService | None = None,
-        events: DomainEventSink | None = None,
     ) -> None:
         self._repo = repo
         self._verifiers = verifiers
@@ -88,9 +84,6 @@ class CustomDomainService:
         self._preflight_cname_target = preflight_cname_target
         # None = cascade delete unavailable (tests). Production wiring sets this.
         self._url_service = url_service
-        # Domain-event sink (webhooks backbone). Null default keeps tests
-        # and self-host wiring unchanged; the sink never raises.
-        self._events = events or NullDomainEventSink()
 
     # ── Public API ───────────────────────────────────────────────────
 
@@ -235,7 +228,6 @@ class CustomDomainService:
                 bump_last_verified_at=True,
             )
             await self._invalidate_cache(doc.fqdn)
-            await self._emit_domain_event(doc, DomainStatus.ACTIVE, "domain.verified")
             log.info(
                 "audit.domain.verified",
                 fqdn=doc.fqdn,
@@ -513,9 +505,6 @@ class CustomDomainService:
         )
         await self._announce_eviction(doc, kind="suspended")
         await self._invalidate_cache(doc.fqdn)
-        await self._emit_domain_event(
-            doc, DomainStatus.SUSPENDED, "domain.suspended", reason=reason
-        )
         log.info(
             "audit.domain.suspended",
             fqdn=doc.fqdn,
@@ -523,28 +512,6 @@ class CustomDomainService:
             owner_id=str(doc.owner_id),
             reason=reason,
             suspending_actor=actor,
-        )
-
-    async def _emit_domain_event(
-        self,
-        doc: CustomDomainDoc,
-        status: DomainStatus,
-        event_type: str,
-        *,
-        reason: str | None = None,
-    ) -> None:
-        """Publish a domain lifecycle fact to the webhooks backbone."""
-        await self._events.emit(
-            DomainEvent(
-                type=event_type,
-                owner_id=str(doc.owner_id),
-                data={
-                    "domain_id": str(doc.id),
-                    "fqdn": doc.fqdn,
-                    "status": status.value,
-                    "reason": reason,
-                },
-            )
         )
 
     # ── Internal: state machine, quotas, blocklist, cache ────────────

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -34,6 +34,9 @@ from schemas.enums.domain_status import DomainStatus, VerificationMethod
 from schemas.models.custom_domain import LEGAL_TRANSITIONS, CustomDomainDoc
 from services.dns_preflight import check_cname, uses_cloudflare_dns
 from services.edge_provisioner.protocol import EdgeProvisioner
+from services.events.contract import DomainEvent
+from services.events.protocol import DomainEventSink
+from services.events.sinks import NullDomainEventSink
 from services.registrar.protocol import HostnameRegistrar
 from services.tenant_resolver.protocol import TenantResolver
 from services.verifiers.protocol import DomainVerifier, VerificationResult
@@ -71,6 +74,7 @@ class CustomDomainService:
         redis_client: aioredis.Redis | None = None,
         preflight_cname_target: str | None = None,
         url_service: UrlService | None = None,
+        events: DomainEventSink | None = None,
     ) -> None:
         self._repo = repo
         self._verifiers = verifiers
@@ -84,6 +88,9 @@ class CustomDomainService:
         self._preflight_cname_target = preflight_cname_target
         # None = cascade delete unavailable (tests). Production wiring sets this.
         self._url_service = url_service
+        # Domain-event sink (webhooks backbone). Null default keeps tests
+        # and self-host wiring unchanged; the sink never raises.
+        self._events = events or NullDomainEventSink()
 
     # ── Public API ───────────────────────────────────────────────────
 
@@ -228,6 +235,7 @@ class CustomDomainService:
                 bump_last_verified_at=True,
             )
             await self._invalidate_cache(doc.fqdn)
+            await self._emit_domain_event(doc, DomainStatus.ACTIVE, "domain.verified")
             log.info(
                 "audit.domain.verified",
                 fqdn=doc.fqdn,
@@ -505,6 +513,9 @@ class CustomDomainService:
         )
         await self._announce_eviction(doc, kind="suspended")
         await self._invalidate_cache(doc.fqdn)
+        await self._emit_domain_event(
+            doc, DomainStatus.SUSPENDED, "domain.suspended", reason=reason
+        )
         log.info(
             "audit.domain.suspended",
             fqdn=doc.fqdn,
@@ -512,6 +523,28 @@ class CustomDomainService:
             owner_id=str(doc.owner_id),
             reason=reason,
             suspending_actor=actor,
+        )
+
+    async def _emit_domain_event(
+        self,
+        doc: CustomDomainDoc,
+        status: DomainStatus,
+        event_type: str,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Publish a domain lifecycle fact to the webhooks backbone."""
+        await self._events.emit(
+            DomainEvent(
+                type=event_type,
+                owner_id=str(doc.owner_id),
+                data={
+                    "domain_id": str(doc.id),
+                    "fqdn": doc.fqdn,
+                    "status": status.value,
+                    "reason": reason,
+                },
+            )
         )
 
     # ── Internal: state machine, quotas, blocklist, cache ────────────

--- a/services/events/__init__.py
+++ b/services/events/__init__.py
@@ -1,0 +1,23 @@
+"""Domain-event backbone — envelope contract, sink protocol, transports.
+
+NOT webhook-specific: the webhooks dispatcher is one consumer; future
+consumers (alerts, event log, audit) register their own consumer groups
+on the same streams without touching this package.
+"""
+
+from services.events.contract import DOMAIN_EVENTS_STREAM, DomainEvent
+from services.events.protocol import DomainEventSink
+from services.events.sinks import (
+    InlineDomainEventSink,
+    NullDomainEventSink,
+    StreamDomainEventSink,
+)
+
+__all__ = [
+    "DOMAIN_EVENTS_STREAM",
+    "DomainEvent",
+    "DomainEventSink",
+    "InlineDomainEventSink",
+    "NullDomainEventSink",
+    "StreamDomainEventSink",
+]

--- a/services/events/contract.py
+++ b/services/events/contract.py
@@ -1,7 +1,6 @@
 """DomainEvent — the pinned wire contract for the ``events:domain`` stream.
 
-Low-volume CRUD-shaped facts (link lifecycle, domain lifecycle, key
-creation) ride this stream; high-volume click facts stay on
+Low-volume CRUD-shaped facts (link lifecycle) ride this stream; high-volume click facts stay on
 ``events:clicks`` with their own contract (services/click/events.py).
 Consumers in any process decode this envelope — treat changes with the
 same discipline as edge_cache/contract.py: additive evolution only,

--- a/services/events/contract.py
+++ b/services/events/contract.py
@@ -1,0 +1,92 @@
+"""DomainEvent — the pinned wire contract for the ``events:domain`` stream.
+
+Low-volume CRUD-shaped facts (link lifecycle, domain lifecycle, key
+creation) ride this stream; high-volume click facts stay on
+``events:clicks`` with their own contract (services/click/events.py).
+Consumers in any process decode this envelope — treat changes with the
+same discipline as edge_cache/contract.py: additive evolution only,
+remove/rename requires a version bump.
+
+Wire format mirrors the click stream so FastStream subscribers decode
+payloads natively:
+
+    {"v": "1", "type": "<event type>", "__data__": "<envelope json>"}
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ValidationError as PydanticValidationError
+
+from infrastructure.logging import get_logger
+
+log = get_logger(__name__)
+
+DOMAIN_EVENTS_STREAM = "events:domain"
+
+STREAM_FIELD_VERSION = "v"
+STREAM_FIELD_TYPE = "type"
+STREAM_FIELD_DATA = "__data__"
+_WIRE_VERSION = "1"
+
+
+def new_event_id() -> str:
+    return f"evt_{uuid.uuid4().hex}"
+
+
+class DomainEvent(BaseModel):
+    """Immutable fact: something happened to a resource an owner cares about.
+
+    ``data`` is validated against the event type's registry payload model
+    at publish time (services/webhooks/registry.py) — the envelope itself
+    stays schema-agnostic so new event types never touch this contract.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    event_id: str = Field(default_factory=new_event_id)
+    type: str
+    v: int = 1
+    owner_id: str
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    data: dict[str, Any]
+
+
+def to_stream_fields(event: DomainEvent) -> dict[str, str]:
+    """Encode an event as flat string fields for ``XADD``."""
+    return {
+        STREAM_FIELD_VERSION: _WIRE_VERSION,
+        STREAM_FIELD_TYPE: event.type,
+        STREAM_FIELD_DATA: event.model_dump_json(),
+    }
+
+
+def _error_summary(exc: PydanticValidationError) -> list[dict[str, Any]]:
+    """Field locations + error types, with input values stripped (PII)."""
+    return [
+        {"loc": e["loc"], "type": e["type"]}
+        for e in exc.errors(include_url=False, include_input=False)
+    ]
+
+
+def domain_event_from_payload(payload: Any) -> DomainEvent | None:
+    """Decode an already-JSON-parsed payload (the FastStream handler path).
+
+    Returns None (and logs) on malformed payloads — a payload that cannot
+    parse today can never parse, so callers drop it instead of letting it
+    poison-pill a consumer group.
+    """
+    if not isinstance(payload, dict):
+        log.warning(
+            "domain_event_payload_not_dict", payload_type=type(payload).__name__
+        )
+        return None
+    try:
+        return DomainEvent.model_validate(payload)
+    except PydanticValidationError as exc:
+        log.warning("domain_event_malformed", errors=_error_summary(exc))
+        return None

--- a/services/events/protocol.py
+++ b/services/events/protocol.py
@@ -1,0 +1,16 @@
+"""DomainEventSink protocol — producers depend on this, never on transports.
+
+Emit is awaited-but-never-raises from the producer's perspective: an event
+side effect must never fail the primary action (same posture as click
+emission and ops_notify sends). Implementations own that guarantee.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from services.events.contract import DomainEvent
+
+
+class DomainEventSink(Protocol):
+    async def emit(self, event: DomainEvent) -> None: ...

--- a/services/events/sinks.py
+++ b/services/events/sinks.py
@@ -1,0 +1,87 @@
+"""DomainEventSink implementations — the OSS opt-in ladder's transport rungs.
+
+StreamDomainEventSink   queue Redis present: XADD to events:domain,
+                        inline fallback on ANY failure (mirrors the click
+                        RedisStreamSink degradation exactly).
+InlineDomainEventSink   no queue Redis: dispatch in-process. Low-volume CRUD
+                        events always; click events only reach this via the
+                        redirect path's own inline mode, where the deployment
+                        is small by definition.
+NullDomainEventSink     webhooks disabled: emit is a no-op, producers need
+                        no conditionals.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import redis.asyncio as aioredis
+
+from infrastructure.logging import get_logger
+from services.events.contract import DOMAIN_EVENTS_STREAM, DomainEvent, to_stream_fields
+
+if TYPE_CHECKING:
+    from services.webhooks.dispatcher import WebhookDispatcher
+
+log = get_logger(__name__)
+
+
+class NullDomainEventSink:
+    async def emit(self, event: DomainEvent) -> None:
+        return None
+
+
+class InlineDomainEventSink:
+    """Dispatches in-process — one matcher pass + Mongo writes at emit time.
+
+    Never raises: a webhook side effect must not fail the primary action.
+    """
+
+    def __init__(self, dispatcher: WebhookDispatcher) -> None:
+        self._dispatcher = dispatcher
+
+    async def emit(self, event: DomainEvent) -> None:
+        try:
+            await self._dispatcher.dispatch(event)
+        except Exception as exc:
+            log.error(
+                "domain_event_inline_dispatch_failed",
+                event_type=event.type,
+                event_id=event.event_id,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+
+
+class StreamDomainEventSink:
+    """XADDs encoded events to events:domain; falls back inline on failure."""
+
+    def __init__(
+        self,
+        redis_client: aioredis.Redis,
+        fallback: InlineDomainEventSink | NullDomainEventSink,
+        stream: str = DOMAIN_EVENTS_STREAM,
+        maxlen: int = 100_000,
+    ) -> None:
+        self._redis = redis_client
+        self._fallback = fallback
+        self._stream = stream
+        self._maxlen = maxlen
+
+    async def emit(self, event: DomainEvent) -> None:
+        try:
+            await self._redis.xadd(
+                self._stream,
+                to_stream_fields(event),
+                maxlen=self._maxlen,
+                approximate=True,
+                ref_policy="ACKED",
+            )
+        except Exception as exc:
+            log.warning(
+                "domain_event_sink_fallback",
+                event_type=event.type,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            await self._fallback.emit(event)

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -56,6 +56,7 @@ CUSTOM_DOMAINS_FLAG = "custom_domains"
 GEO_TARGETING_FLAG = "geo_targeting"
 META_TAGS_FLAG = "custom_meta_tags"
 AB_TESTING_FLAG = "ab_testing"
+WEBHOOKS_FLAG = "webhooks"
 
 # Flags whose per-user answer is exposed to clients via GET /api/v1/me/
 # features, so frontends can decide what to render. Enforcement stays on
@@ -66,6 +67,7 @@ EXPOSED_FEATURES: tuple[str, ...] = (
     GEO_TARGETING_FLAG,
     META_TAGS_FLAG,
     AB_TESTING_FLAG,
+    WEBHOOKS_FLAG,
 )
 
 

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -55,7 +55,7 @@ from services.events.protocol import DomainEventSink
 from services.events.sinks import NullDomainEventSink
 from services.meta_tags.events import MetaImageValidateEvent
 from services.meta_tags.images import ingest_meta_image
-from services.webhooks.payloads import link_owner_id, link_snapshot
+from services.webhooks.payloads import build_link_expired, link_owner_id, link_snapshot
 
 if TYPE_CHECKING:
     from infrastructure.cloudflare_kv import CloudflareKVClient
@@ -582,6 +582,14 @@ class UrlService:
                     reason="expiration_time_reached",
                 )
                 await self._url_cache.invalidate(short_code, data.domain)
+                # link.expired fires at discovery, once per link — the
+                # atomic flip above is the gate. One extra read on a
+                # once-per-link branch buys the full snapshot payload.
+                doc = await self._url_repo.find_by_id(ObjectId(data.id))
+                if doc is not None:
+                    event = build_link_expired(doc, "time_expired")
+                    if event is not None:
+                        await self._events.emit(event)
         raise GoneError("URL has expired (expiration time reached)")
 
     async def check_alias_available(

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -50,8 +50,12 @@ from schemas.dto.requests.url import (
 )
 from services.edge_cache.contract import cache_key
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
+from services.events.contract import DomainEvent
+from services.events.protocol import DomainEventSink
+from services.events.sinks import NullDomainEventSink
 from services.meta_tags.events import MetaImageValidateEvent
 from services.meta_tags.images import ingest_meta_image
+from services.webhooks.payloads import link_owner_id, link_snapshot
 
 if TYPE_CHECKING:
     from infrastructure.cloudflare_kv import CloudflareKVClient
@@ -403,6 +407,7 @@ class UrlService:
         meta_image_max_bytes: int = 512_000,
         meta_image_sink: MetaImageValidationSink | None = None,
         meta_key_secret: str = "",
+        events: DomainEventSink | None = None,
     ) -> None:
         self._url_repo = url_repo
         self._legacy_repo = legacy_repo
@@ -437,6 +442,9 @@ class UrlService:
         # HMAC pepper for storage-key owner prefixes (public URLs must not
         # carry raw ObjectIds). Wired from settings.secret_key.
         self._meta_key_secret = meta_key_secret
+        # Domain-event sink (webhooks backbone). Null default: producers
+        # never carry conditionals and tests need no wiring changes.
+        self._events = events or NullDomainEventSink()
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -902,6 +910,8 @@ class UrlService:
         # image_meta already). Best-effort emit — sink swallows failures.
         await self._maybe_emit_image_validation(url_doc)
 
+        await self._emit_link_event("link.created", url_doc)
+
         return url_doc
 
     async def update(
@@ -1022,7 +1032,39 @@ class UrlService:
         if "meta_tags" in update_ops:
             await self._maybe_emit_image_validation(merged_doc)
 
+        await self._emit_link_event(
+            "link.updated",
+            merged_doc,
+            extra={"changes": _event_changes(existing, update_ops)},
+        )
+        if "status" in update_ops:
+            await self._emit_link_event(
+                "link.status_changed",
+                merged_doc,
+                extra={
+                    "old_status": existing.status.value,
+                    "new_status": UrlStatus(update_ops["status"]).value,
+                    "reason": None,
+                },
+            )
+
         return merged_doc
+
+    async def _emit_link_event(
+        self, event_type: str, doc: UrlV2Doc, extra: dict | None = None
+    ) -> None:
+        """Publish a link lifecycle fact to the domain-event backbone.
+
+        Anonymous links skip entirely (no possible webhook subscriber);
+        the sink never raises, so producers stay unconditional.
+        """
+        owner = link_owner_id(doc)
+        if owner is None:
+            return
+        data: dict = {"link": link_snapshot(doc)}
+        if extra:
+            data.update(extra)
+        await self._events.emit(DomainEvent(type=event_type, owner_id=owner, data=data))
 
     async def _maybe_emit_image_validation(self, doc: UrlV2Doc) -> None:
         """Queue async validation for an external https og:image."""
@@ -1143,6 +1185,7 @@ class UrlService:
             short_code=existing.alias,
             user_id=str(owner_id),
         )
+        await self._emit_link_event("link.deleted", existing)
 
     async def delete_all_by_domain(
         self,
@@ -1450,6 +1493,30 @@ class UrlService:
 
 
 # ── Module-level helpers ──────────────────────────────────────────────────────
+
+
+def _event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
+    """update_ops → the public ``changes`` map for link.updated.
+
+    Password values are structurally redacted to presence booleans —
+    hashes must never ride the event backbone (same posture as
+    ClickEvent's password strip).
+    """
+    changes: dict = {}
+    for field_name, new_value in update_ops.items():
+        if field_name == "updated_at":
+            continue
+        old_value = getattr(existing, field_name, None)
+        if field_name == "password":
+            old_value = old_value is not None
+            new_value = new_value is not None
+            field_name = "password_protected"
+        if isinstance(old_value, UrlStatus):
+            old_value = old_value.value
+        if isinstance(new_value, UrlStatus):
+            new_value = new_value.value
+        changes[field_name] = {"old": old_value, "new": new_value}
+    return changes
 
 
 def _raise_for_status(status: UrlStatus) -> None:

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -55,7 +55,12 @@ from services.events.protocol import DomainEventSink
 from services.events.sinks import NullDomainEventSink
 from services.meta_tags.events import MetaImageValidateEvent
 from services.meta_tags.images import ingest_meta_image
-from services.webhooks.payloads import build_link_expired, link_owner_id, link_snapshot
+from services.webhooks.payloads import (
+    build_link_expired,
+    event_changes,
+    link_owner_id,
+    link_snapshot,
+)
 
 if TYPE_CHECKING:
     from infrastructure.cloudflare_kv import CloudflareKVClient
@@ -1043,18 +1048,8 @@ class UrlService:
         await self._emit_link_event(
             "link.updated",
             merged_doc,
-            extra={"changes": _event_changes(existing, update_ops)},
+            extra={"changes": event_changes(existing, update_ops)},
         )
-        if "status" in update_ops:
-            await self._emit_link_event(
-                "link.status_changed",
-                merged_doc,
-                extra={
-                    "old_status": existing.status.value,
-                    "new_status": UrlStatus(update_ops["status"]).value,
-                    "reason": None,
-                },
-            )
 
         return merged_doc
 
@@ -1501,50 +1496,6 @@ class UrlService:
 
 
 # ── Module-level helpers ──────────────────────────────────────────────────────
-
-
-_META_TAGS_PUBLIC_FIELDS = ("title", "description", "image", "color")
-
-
-def _event_change_value(field_name: str, value: object) -> object:
-    """Project one changed value into its public wire form.
-
-    Secrets and internal bookkeeping are stripped structurally here so
-    every producer of the changes map inherits the guarantee: password
-    material never rides the backbone, meta_tags keep only their public
-    fields (``updated_ip``/``updated_at``/``image_meta`` are internal),
-    and datetimes are ISO-8601 like every other timestamp on the wire.
-    """
-    if value is None:
-        return None
-    if isinstance(value, UrlStatus):
-        return value.value
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if field_name == "meta_tags":
-        raw = value.model_dump() if isinstance(value, LinkMetaTags) else dict(value)
-        return {k: raw.get(k) for k in _META_TAGS_PUBLIC_FIELDS}
-    return value
-
-
-def _event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
-    """update_ops → the public ``changes`` map for link.updated."""
-    changes: dict = {}
-    for field_name, new_value in update_ops.items():
-        if field_name == "updated_at":
-            continue
-        old_value = getattr(existing, field_name, None)
-        if field_name == "password":
-            # Presence booleans only — hashes must never ride the backbone
-            # (same posture as ClickEvent's password strip).
-            old_value = old_value is not None
-            new_value = new_value is not None
-            field_name = "password_protected"
-        changes[field_name] = {
-            "old": _event_change_value(field_name, old_value),
-            "new": _event_change_value(field_name, new_value),
-        }
-    return changes
 
 
 def _raise_for_status(status: UrlStatus) -> None:

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -1503,27 +1503,47 @@ class UrlService:
 # ── Module-level helpers ──────────────────────────────────────────────────────
 
 
-def _event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
-    """update_ops → the public ``changes`` map for link.updated.
+_META_TAGS_PUBLIC_FIELDS = ("title", "description", "image", "color")
 
-    Password values are structurally redacted to presence booleans —
-    hashes must never ride the event backbone (same posture as
-    ClickEvent's password strip).
+
+def _event_change_value(field_name: str, value: object) -> object:
+    """Project one changed value into its public wire form.
+
+    Secrets and internal bookkeeping are stripped structurally here so
+    every producer of the changes map inherits the guarantee: password
+    material never rides the backbone, meta_tags keep only their public
+    fields (``updated_ip``/``updated_at``/``image_meta`` are internal),
+    and datetimes are ISO-8601 like every other timestamp on the wire.
     """
+    if value is None:
+        return None
+    if isinstance(value, UrlStatus):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if field_name == "meta_tags":
+        raw = value.model_dump() if isinstance(value, LinkMetaTags) else dict(value)
+        return {k: raw.get(k) for k in _META_TAGS_PUBLIC_FIELDS}
+    return value
+
+
+def _event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
+    """update_ops → the public ``changes`` map for link.updated."""
     changes: dict = {}
     for field_name, new_value in update_ops.items():
         if field_name == "updated_at":
             continue
         old_value = getattr(existing, field_name, None)
         if field_name == "password":
+            # Presence booleans only — hashes must never ride the backbone
+            # (same posture as ClickEvent's password strip).
             old_value = old_value is not None
             new_value = new_value is not None
             field_name = "password_protected"
-        if isinstance(old_value, UrlStatus):
-            old_value = old_value.value
-        if isinstance(new_value, UrlStatus):
-            new_value = new_value.value
-        changes[field_name] = {"old": old_value, "new": new_value}
+        changes[field_name] = {
+            "old": _event_change_value(field_name, old_value),
+            "new": _event_change_value(field_name, new_value),
+        }
     return changes
 
 

--- a/services/webhooks/__init__.py
+++ b/services/webhooks/__init__.py
@@ -1,0 +1,18 @@
+"""Webhooks system — stateless fan-out of domain facts to subscriber URLs.
+
+One consumer of the services/events backbone; the alerts engine and the
+account event log are future sibling consumers, not parts of this package.
+"""
+
+from services.webhooks.dispatcher import WebhookDispatcher
+from services.webhooks.executor import DeliveryExecutor
+from services.webhooks.matcher import OwnerSubscriptionCache, SubscriptionMatcher
+from services.webhooks.service import WebhookService
+
+__all__ = [
+    "DeliveryExecutor",
+    "OwnerSubscriptionCache",
+    "SubscriptionMatcher",
+    "WebhookDispatcher",
+    "WebhookService",
+]

--- a/services/webhooks/consumers.py
+++ b/services/webhooks/consumers.py
@@ -1,0 +1,98 @@
+"""Webhooks consumer-group handlers — framework-free like the click
+consumers; the worker's FastStream subscribers delegate here.
+
+Two feeds, one dispatcher:
+- ``events:clicks`` (existing stream, new ``webhooks`` group): ClickEvent
+  → link.clicked adaptation happens here, at read time — the producer
+  side of the click pipeline is untouched.
+- ``events:domain`` (new stream): the envelope is already a DomainEvent.
+
+Malformed payloads are dropped (never raised) — a payload that cannot
+parse today can never parse, and raising would leave it pending forever
+(the claim path's DLQ guard is the backstop for transient poison).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from infrastructure.geoip import GeoIPService
+from infrastructure.logging import get_logger
+from services.click.events import click_event_from_payload
+from services.events.contract import domain_event_from_payload
+from services.webhooks.dispatcher import WebhookDispatcher
+from services.webhooks.payloads import build_link_clicked
+
+log = get_logger(__name__)
+
+
+class WebhookClickConsumer:
+    """events:clicks / group ``webhooks`` — adapt + dispatch."""
+
+    def __init__(
+        self,
+        dispatcher: WebhookDispatcher,
+        geoip: GeoIPService | None,
+        system_default_domain: str,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._geoip = geoip
+        self._system_default_domain = system_default_domain
+
+    async def consume(self, payload: Any) -> None:
+        click = click_event_from_payload(payload)
+        if click is None:
+            return  # malformed — logged by the decoder, drop
+        event = build_link_clicked(
+            click, self._system_default_domain, geoip=self._geoip
+        )
+        if event is None:
+            return  # unowned link — no possible subscriber
+        await self._dispatcher.dispatch(event)
+
+
+class WebhookDomainConsumer:
+    """events:domain / group ``webhooks`` — decode + dispatch."""
+
+    def __init__(self, dispatcher: WebhookDispatcher) -> None:
+        self._dispatcher = dispatcher
+
+    async def consume(self, payload: Any) -> None:
+        event = domain_event_from_payload(payload)
+        if event is None:
+            return
+        await self._dispatcher.dispatch(event)
+
+
+class WebhookFanoutClickSink:
+    """The inline rung's click feed (TRD §5): wraps the inline click sink
+    so link.clicked webhooks work with no queue Redis and no worker —
+    tracking first, then best-effort dispatch. Never raises past the
+    inner sink; a webhook must not cost a redirect."""
+
+    def __init__(
+        self,
+        inner: Any,  # ClickEventSink
+        dispatcher: WebhookDispatcher,
+        geoip: GeoIPService | None,
+        system_default_domain: str,
+    ) -> None:
+        self._inner = inner
+        self._dispatcher = dispatcher
+        self._geoip = geoip
+        self._system_default_domain = system_default_domain
+
+    async def emit(self, event: Any) -> None:
+        await self._inner.emit(event)
+        try:
+            domain_event = build_link_clicked(
+                event, self._system_default_domain, geoip=self._geoip
+            )
+            if domain_event is not None:
+                await self._dispatcher.dispatch(domain_event)
+        except Exception as exc:
+            log.error(
+                "webhook_click_fanout_failed",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )

--- a/services/webhooks/consumers.py
+++ b/services/webhooks/consumers.py
@@ -65,7 +65,7 @@ class WebhookDomainConsumer:
 
 
 class WebhookFanoutClickSink:
-    """The inline rung's click feed (TRD §5): wraps the inline click sink
+    """The no-queue-Redis deployment's click feed: wraps the inline click sink
     so link.clicked webhooks work with no queue Redis and no worker —
     tracking first, then best-effort dispatch. Never raises past the
     inner sink; a webhook must not cost a redirect."""

--- a/services/webhooks/consumers.py
+++ b/services/webhooks/consumers.py
@@ -43,7 +43,7 @@ class WebhookClickConsumer:
         click = click_event_from_payload(payload)
         if click is None:
             return  # malformed — logged by the decoder, drop
-        event = build_link_clicked(
+        event = await build_link_clicked(
             click, self._system_default_domain, geoip=self._geoip
         )
         if event is None:
@@ -85,7 +85,7 @@ class WebhookFanoutClickSink:
     async def emit(self, event: Any) -> None:
         await self._inner.emit(event)
         try:
-            domain_event = build_link_clicked(
+            domain_event = await build_link_clicked(
                 event, self._system_default_domain, geoip=self._geoip
             )
             if domain_event is not None:

--- a/services/webhooks/dispatcher.py
+++ b/services/webhooks/dispatcher.py
@@ -2,9 +2,10 @@
 
 Runs on the consumer ack path (stream mode) or at emit time (inline
 mode), so its cost must be bounded and payload-size-independent: one
-matcher pass, one event insert, N thin delivery rows (D14/D15). The
+matcher pass, one event insert, N thin delivery rows. The
 caller acks the stream message AFTER dispatch returns — delivery intent
-recorded durably is the ack condition, not delivery success (TRD §3).
+recorded durably is the ack condition, not delivery success — a
+multi-hour retry ladder cannot hold a stream entry pending.
 """
 
 from __future__ import annotations
@@ -72,7 +73,7 @@ class WebhookDispatcher:
         event_oid = await self._event_repo.insert_event(event)
         rows: list[dict] = []
         for endpoint in endpoints:
-            # D13: the pending cap protects the queue itself. A subscriber
+            # The pending cap protects the queue itself. A subscriber
             # who can't drink max_pending deliveries has already lost the
             # facts — counting beats pretending.
             if (

--- a/services/webhooks/dispatcher.py
+++ b/services/webhooks/dispatcher.py
@@ -1,0 +1,97 @@
+"""WebhookDispatcher — fact → durable delivery intent. No HTTP, no rendering.
+
+Runs on the consumer ack path (stream mode) or at emit time (inline
+mode), so its cost must be bounded and payload-size-independent: one
+matcher pass, one event insert, N thin delivery rows (D14/D15). The
+caller acks the stream message AFTER dispatch returns — delivery intent
+recorded durably is the ack condition, not delivery success (TRD §3).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from infrastructure.logging import get_logger
+from repositories.webhook_delivery_repository import WebhookDeliveryRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from repositories.webhook_event_repository import WebhookEventRepository
+from schemas.enums.webhook import DeliveryStatus
+from schemas.models.webhook import WebhookEndpointDoc
+from services.events.contract import DomainEvent
+from services.webhooks.matcher import SubscriptionMatcher
+from services.webhooks.signing import new_webhook_id
+
+log = get_logger(__name__)
+
+
+def make_delivery_row(
+    event_oid: ObjectId, event: DomainEvent, endpoint: WebhookEndpointDoc
+) -> dict:
+    return {
+        "endpoint_id": endpoint.id,
+        "user_id": endpoint.user_id,
+        "event_oid": event_oid,
+        "event_type": event.type,
+        "webhook_id": new_webhook_id(),
+        "is_test": False,
+        "rendered_body": None,
+        "dropped_since_last": 0,
+        "status": DeliveryStatus.PENDING.value,
+        "attempts": [],
+        "attempt_count": 0,
+        "next_attempt_at": datetime.now(timezone.utc),
+        "claimed_until": None,
+        "created_at": datetime.now(timezone.utc),
+        "completed_at": None,
+    }
+
+
+class WebhookDispatcher:
+    def __init__(
+        self,
+        matcher: SubscriptionMatcher,
+        event_repo: WebhookEventRepository,
+        delivery_repo: WebhookDeliveryRepository,
+        endpoint_repo: WebhookEndpointRepository,
+        *,
+        max_pending_per_endpoint: int = 1000,
+    ) -> None:
+        self._matcher = matcher
+        self._event_repo = event_repo
+        self._delivery_repo = delivery_repo
+        self._endpoint_repo = endpoint_repo
+        self._max_pending = max_pending_per_endpoint
+
+    async def dispatch(self, event: DomainEvent) -> None:
+        endpoints = await self._matcher.match(event)
+        if not endpoints:
+            return  # common case: cache hit, zero further Mongo work
+
+        event_oid = await self._event_repo.insert_event(event)
+        rows: list[dict] = []
+        for endpoint in endpoints:
+            # D13: the pending cap protects the queue itself. A subscriber
+            # who can't drink max_pending deliveries has already lost the
+            # facts — counting beats pretending.
+            if (
+                await self._delivery_repo.count_pending(endpoint.id)
+                >= self._max_pending
+            ):
+                await self._endpoint_repo.increment_dropped(endpoint.id)
+                log.warning(
+                    "webhook_delivery_dropped_over_cap",
+                    endpoint_id=str(endpoint.id),
+                    event_type=event.type,
+                )
+                continue
+            rows.append(make_delivery_row(event_oid, event, endpoint))
+
+        await self._delivery_repo.insert_many_rows(rows)
+        log.info(
+            "webhook_dispatched",
+            event_type=event.type,
+            event_id=event.event_id,
+            endpoints=len(rows),
+        )

--- a/services/webhooks/dispatcher.py
+++ b/services/webhooks/dispatcher.py
@@ -38,7 +38,12 @@ def make_delivery_row(
         "webhook_id": new_webhook_id(),
         "is_test": False,
         "rendered_body": None,
-        "dropped_since_last": 0,
+        # Carry the drop counter accumulated while this endpoint was over
+        # the pending cap; the renderer surfaces it and record_success
+        # resets it, so the signal reaches the subscriber on the next
+        # delivery that lands. At-least-once: consecutive rows may repeat
+        # the same count until one succeeds.
+        "dropped_since_last": endpoint.dropped_count,
         "status": DeliveryStatus.PENDING.value,
         "attempts": [],
         "attempt_count": 0,
@@ -75,7 +80,10 @@ class WebhookDispatcher:
         for endpoint in endpoints:
             # The pending cap protects the queue itself. A subscriber
             # who can't drink max_pending deliveries has already lost the
-            # facts — counting beats pretending.
+            # facts — counting beats pretending. Count-then-insert is
+            # deliberately non-atomic: concurrent dispatchers can overshoot
+            # by a batch, which is fine for a protective backstop; an exact
+            # cap would cost a reservation counter on every dispatch.
             if (
                 await self._delivery_repo.count_pending(endpoint.id)
                 >= self._max_pending

--- a/services/webhooks/dispatcher.py
+++ b/services/webhooks/dispatcher.py
@@ -98,6 +98,8 @@ class WebhookDispatcher:
             rows.append(make_delivery_row(event_oid, event, endpoint))
 
         await self._delivery_repo.insert_many_rows(rows)
+        for row in rows:
+            await self._endpoint_repo.increment_deliveries(row["endpoint_id"])
         log.info(
             "webhook_dispatched",
             event_type=event.type,

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -34,6 +34,7 @@ from services.webhooks.signing import (
     HEADER_TIMESTAMP,
     sign,
 )
+from shared.datetime_utils import as_aware_utc
 
 log = get_logger(__name__)
 
@@ -103,9 +104,20 @@ class DeliveryExecutor:
     # ── One attempt ──────────────────────────────────────────────────────
 
     async def attempt(self, row: WebhookDeliveryDoc) -> None:
+        # Test sends and manual retries are single-shot: they must never
+        # touch endpoint health counters or enter the retry ladder — a
+        # failing test would otherwise auto-disable a real endpoint, and a
+        # passing one would reset a real failure streak.
+        single_shot = row.is_test or row.status != DeliveryStatus.PENDING
+
         endpoint = await self._endpoints.find_by_id(row.endpoint_id)
-        if endpoint is None or endpoint.status != WebhookStatus.ACTIVE:
+        if endpoint is None or endpoint.status == WebhookStatus.DISABLED:
             await self._deliveries.mark_failed(row.id, "endpoint_inactive")
+            return
+        if endpoint.status == WebhookStatus.PAUSED and not single_shot:
+            # Paused is a temporary state the owner controls: hold the
+            # delivery instead of killing it, recheck in five minutes.
+            await self._deliveries.defer(row.id, delay_seconds=300)
             return
 
         body = row.rendered_body
@@ -114,11 +126,31 @@ class DeliveryExecutor:
             if body is None:
                 return  # _render already recorded the terminal failure
 
+        try:
+            headers = self._headers(row.webhook_id, body, endpoint)
+        except Exception as exc:
+            # Unreadable secret (e.g. SECRET_KEY rotated: AES-GCM auth fails
+            # for every stored secret). Without this guard the exception
+            # escapes before any attempt is recorded, the lease expires, and
+            # the same row re-claims forever — a silent livelock. Terminate
+            # the row and disable the endpoint loudly instead; re-enabling
+            # after re-creating the endpoint (new secret) recovers.
+            log.error(
+                "webhook_secret_unreadable",
+                endpoint_id=str(endpoint.id),
+                webhook_id=row.webhook_id,
+                error_type=type(exc).__name__,
+            )
+            await self._deliveries.mark_failed(row.id, "secret_unreadable")
+            if not single_shot:
+                await self._disable(endpoint, EndpointDisabledReason.SECRET_UNREADABLE)
+            return
+
         started = time.monotonic()
         result = await post_public(
             endpoint.url,
             body,
-            headers=self._headers(row.webhook_id, body, endpoint),
+            headers=headers,
             timeout=self._timeout,
         )
         duration_ms = int((time.monotonic() - started) * 1000)
@@ -135,7 +167,8 @@ class DeliveryExecutor:
             await self._deliveries.record_attempt_and_finish(
                 row.id, attempt, DeliveryStatus.SUCCESS
             )
-            await self._endpoints.record_success(endpoint.id)
+            if not single_shot:
+                await self._endpoints.record_success(endpoint.id)
             log.info(
                 "webhook_delivered",
                 endpoint_id=str(endpoint.id),
@@ -157,6 +190,14 @@ class DeliveryExecutor:
             duration_ms=duration_ms,
             attempt=row.attempt_count + 1,
         )
+
+        if single_shot:
+            # One recorded attempt, terminal, health untouched: the caller
+            # (test send / manual retry) reads the outcome synchronously.
+            await self._deliveries.record_attempt_and_finish(
+                row.id, attempt, DeliveryStatus.FAILED
+            )
+            return
 
         if result.status_code == 410:
             await self._deliveries.record_attempt_and_finish(
@@ -224,9 +265,9 @@ class DeliveryExecutor:
             endpoint.signing_secret_enc, self._master_secret, domain=SECRET_ENC_DOMAIN
         )
         signatures = [sign(webhook_id, ts, body, secret)]
+        grace_expires = as_aware_utc(endpoint.previous_secret_expires_at)
         if endpoint.previous_secret_enc and (
-            endpoint.previous_secret_expires_at
-            and endpoint.previous_secret_expires_at > datetime.now(timezone.utc)
+            grace_expires and grace_expires > datetime.now(timezone.utc)
         ):
             previous = decrypt_secret(
                 endpoint.previous_secret_enc,

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -44,6 +44,10 @@ USER_AGENT = "spoo.me-webhooks/1.0 (+https://spoo.me)"
 # Standard Webhooks retry convention: immediate, 5s, 5m, 30m, 2h, 5h, 10h.
 RETRY_SCHEDULE_SECONDS = (0, 5, 300, 1800, 7200, 18000, 36000)
 
+# 429 handling: honor Retry-After within a ceiling, else back off a minute.
+RATE_LIMIT_FALLBACK_SECONDS = 60
+RATE_LIMIT_MAX_DEFER_SECONDS = 900
+
 # Type of the on-disable hook — wiring plugs email notification in here so
 # the executor never grows an email dependency.
 OnDisabled = Callable[[WebhookEndpointDoc, str], Awaitable[None]]
@@ -180,6 +184,29 @@ class DeliveryExecutor:
                 is_test=row.is_test,
             )
             return
+
+        if result.status_code == 429 and not single_shot:
+            # Rate limiting is receiver flow control, not endpoint failure —
+            # normal operation for Discord/Slack receivers. Hold the row
+            # without burning a ladder attempt or touching the streak; the
+            # delivery-log TTL is the backstop for a receiver that
+            # rate-limits forever, and the pending cap bounds the queue.
+            delay = int(
+                min(
+                    result.retry_after_seconds or RATE_LIMIT_FALLBACK_SECONDS,
+                    RATE_LIMIT_MAX_DEFER_SECONDS,
+                )
+            )
+            await self._deliveries.defer(row.id, delay_seconds=delay)
+            log.info(
+                "webhook_delivery_rate_limited",
+                endpoint_id=str(endpoint.id),
+                event_type=row.event_type,
+                webhook_id=row.webhook_id,
+                delay_seconds=delay,
+            )
+            return
+
         log.warning(
             "webhook_delivery_attempt_failed",
             endpoint_id=str(endpoint.id),

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -1,0 +1,236 @@
+"""DeliveryExecutor — the Mongo claim loop that actually delivers.
+
+Mongo-only by design (TRD D2): claim → render (first attempt only) →
+sign → POST → record. No Redis anywhere in the retry path, which is what
+lets the same class run in the click worker (prod) or embedded in the
+app lifespan (self-host rungs). Atomic claims with a lease make N
+concurrent executors safe; the claim query is stateless over
+``next_attempt_at``, so restarts self-heal on the first loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta, timezone
+
+from infrastructure.crypto import decrypt_secret
+from infrastructure.logging import get_logger
+from infrastructure.safe_fetch import post_public
+from repositories.webhook_delivery_repository import WebhookDeliveryRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from repositories.webhook_event_repository import WebhookEventRepository
+from schemas.enums.webhook import DeliveryStatus, EndpointDisabledReason, WebhookStatus
+from schemas.models.webhook import (
+    DeliveryAttempt,
+    WebhookDeliveryDoc,
+    WebhookEndpointDoc,
+)
+from services.webhooks.renderers import Renderer
+from services.webhooks.signing import (
+    HEADER_ID,
+    HEADER_SIGNATURE,
+    HEADER_TIMESTAMP,
+    sign,
+)
+
+log = get_logger(__name__)
+
+SECRET_ENC_DOMAIN = "webhook-signing-secret-v1"
+USER_AGENT = "spoo.me-webhooks/1.0 (+https://spoo.me)"
+
+# Standard Webhooks retry convention: immediate, 5s, 5m, 30m, 2h, 5h, 10h.
+RETRY_SCHEDULE_SECONDS = (0, 5, 300, 1800, 7200, 18000, 36000)
+
+# Type of the on-disable hook — wiring plugs email notification in here so
+# the executor never grows an email dependency.
+OnDisabled = Callable[[WebhookEndpointDoc, str], Awaitable[None]]
+
+
+class DeliveryExecutor:
+    def __init__(
+        self,
+        delivery_repo: WebhookDeliveryRepository,
+        endpoint_repo: WebhookEndpointRepository,
+        event_repo: WebhookEventRepository,
+        renderers: dict[str, Renderer],
+        *,
+        master_secret: str,
+        delivery_timeout: float = 15.0,
+        max_payload_bytes: int = 20_480,
+        max_consecutive_failures: int = 10,
+        poll_interval: float = 1.0,
+        lease_seconds: int = 60,
+        on_disabled: OnDisabled | None = None,
+    ) -> None:
+        self._deliveries = delivery_repo
+        self._endpoints = endpoint_repo
+        self._events = event_repo
+        self._renderers = renderers
+        self._master_secret = master_secret
+        self._timeout = delivery_timeout
+        self._max_bytes = max_payload_bytes
+        self._max_consecutive = max_consecutive_failures
+        self._poll_interval = poll_interval
+        self._lease = lease_seconds
+        self._on_disabled = on_disabled
+
+    # ── Loop ─────────────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        """Long-lived task; cancellation is the shutdown path."""
+        log.info("webhook_executor_started", poll_interval=self._poll_interval)
+        while True:
+            try:
+                row = await self._deliveries.claim_due(lease_seconds=self._lease)
+                if row is None:
+                    await asyncio.sleep(self._poll_interval)
+                    continue
+                await self.attempt(row)
+            except asyncio.CancelledError:
+                log.info("webhook_executor_stopped")
+                raise
+            except Exception as exc:
+                # One bad row must not kill the loop.
+                log.error(
+                    "webhook_executor_tick_failed",
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                await asyncio.sleep(self._poll_interval)
+
+    # ── One attempt ──────────────────────────────────────────────────────
+
+    async def attempt(self, row: WebhookDeliveryDoc) -> None:
+        endpoint = await self._endpoints.find_by_id(row.endpoint_id)
+        if endpoint is None or endpoint.status != WebhookStatus.ACTIVE:
+            await self._deliveries.mark_failed(row.id, "endpoint_inactive")
+            return
+
+        body = row.rendered_body
+        if body is None:
+            body = await self._render(row, endpoint)
+            if body is None:
+                return  # _render already recorded the terminal failure
+
+        started = time.monotonic()
+        result = await post_public(
+            endpoint.url,
+            body,
+            headers=self._headers(row.webhook_id, body, endpoint),
+            timeout=self._timeout,
+        )
+        duration_ms = int((time.monotonic() - started) * 1000)
+        attempt = DeliveryAttempt(
+            attempted_at=datetime.now(timezone.utc),
+            status_code=result.status_code,
+            duration_ms=duration_ms,
+            error=result.error,
+            response_body=result.body_snippet,
+        )
+
+        ok = result.status_code is not None and 200 <= result.status_code < 300
+        if ok:
+            await self._deliveries.record_attempt_and_finish(
+                row.id, attempt, DeliveryStatus.SUCCESS
+            )
+            await self._endpoints.record_success(endpoint.id)
+            return
+
+        if result.status_code == 410:
+            await self._deliveries.record_attempt_and_finish(
+                row.id, attempt, DeliveryStatus.FAILED
+            )
+            await self._disable(endpoint, EndpointDisabledReason.GONE)
+            return
+
+        # attempt_count on the claimed row predates this attempt.
+        attempts_done = row.attempt_count + 1
+        if attempts_done >= len(RETRY_SCHEDULE_SECONDS):
+            await self._deliveries.record_attempt_and_finish(
+                row.id, attempt, DeliveryStatus.FAILED
+            )
+            reason = result.error or f"status {result.status_code}"
+            streak = await self._endpoints.record_exhausted(endpoint.id, reason)
+            if streak >= self._max_consecutive:
+                await self._disable(
+                    endpoint, EndpointDisabledReason.CONSECUTIVE_FAILURES
+                )
+            return
+
+        delay = RETRY_SCHEDULE_SECONDS[attempts_done]
+        await self._deliveries.record_attempt_and_reschedule(
+            row.id,
+            attempt,
+            datetime.now(timezone.utc) + timedelta(seconds=delay),
+        )
+
+    # ── Internals ────────────────────────────────────────────────────────
+
+    async def _render(
+        self, row: WebhookDeliveryDoc, endpoint: WebhookEndpointDoc
+    ) -> str | None:
+        event = await self._events.find_by_oid(row.event_oid)
+        if event is None:
+            # TTL race at the 30-day edge — terminal, never a crash.
+            await self._deliveries.mark_failed(row.id, "event_expired")
+            return None
+        renderer = self._renderers.get(endpoint.flavor.value)
+        if renderer is None:
+            await self._deliveries.mark_failed(
+                row.id, f"unknown_flavor:{endpoint.flavor}"
+            )
+            return None
+        payload = dict(event.payload)
+        if row.dropped_since_last:
+            payload["dropped_since_last"] = row.dropped_since_last
+        body = renderer.render(event.type, event.occurred_at.isoformat(), payload)
+        if len(body.encode()) > self._max_bytes:
+            await self._deliveries.mark_failed(row.id, "payload_over_cap")
+            return None
+        await self._deliveries.set_rendered_body(row.id, body)
+        return body
+
+    def _headers(
+        self, webhook_id: str, body: str, endpoint: WebhookEndpointDoc
+    ) -> dict[str, str]:
+        """Fresh timestamp per attempt (replay protection); dual signatures
+        during a rotation grace window, space-delimited per the spec."""
+        ts = int(time.time())
+        secret = decrypt_secret(
+            endpoint.signing_secret_enc, self._master_secret, domain=SECRET_ENC_DOMAIN
+        )
+        signatures = [sign(webhook_id, ts, body, secret)]
+        if endpoint.previous_secret_enc and (
+            endpoint.previous_secret_expires_at
+            and endpoint.previous_secret_expires_at > datetime.now(timezone.utc)
+        ):
+            previous = decrypt_secret(
+                endpoint.previous_secret_enc,
+                self._master_secret,
+                domain=SECRET_ENC_DOMAIN,
+            )
+            signatures.append(sign(webhook_id, ts, body, previous))
+        return {
+            HEADER_ID: webhook_id,
+            HEADER_TIMESTAMP: str(ts),
+            HEADER_SIGNATURE: " ".join(signatures),
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+
+    async def _disable(
+        self, endpoint: WebhookEndpointDoc, reason: EndpointDisabledReason
+    ) -> None:
+        await self._endpoints.disable(endpoint.id, reason)
+        log.warning(
+            "webhook_endpoint_disabled",
+            endpoint_id=str(endpoint.id),
+            reason=reason.value,
+        )
+        if self._on_disabled is not None:
+            try:
+                await self._on_disabled(endpoint, reason.value)
+            except Exception as exc:
+                log.error("webhook_disabled_notify_failed", error=str(exc))

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -1,6 +1,6 @@
 """DeliveryExecutor — the Mongo claim loop that actually delivers.
 
-Mongo-only by design (TRD D2): claim → render (first attempt only) →
+Mongo-only by design: claim → render (first attempt only) →
 sign → POST → record. No Redis anywhere in the retry path, which is what
 lets the same class run in the click worker (prod) or embedded in the
 app lifespan (self-host rungs). Atomic claims with a lease make N
@@ -136,7 +136,27 @@ class DeliveryExecutor:
                 row.id, attempt, DeliveryStatus.SUCCESS
             )
             await self._endpoints.record_success(endpoint.id)
+            log.info(
+                "webhook_delivered",
+                endpoint_id=str(endpoint.id),
+                event_type=row.event_type,
+                webhook_id=row.webhook_id,
+                status_code=result.status_code,
+                duration_ms=duration_ms,
+                attempt=row.attempt_count + 1,
+                is_test=row.is_test,
+            )
             return
+        log.warning(
+            "webhook_delivery_attempt_failed",
+            endpoint_id=str(endpoint.id),
+            event_type=row.event_type,
+            webhook_id=row.webhook_id,
+            status_code=result.status_code,
+            error=result.error,
+            duration_ms=duration_ms,
+            attempt=row.attempt_count + 1,
+        )
 
         if result.status_code == 410:
             await self._deliveries.record_attempt_and_finish(

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -14,6 +14,7 @@ import asyncio
 import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
 
 from infrastructure.crypto import decrypt_secret
 from infrastructure.logging import get_logger
@@ -152,7 +153,7 @@ class DeliveryExecutor:
 
         started = time.monotonic()
         result = await post_public(
-            endpoint.url,
+            self._delivery_url(endpoint),
             body,
             headers=headers,
             timeout=self._timeout,
@@ -255,6 +256,17 @@ class DeliveryExecutor:
         )
 
     # ── Internals ────────────────────────────────────────────────────────
+
+    def _delivery_url(self, endpoint: WebhookEndpointDoc) -> str:
+        """Endpoint URL plus any query params the flavor's renderer
+        declares (Discord's components-v2 bodies need
+        ``with_components=true``). The signature covers the body alone,
+        so delivery mechanics can ride the URL."""
+        renderer = self._renderers.get(endpoint.flavor.value)
+        query = getattr(renderer, "url_query", None)
+        if not query:
+            return endpoint.url
+        return endpoint.url + ("&" if "?" in endpoint.url else "?") + urlencode(query)
 
     async def _render(
         self, row: WebhookDeliveryDoc, endpoint: WebhookEndpointDoc

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -205,7 +205,9 @@ class DeliveryExecutor:
         payload = dict(event.payload)
         if row.dropped_since_last:
             payload["dropped_since_last"] = row.dropped_since_last
-        body = renderer.render(event.type, event.occurred_at.isoformat(), payload)
+        body = renderer.render(
+            event.event_id, event.type, event.occurred_at.isoformat(), payload
+        )
         if len(body.encode()) > self._max_bytes:
             await self._deliveries.mark_failed(row.id, "payload_over_cap")
             return None

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -273,8 +273,14 @@ class DeliveryExecutor:
         payload = dict(event.payload)
         if row.dropped_since_last:
             payload["dropped_since_last"] = row.dropped_since_last
+        # Mongo returns naive datetimes; the wire timestamp must carry its
+        # UTC offset or consumers (and Discord's local-time rendering)
+        # can't place it.
         body = renderer.render(
-            event.event_id, event.type, event.occurred_at.isoformat(), payload
+            event.event_id,
+            event.type,
+            as_aware_utc(event.occurred_at).isoformat(),
+            payload,
         )
         if len(body.encode()) > self._max_bytes:
             await self._deliveries.mark_failed(row.id, "payload_over_cap")

--- a/services/webhooks/matcher.py
+++ b/services/webhooks/matcher.py
@@ -4,7 +4,7 @@ Stateless predicates over the single event in hand; anything needing
 memory is the alerts engine's job, enforced by this class having no
 storage access beyond the endpoints query.
 
-The owner cache (D16) exists for one reason: at click rate the common
+The owner cache exists for one reason: at click rate the common
 case is "this owner has no webhooks", and that answer must come from
 Redis, not Mongo. Write-through invalidation from WebhookService on
 every endpoint mutation; degrades to per-event queries without Redis —

--- a/services/webhooks/matcher.py
+++ b/services/webhooks/matcher.py
@@ -1,0 +1,109 @@
+"""Subscription matching — which endpoints care about this event.
+
+Stateless predicates over the single event in hand; anything needing
+memory is the alerts engine's job, enforced by this class having no
+storage access beyond the endpoints query.
+
+The owner cache (D16) exists for one reason: at click rate the common
+case is "this owner has no webhooks", and that answer must come from
+Redis, not Mongo. Write-through invalidation from WebhookService on
+every endpoint mutation; degrades to per-event queries without Redis —
+which is exactly the deployment rung where click volume is small.
+"""
+
+from __future__ import annotations
+
+import redis.asyncio as aioredis
+from bson import ObjectId
+
+from infrastructure.logging import get_logger
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from schemas.models.webhook import WebhookEndpointDoc
+from services.events.contract import DomainEvent
+from services.webhooks.registry import expand
+
+log = get_logger(__name__)
+
+_CACHE_KEY = "wh:sub:{owner_id}"
+
+
+class OwnerSubscriptionCache:
+    """owner_id → active endpoint count ("0" short-circuits matching)."""
+
+    def __init__(self, redis_client: aioredis.Redis | None, ttl_seconds: int) -> None:
+        self._redis = redis_client
+        self._ttl = ttl_seconds
+
+    async def get(self, owner_id: str) -> int | None:
+        if self._redis is None:
+            return None
+        try:
+            raw = await self._redis.get(_CACHE_KEY.format(owner_id=owner_id))
+            return int(raw) if raw is not None else None
+        except Exception:
+            return None  # cache trouble must never block matching
+
+    async def set(self, owner_id: str, count: int) -> None:
+        if self._redis is None:
+            return
+        try:
+            await self._redis.set(
+                _CACHE_KEY.format(owner_id=owner_id), str(count), ex=self._ttl
+            )
+        except Exception:
+            log.warning("webhook_sub_cache_set_failed", owner_id=owner_id)
+
+    async def invalidate(self, owner_id: str) -> None:
+        if self._redis is None:
+            return
+        try:
+            await self._redis.delete(_CACHE_KEY.format(owner_id=owner_id))
+        except Exception:
+            log.warning("webhook_sub_cache_invalidate_failed", owner_id=owner_id)
+
+
+def event_link_id(event: DomainEvent) -> ObjectId | None:
+    """Extract the subject link id for scope evaluation (None for
+    non-link events — scope never excludes those)."""
+    raw = event.data.get("link_id")
+    if raw is None:
+        link = event.data.get("link")
+        if isinstance(link, dict):
+            raw = link.get("link_id")
+    if isinstance(raw, str) and ObjectId.is_valid(raw):
+        return ObjectId(raw)
+    return None
+
+
+class SubscriptionMatcher:
+    def __init__(
+        self,
+        endpoint_repo: WebhookEndpointRepository,
+        cache: OwnerSubscriptionCache,
+    ) -> None:
+        self._repo = endpoint_repo
+        self._cache = cache
+
+    async def match(self, event: DomainEvent) -> list[WebhookEndpointDoc]:
+        cached = await self._cache.get(event.owner_id)
+        if cached == 0:
+            return []
+
+        owner_oid = ObjectId(event.owner_id)
+        endpoints = await self._repo.find_active_for_owner(owner_oid)
+        if cached is None:
+            await self._cache.set(event.owner_id, len(endpoints))
+        if not endpoints:
+            return []
+
+        link_id = event_link_id(event)
+        matched = []
+        for ep in endpoints:
+            # Patterns stored verbatim, expanded at match time so `link.*`
+            # subscribers pick up event types added after they subscribed.
+            if event.type not in expand(ep.events):
+                continue
+            if event.type.startswith("link.") and not ep.scope.matches_link(link_id):
+                continue
+            matched.append(ep)
+        return matched

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -1,0 +1,107 @@
+"""Payload builders — internal facts → public webhook payloads.
+
+The one place internal shapes (ClickEvent, UrlV2Doc) are projected into
+the payloads the registry documents. Privacy inherits structurally from
+the sources (ClickEvent strips password material and sanitizes UTM);
+this module additionally guarantees no raw IP and no password hashes
+ever reach a payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ua_parser import parse as ua_parse
+
+from infrastructure.geoip import GeoIPService
+from schemas.models.base import ANONYMOUS_OWNER_ID
+from schemas.models.url import UrlV2Doc
+from services.click.bot_detection import get_bot_name, is_bot_request
+from services.click.events import ClickEvent
+from services.click.handlers import classify_device
+from services.events.contract import DomainEvent
+
+
+def short_url_of(domain: str, alias: str) -> str:
+    return f"https://{domain}/{alias}"
+
+
+def link_snapshot(doc: UrlV2Doc) -> dict[str, Any]:
+    """The public snapshot carried by every link.* lifecycle event."""
+    return {
+        "link_id": str(doc.id),
+        "alias": doc.alias,
+        "domain": doc.domain,
+        "short_url": short_url_of(doc.domain, doc.alias),
+        "long_url": doc.long_url,
+        "status": doc.status.value,
+        "password_protected": doc.password is not None,
+        "block_bots": bool(doc.block_bots),
+        "max_clicks": doc.max_clicks,
+        "expires_at": doc.expire_after.isoformat() if doc.expire_after else None,
+        "total_clicks": doc.total_clicks,
+        "created_at": doc.created_at.isoformat(),
+    }
+
+
+def link_owner_id(doc: UrlV2Doc) -> str | None:
+    """Anonymous links have no possible subscriber — producers skip emit."""
+    if doc.owner_id == ANONYMOUS_OWNER_ID:
+        return None
+    return str(doc.owner_id)
+
+
+def build_link_clicked(
+    event: ClickEvent,
+    system_default_domain: str,
+    geoip: GeoIPService | None = None,
+) -> DomainEvent | None:
+    """Adapt a ClickEvent (events:clicks wire) to a link.clicked DomainEvent.
+
+    Returns None for unowned links — subscriptions are per-owner, so
+    anonymous/v1 clicks have no possible subscriber and skip the
+    (comparatively expensive) UA parse entirely.
+    """
+    owner_id = event.url.owner_id
+    if owner_id is None or owner_id == str(ANONYMOUS_OWNER_ID):
+        return None
+
+    ua = ua_parse(event.user_agent)
+    browser = ua.user_agent.family if ua.user_agent else None
+    os_family = ua.os.family if ua.os else None
+    device = classify_device(ua, event.user_agent)
+    bot = is_bot_request(event.user_agent)
+
+    # Geo links carry the routing decision; everything else resolves the
+    # same mmdb the stats consumer uses. IP itself never leaves this frame.
+    country = event.resolved_country
+    if country is None and geoip is not None:
+        country = geoip.get_country_code(event.client_ip)
+
+    domain = event.url.domain or system_default_domain
+    return DomainEvent(
+        type="link.clicked",
+        owner_id=owner_id,
+        occurred_at=event.enqueued_at,
+        data={
+            "link_id": event.url.id,
+            "alias": event.short_code,
+            "domain": domain,
+            "short_url": short_url_of(domain, event.short_code),
+            "clicked_at": event.enqueued_at.isoformat(),
+            "country": country,
+            "city": event.cf_city,
+            "browser": browser,
+            "os": os_family,
+            "device": device,
+            "referrer": event.referrer,
+            "utm": {
+                "source": event.utm_source,
+                "medium": event.utm_medium,
+                "campaign": event.utm_campaign,
+            },
+            "is_bot": bot,
+            "bot_name": get_bot_name(event.user_agent) if bot else None,
+            "total_clicks": event.url.total_clicks,
+        },
+    )

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -9,13 +9,14 @@ ever reach a payload.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from ua_parser import parse as ua_parse
 
 from infrastructure.geoip import GeoIPService
 from schemas.models.base import ANONYMOUS_OWNER_ID
-from schemas.models.url import UrlV2Doc
+from schemas.models.url import LinkMetaTags, UrlStatus, UrlV2Doc
 from services.click.bot_detection import get_bot_name, is_bot_request
 from services.click.events import ClickEvent
 from services.click.handlers import classify_device
@@ -49,6 +50,51 @@ def link_owner_id(doc: UrlV2Doc) -> str | None:
     if doc.owner_id == ANONYMOUS_OWNER_ID:
         return None
     return str(doc.owner_id)
+
+
+_META_TAGS_PUBLIC_FIELDS = ("title", "description", "image", "color")
+
+
+def _event_change_value(field_name: str, value: object) -> object:
+    """Project one changed value into its public wire form.
+
+    Secrets and internal bookkeeping are stripped structurally here so
+    every producer of the changes map inherits the guarantee: password
+    material never rides the backbone, meta_tags keep only their public
+    fields (``updated_ip``/``updated_at``/``image_meta`` are internal),
+    and datetimes are ISO-8601 like every other timestamp on the wire.
+    """
+    if value is None:
+        return None
+    if isinstance(value, UrlStatus):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if field_name == "meta_tags":
+        raw = value.model_dump() if isinstance(value, LinkMetaTags) else dict(value)
+        return {k: raw.get(k) for k in _META_TAGS_PUBLIC_FIELDS}
+    return value
+
+
+def event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
+    """update_ops → the public ``changes`` map for link.updated. Shared by
+    the single-item and bulk producers so the wire shape cannot fork."""
+    changes: dict = {}
+    for field_name, new_value in update_ops.items():
+        if field_name == "updated_at":
+            continue
+        old_value = getattr(existing, field_name, None)
+        if field_name == "password":
+            # Presence booleans only — hashes must never ride the backbone
+            # (same posture as ClickEvent's password strip).
+            old_value = old_value is not None
+            new_value = new_value is not None
+            field_name = "password_protected"
+        changes[field_name] = {
+            "old": _event_change_value(field_name, old_value),
+            "new": _event_change_value(field_name, new_value),
+        }
+    return changes
 
 
 def build_link_expired(doc: UrlV2Doc, reason: str) -> DomainEvent | None:

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -27,8 +27,21 @@ def short_url_of(domain: str, alias: str) -> str:
     return f"https://{domain}/{alias}"
 
 
+def _public_meta_tags(meta: LinkMetaTags | None) -> dict[str, Any] | None:
+    """Public projection of meta tags — updated_ip/updated_at/image_meta
+    are internal bookkeeping and never ride the wire."""
+    if meta is None:
+        return None
+    return {k: getattr(meta, k, None) for k in _META_TAGS_PUBLIC_FIELDS}
+
+
 def link_snapshot(doc: UrlV2Doc) -> dict[str, Any]:
-    """The public snapshot carried by every link.* lifecycle event."""
+    """The public snapshot carried by every link.* lifecycle event.
+
+    A projection of the link DOCUMENT, never of entitlements: feature
+    fields (geo_rules, meta_tags) are null when unset, which needs no
+    flag lookup — flags gate writes, the doc already carries the truth.
+    """
     return {
         "link_id": str(doc.id),
         "alias": doc.alias,
@@ -40,6 +53,8 @@ def link_snapshot(doc: UrlV2Doc) -> dict[str, Any]:
         "block_bots": bool(doc.block_bots),
         "max_clicks": doc.max_clicks,
         "expires_at": doc.expire_after.isoformat() if doc.expire_after else None,
+        "geo_rules": doc.geo_rules or None,
+        "meta_tags": _public_meta_tags(doc.meta_tags),
         "total_clicks": doc.total_clicks,
         "created_at": doc.created_at.isoformat(),
     }
@@ -71,14 +86,21 @@ def _event_change_value(field_name: str, value: object) -> object:
     if isinstance(value, datetime):
         return value.isoformat()
     if field_name == "meta_tags":
-        raw = value.model_dump() if isinstance(value, LinkMetaTags) else dict(value)
-        return {k: raw.get(k) for k in _META_TAGS_PUBLIC_FIELDS}
+        if isinstance(value, LinkMetaTags):
+            return _public_meta_tags(value)
+        return {k: dict(value).get(k) for k in _META_TAGS_PUBLIC_FIELDS}
     return value
+
+
+# Internal field name → the public snapshot vocabulary. One resource,
+# one vocabulary: a consumer must never meet two names for one field.
+_CHANGE_KEY_PUBLIC = {"expire_after": "expires_at"}
 
 
 def event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
     """update_ops → the public ``changes`` map for link.updated. Shared by
-    the single-item and bulk producers so the wire shape cannot fork."""
+    the single-item and bulk producers so the wire shape cannot fork.
+    Keys speak the snapshot's public names, never Mongo field names."""
     changes: dict = {}
     for field_name, new_value in update_ops.items():
         if field_name == "updated_at":
@@ -90,7 +112,8 @@ def event_changes(existing: UrlV2Doc, update_ops: dict) -> dict:
             old_value = old_value is not None
             new_value = new_value is not None
             field_name = "password_protected"
-        changes[field_name] = {
+        public_name = _CHANGE_KEY_PUBLIC.get(field_name, field_name)
+        changes[public_name] = {
             "old": _event_change_value(field_name, old_value),
             "new": _event_change_value(field_name, new_value),
         }
@@ -148,6 +171,7 @@ def build_link_clicked(
             "alias": event.short_code,
             "domain": domain,
             "short_url": short_url_of(domain, event.short_code),
+            "long_url": event.url.long_url,
             "clicked_at": event.enqueued_at.isoformat(),
             "country": country,
             "city": event.cf_city,

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -145,7 +145,7 @@ def build_link_expired(doc: UrlV2Doc, reason: str) -> DomainEvent | None:
     )
 
 
-def build_link_clicked(
+async def build_link_clicked(
     event: ClickEvent,
     system_default_domain: str,
     geoip: GeoIPService | None = None,
@@ -155,6 +155,10 @@ def build_link_clicked(
     Returns None for unowned links — subscriptions are per-owner, so
     anonymous/v1 clicks have no possible subscriber and skip the
     (comparatively expensive) UA parse entirely.
+
+    Async because the geoip fallback lookup is async; every caller is
+    already in an async context (the webhooks consumer and the inline
+    fanout sink).
     """
     owner_id = event.url.owner_id
     if owner_id is None or owner_id == str(ANONYMOUS_OWNER_ID):
@@ -170,7 +174,7 @@ def build_link_clicked(
     # same mmdb the stats consumer uses. IP itself never leaves this frame.
     country = event.resolved_country
     if country is None and geoip is not None:
-        country = geoip.get_country_code(event.client_ip)
+        country = await geoip.get_country_code(event.client_ip)
 
     domain = event.url.domain or system_default_domain
     return DomainEvent(

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -51,6 +51,20 @@ def link_owner_id(doc: UrlV2Doc) -> str | None:
     return str(doc.owner_id)
 
 
+def build_link_expired(doc: UrlV2Doc, reason: str) -> DomainEvent | None:
+    """link.expired fires at DISCOVERY time: the max-clicks branch of the
+    click handler, or the redirect path's lazy time-expiry flip. Both are
+    once-per-link (atomic conditional updates gate the emit)."""
+    owner = link_owner_id(doc)
+    if owner is None:
+        return None
+    return DomainEvent(
+        type="link.expired",
+        owner_id=owner,
+        data={"link": link_snapshot(doc), "reason": reason},
+    )
+
+
 def build_link_clicked(
     event: ClickEvent,
     system_default_domain: str,

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -9,6 +9,7 @@ ever reach a payload.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any
 
@@ -21,6 +22,16 @@ from services.click.bot_detection import get_bot_name, is_bot_request
 from services.click.events import ClickEvent
 from services.click.handlers import classify_device
 from services.events.contract import DomainEvent
+
+# Raw UA is visitor-controlled input — bound and strip control chars
+# before it rides the wire (same posture as ClickEvent's UTM bound).
+_UA_MAX_LEN = 512
+_UA_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _wire_user_agent(user_agent: str) -> str | None:
+    cleaned = _UA_CONTROL_CHARS_RE.sub("", user_agent).strip()[:_UA_MAX_LEN]
+    return cleaned or None
 
 
 def short_url_of(domain: str, alias: str) -> str:
@@ -178,6 +189,7 @@ def build_link_clicked(
             "browser": browser,
             "os": os_family,
             "device": device,
+            "user_agent": _wire_user_agent(event.user_agent),
             "referrer": event.referrer,
             "utm": {
                 "source": event.utm_source,

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -1,0 +1,379 @@
+"""EVENT_REGISTRY — the webhook event catalog as code.
+
+One registry drives five things that therefore can never drift: publish-time
+payload validation, the public catalog endpoint, docs sample payloads, test
+sends, and wildcard expansion.
+
+Catalog governance (the forever-contract rules):
+- An event is a fact someone would act on without having been there.
+- Payload = full resource snapshot + event context. Additive changes only;
+  remove/rename = envelope version bump.
+- Per-field events are never minted unless the reaction class differs
+  (``link.status_changed`` exists; ``link.password_changed`` never will).
+- ``link.clicked`` fires for every TRACKED click including bots (``is_bot``
+  rides the payload); ``bot.detected`` fires only for BLOCKED bots (which
+  produce no click) — one visit never fires both.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from difflib import get_close_matches
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from errors import ValidationError
+
+_SAMPLE_LINK_ID = "665f1f77bcf86cd799439011"
+_SAMPLE_OWNER_ID = "507f1f77bcf86cd799439011"
+
+
+# ── Payload models ────────────────────────────────────────────────────────────
+# extra="allow" on the base: payloads are additive-forever (consumers must
+# tolerate new fields), so validation pins required shape without freezing it.
+
+
+class _PayloadBase(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class LinkSnapshot(_PayloadBase):
+    """The public snapshot of a link — field names track UrlResponse."""
+
+    link_id: str
+    alias: str
+    domain: str
+    short_url: str
+    long_url: str
+    status: str
+    password_protected: bool = False
+    block_bots: bool = False
+    max_clicks: int | None = None
+    expires_at: str | None = None
+    total_clicks: int = 0
+    created_at: str
+
+
+class LinkLifecyclePayload(_PayloadBase):
+    link: LinkSnapshot
+
+
+class LinkUpdatedPayload(_PayloadBase):
+    link: LinkSnapshot
+    changes: dict[str, dict[str, Any]]  # field -> {"old": …, "new": …}
+
+
+class LinkStatusChangedPayload(_PayloadBase):
+    link: LinkSnapshot
+    old_status: str
+    new_status: str
+    reason: str | None = None
+
+
+class LinkClickedPayload(_PayloadBase):
+    link_id: str
+    alias: str
+    domain: str
+    short_url: str
+    clicked_at: str
+    country: str | None = None
+    city: str | None = None
+    browser: str | None = None
+    os: str | None = None
+    device: str | None = None
+    referrer: str | None = None
+    utm: dict[str, str | None] | None = None
+    is_bot: bool = False
+    bot_name: str | None = None
+    total_clicks: int | None = None
+
+
+class LinkExpiredPayload(_PayloadBase):
+    link: LinkSnapshot
+    reason: str  # "max_clicks_reached" | "time_expired"
+
+
+class BotDetectedPayload(_PayloadBase):
+    link_id: str
+    alias: str
+    domain: str
+    bot_name: str | None = None
+    country: str | None = None
+    blocked: bool = True
+
+
+class DomainLifecyclePayload(_PayloadBase):
+    domain_id: str
+    fqdn: str
+    status: str
+    reason: str | None = None
+
+
+class KeyCreatedPayload(_PayloadBase):
+    key_id: str
+    name: str
+    prefix: str
+    scopes: list[str] = []
+
+
+class WebhookTestPayload(_PayloadBase):
+    message: str
+
+
+# ── Samples ───────────────────────────────────────────────────────────────────
+
+
+def _sample_link() -> dict[str, Any]:
+    return {
+        "link_id": _SAMPLE_LINK_ID,
+        "alias": "summer-drop",
+        "domain": "spoo.me",
+        "short_url": "https://spoo.me/summer-drop",
+        "long_url": "https://example.com/campaign",
+        "status": "ACTIVE",
+        "password_protected": False,
+        "block_bots": False,
+        "max_clicks": None,
+        "expires_at": None,
+        "total_clicks": 4102,
+        "created_at": "2026-07-01T09:00:00+00:00",
+    }
+
+
+# ── Registry ──────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class EventTypeSpec:
+    name: str
+    category: str  # "link" | "domain" | "key"
+    description: str
+    frequency: str  # "high" | "low"
+    payload_model: type[BaseModel]
+    sample: Callable[[], dict[str, Any]]
+
+
+EVENT_REGISTRY: dict[str, EventTypeSpec] = {
+    spec.name: spec
+    for spec in (
+        EventTypeSpec(
+            name="link.created",
+            category="link",
+            description="A short link was created.",
+            frequency="low",
+            payload_model=LinkLifecyclePayload,
+            sample=lambda: {"link": _sample_link()},
+        ),
+        EventTypeSpec(
+            name="link.updated",
+            category="link",
+            description=(
+                "A short link was edited. `changes` maps each edited field "
+                "to its old and new values."
+            ),
+            frequency="low",
+            payload_model=LinkUpdatedPayload,
+            sample=lambda: {
+                "link": _sample_link(),
+                "changes": {
+                    "long_url": {
+                        "old": "https://example.com/old",
+                        "new": "https://example.com/campaign",
+                    }
+                },
+            },
+        ),
+        EventTypeSpec(
+            name="link.deleted",
+            category="link",
+            description="A short link was deleted.",
+            frequency="low",
+            payload_model=LinkLifecyclePayload,
+            sample=lambda: {"link": _sample_link()},
+        ),
+        EventTypeSpec(
+            name="link.status_changed",
+            category="link",
+            description=(
+                "A link's status changed (activated, deactivated, blocked, expired)."
+            ),
+            frequency="low",
+            payload_model=LinkStatusChangedPayload,
+            sample=lambda: {
+                "link": {**_sample_link(), "status": "BLOCKED"},
+                "old_status": "ACTIVE",
+                "new_status": "BLOCKED",
+                "reason": "abuse_report",
+            },
+        ),
+        EventTypeSpec(
+            name="link.clicked",
+            category="link",
+            description=(
+                "A tracked click was recorded (bots included — check "
+                "`is_bot`). Edge-served clicks are not tracked."
+            ),
+            frequency="high",
+            payload_model=LinkClickedPayload,
+            sample=lambda: {
+                "link_id": _SAMPLE_LINK_ID,
+                "alias": "summer-drop",
+                "domain": "spoo.me",
+                "short_url": "https://spoo.me/summer-drop",
+                "clicked_at": "2026-07-22T14:03:10+00:00",
+                "country": "IN",
+                "city": "Mumbai",
+                "browser": "Chrome",
+                "os": "Android",
+                "device": "mobile",
+                "referrer": "https://x.com/",
+                "utm": {"source": "newsletter", "medium": "email", "campaign": None},
+                "is_bot": False,
+                "bot_name": None,
+                "total_clicks": 4102,
+            },
+        ),
+        EventTypeSpec(
+            name="link.expired",
+            category="link",
+            description=(
+                "A link expired (max clicks reached, or its expiry time was "
+                "discovered to have passed)."
+            ),
+            frequency="low",
+            payload_model=LinkExpiredPayload,
+            sample=lambda: {
+                "link": {**_sample_link(), "status": "EXPIRED", "max_clicks": 5000},
+                "reason": "max_clicks_reached",
+            },
+        ),
+        EventTypeSpec(
+            name="bot.detected",
+            category="link",
+            description=(
+                "A bot was blocked from a bot-protected link (blocked bots "
+                "produce no click event)."
+            ),
+            frequency="low",
+            payload_model=BotDetectedPayload,
+            sample=lambda: {
+                "link_id": _SAMPLE_LINK_ID,
+                "alias": "summer-drop",
+                "domain": "spoo.me",
+                "bot_name": "curl",
+                "country": "US",
+                "blocked": True,
+            },
+        ),
+        EventTypeSpec(
+            name="domain.verified",
+            category="domain",
+            description="A custom domain finished verification and is active.",
+            frequency="low",
+            payload_model=DomainLifecyclePayload,
+            sample=lambda: {
+                "domain_id": "666f1f77bcf86cd799439011",
+                "fqdn": "go.example.com",
+                "status": "active",
+                "reason": None,
+            },
+        ),
+        EventTypeSpec(
+            name="domain.suspended",
+            category="domain",
+            description="A custom domain was suspended (DNS no longer verifies).",
+            frequency="low",
+            payload_model=DomainLifecyclePayload,
+            sample=lambda: {
+                "domain_id": "666f1f77bcf86cd799439011",
+                "fqdn": "go.example.com",
+                "status": "suspended",
+                "reason": "dns_verification_failed",
+            },
+        ),
+        EventTypeSpec(
+            name="key.created",
+            category="key",
+            description=(
+                "An API key was created on your account (security audit signal)."
+            ),
+            frequency="low",
+            payload_model=KeyCreatedPayload,
+            sample=lambda: {
+                "key_id": "667f1f77bcf86cd799439011",
+                "name": "ci-deploys",
+                "prefix": "spoo_ab12",
+                "scopes": ["shorten:create"],
+            },
+        ),
+    )
+}
+
+# webhook.test is sendable (test sends may use any type above OR this one)
+# but not subscribable — it is delivered to the endpoint under test directly.
+TEST_EVENT_TYPE = "webhook.test"
+TEST_EVENT_SPEC = EventTypeSpec(
+    name=TEST_EVENT_TYPE,
+    category="webhook",
+    description="A test ping sent from the dashboard or API.",
+    frequency="low",
+    payload_model=WebhookTestPayload,
+    sample=lambda: {"message": "If you can read this, your endpoint works."},
+)
+
+_WILDCARD_ALL = "*"
+
+
+def valid_patterns() -> frozenset[str]:
+    """Every string accepted in an endpoint's ``events`` list."""
+    names = set(EVENT_REGISTRY)
+    categories = {f"{spec.category}.*" for spec in EVENT_REGISTRY.values()}
+    return frozenset(names | categories | {_WILDCARD_ALL})
+
+
+def expand(patterns: list[str]) -> frozenset[str]:
+    """Expand subscription patterns to concrete event names.
+
+    Expansion happens at MATCH time against the current registry (never
+    persisted expanded), so ``link.*`` subscribers pick up future link
+    events automatically.
+    """
+    out: set[str] = set()
+    for pattern in patterns:
+        if pattern == _WILDCARD_ALL:
+            return frozenset(EVENT_REGISTRY)
+        if pattern.endswith(".*"):
+            category = pattern[:-2]
+            out.update(
+                name
+                for name, spec in EVENT_REGISTRY.items()
+                if spec.category == category
+            )
+        elif pattern in EVENT_REGISTRY:
+            out.add(pattern)
+    return frozenset(out)
+
+
+def validate_patterns(patterns: list[str]) -> None:
+    """Raise ValidationError (with a typo suggestion) on unknown patterns."""
+    valid = valid_patterns()
+    for pattern in patterns:
+        if pattern in valid:
+            continue
+        suggestion = get_close_matches(pattern, sorted(valid), n=1, cutoff=0.6)
+        hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+        raise ValidationError(f"Unknown event type '{pattern}'.{hint}")
+
+
+def validate_payload(event_type: str, payload: dict[str, Any]) -> None:
+    """Publish-time payload validation against the registry model."""
+    spec = (
+        TEST_EVENT_SPEC
+        if event_type == TEST_EVENT_TYPE
+        else EVENT_REGISTRY.get(event_type)
+    )
+    if spec is None:
+        raise ValidationError(f"Unknown event type '{event_type}'")
+    spec.payload_model.model_validate(payload)

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -8,8 +8,12 @@ Catalog governance (the forever-contract rules):
 - An event is a fact someone would act on without having been there.
 - Payload = full resource snapshot + event context. Additive changes only;
   remove/rename = envelope version bump.
-- Per-field events are never minted unless the reaction class differs
-  (``link.status_changed`` exists; ``link.password_changed`` never will).
+- Events split by CAUSER, not by field: actor edits (owner, API key,
+  connected app) ride ``link.updated`` and its ``changes`` map — status
+  included; system-discovered facts get named events (``link.expired``
+  today; ``link.blocked`` when the safety framework ships a producer).
+  ``link.status_changed`` was cut for violating this: it only ever fired
+  for owner edits and double-fired alongside ``link.updated``.
 - ``link.clicked`` fires for every TRACKED click including bots (``is_bot``
   rides the payload). Blocked bots on ``block_bots`` links produce no click
   and therefore no event — deliberate: a dedicated ``bot.detected`` event
@@ -65,13 +69,6 @@ class LinkLifecyclePayload(_PayloadBase):
 class LinkUpdatedPayload(_PayloadBase):
     link: LinkSnapshot
     changes: dict[str, dict[str, Any]]  # field -> {"old": …, "new": …}
-
-
-class LinkStatusChangedPayload(_PayloadBase):
-    link: LinkSnapshot
-    old_status: str
-    new_status: str
-    reason: str | None = None
 
 
 class LinkClickedPayload(_PayloadBase):
@@ -149,8 +146,8 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
             name="link.updated",
             category="link",
             description=(
-                "A short link was edited. `changes` maps each edited field "
-                "to its old and new values."
+                "A short link was edited (any field, status included). "
+                "`changes` maps each edited field to its old and new values."
             ),
             frequency="low",
             payload_model=LinkUpdatedPayload,
@@ -171,21 +168,6 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
             frequency="low",
             payload_model=LinkLifecyclePayload,
             sample=lambda: {"link": _sample_link()},
-        ),
-        EventTypeSpec(
-            name="link.status_changed",
-            category="link",
-            description=(
-                "A link's status changed (activated, deactivated, blocked, expired)."
-            ),
-            frequency="low",
-            payload_model=LinkStatusChangedPayload,
-            sample=lambda: {
-                "link": {**_sample_link(), "status": "BLOCKED"},
-                "old_status": "ACTIVE",
-                "new_status": "BLOCKED",
-                "reason": "abuse_report",
-            },
         ),
         EventTypeSpec(
             name="link.clicked",

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -11,8 +11,10 @@ Catalog governance (the forever-contract rules):
 - Per-field events are never minted unless the reaction class differs
   (``link.status_changed`` exists; ``link.password_changed`` never will).
 - ``link.clicked`` fires for every TRACKED click including bots (``is_bot``
-  rides the payload); ``bot.detected`` fires only for BLOCKED bots (which
-  produce no click) — one visit never fires both.
+  rides the payload). Blocked bots on ``block_bots`` links produce no click
+  and therefore no event — deliberate: a dedicated ``bot.detected`` event
+  was considered and cut (the payload flag covers the tracked case, and
+  blocked-bot noise isn't worth a forever-contract).
 """
 
 from __future__ import annotations
@@ -95,27 +97,11 @@ class LinkExpiredPayload(_PayloadBase):
     reason: str  # "max_clicks_reached" | "time_expired"
 
 
-class BotDetectedPayload(_PayloadBase):
-    link_id: str
-    alias: str
-    domain: str
-    bot_name: str | None = None
-    country: str | None = None
-    blocked: bool = True
-
-
 class DomainLifecyclePayload(_PayloadBase):
     domain_id: str
     fqdn: str
     status: str
     reason: str | None = None
-
-
-class KeyCreatedPayload(_PayloadBase):
-    key_id: str
-    name: str
-    prefix: str
-    scopes: list[str] = []
 
 
 class WebhookTestPayload(_PayloadBase):
@@ -148,7 +134,7 @@ def _sample_link() -> dict[str, Any]:
 @dataclass(frozen=True)
 class EventTypeSpec:
     name: str
-    category: str  # "link" | "domain" | "key"
+    category: str  # "link" | "domain"
     description: str
     frequency: str  # "high" | "low"
     payload_model: type[BaseModel]
@@ -250,24 +236,6 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
             },
         ),
         EventTypeSpec(
-            name="bot.detected",
-            category="link",
-            description=(
-                "A bot was blocked from a bot-protected link (blocked bots "
-                "produce no click event)."
-            ),
-            frequency="low",
-            payload_model=BotDetectedPayload,
-            sample=lambda: {
-                "link_id": _SAMPLE_LINK_ID,
-                "alias": "summer-drop",
-                "domain": "spoo.me",
-                "bot_name": "curl",
-                "country": "US",
-                "blocked": True,
-            },
-        ),
-        EventTypeSpec(
             name="domain.verified",
             category="domain",
             description="A custom domain finished verification and is active.",
@@ -291,21 +259,6 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
                 "fqdn": "go.example.com",
                 "status": "suspended",
                 "reason": "dns_verification_failed",
-            },
-        ),
-        EventTypeSpec(
-            name="key.created",
-            category="key",
-            description=(
-                "An API key was created on your account (security audit signal)."
-            ),
-            frequency="low",
-            payload_model=KeyCreatedPayload,
-            sample=lambda: {
-                "key_id": "667f1f77bcf86cd799439011",
-                "name": "ci-deploys",
-                "prefix": "spoo_ab12",
-                "scopes": ["shorten:create"],
             },
         ),
     )

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -197,6 +197,7 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
                 "browser": "Chrome",
                 "os": "Android",
                 "device": "mobile",
+                "user_agent": "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Mobile Safari/537.36",
                 "referrer": "https://x.com/",
                 "utm": {"source": "newsletter", "medium": "email", "campaign": None},
                 "is_bot": False,

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -46,7 +46,9 @@ class _PayloadBase(BaseModel):
 
 
 class LinkSnapshot(_PayloadBase):
-    """The public snapshot of a link — field names track UrlResponse."""
+    """The public snapshot of a link — field names track UrlResponse.
+    Feature fields are null when unset on the DOCUMENT (no entitlement
+    lookups on the event path — flags gate writes, not payloads)."""
 
     link_id: str
     alias: str
@@ -58,6 +60,8 @@ class LinkSnapshot(_PayloadBase):
     block_bots: bool = False
     max_clicks: int | None = None
     expires_at: str | None = None
+    geo_rules: dict[str, str] | None = None
+    meta_tags: dict[str, Any] | None = None
     total_clicks: int = 0
     created_at: str
 
@@ -83,6 +87,7 @@ class LinkClickedPayload(_PayloadBase):
     os: str | None = None
     device: str | None = None
     referrer: str | None = None
+    long_url: str | None = None
     utm: dict[str, str | None] | None = None
     is_bot: bool = False
     bot_name: str | None = None
@@ -113,6 +118,8 @@ def _sample_link() -> dict[str, Any]:
         "block_bots": False,
         "max_clicks": None,
         "expires_at": None,
+        "geo_rules": None,
+        "meta_tags": None,
         "total_clicks": 4102,
         "created_at": "2026-07-01T09:00:00+00:00",
     }
@@ -183,6 +190,7 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
                 "alias": "summer-drop",
                 "domain": "spoo.me",
                 "short_url": "https://spoo.me/summer-drop",
+                "long_url": "https://example.com/campaign",
                 "clicked_at": "2026-07-22T14:03:10+00:00",
                 "country": "IN",
                 "city": "Mumbai",

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -97,13 +97,6 @@ class LinkExpiredPayload(_PayloadBase):
     reason: str  # "max_clicks_reached" | "time_expired"
 
 
-class DomainLifecyclePayload(_PayloadBase):
-    domain_id: str
-    fqdn: str
-    status: str
-    reason: str | None = None
-
-
 class WebhookTestPayload(_PayloadBase):
     message: str
 
@@ -134,7 +127,7 @@ def _sample_link() -> dict[str, Any]:
 @dataclass(frozen=True)
 class EventTypeSpec:
     name: str
-    category: str  # "link" | "domain"
+    category: str  # "link" today; new categories get their own wildcard for free
     description: str
     frequency: str  # "high" | "low"
     payload_model: type[BaseModel]
@@ -233,32 +226,6 @@ EVENT_REGISTRY: dict[str, EventTypeSpec] = {
             sample=lambda: {
                 "link": {**_sample_link(), "status": "EXPIRED", "max_clicks": 5000},
                 "reason": "max_clicks_reached",
-            },
-        ),
-        EventTypeSpec(
-            name="domain.verified",
-            category="domain",
-            description="A custom domain finished verification and is active.",
-            frequency="low",
-            payload_model=DomainLifecyclePayload,
-            sample=lambda: {
-                "domain_id": "666f1f77bcf86cd799439011",
-                "fqdn": "go.example.com",
-                "status": "active",
-                "reason": None,
-            },
-        ),
-        EventTypeSpec(
-            name="domain.suspended",
-            category="domain",
-            description="A custom domain was suspended (DNS no longer verifies).",
-            frequency="low",
-            payload_model=DomainLifecyclePayload,
-            sample=lambda: {
-                "domain_id": "666f1f77bcf86cd799439011",
-                "fqdn": "go.example.com",
-                "status": "suspended",
-                "reason": "dns_verification_failed",
             },
         ),
     )

--- a/services/webhooks/renderers/__init__.py
+++ b/services/webhooks/renderers/__init__.py
@@ -1,11 +1,23 @@
 """Flavor registry — adding a flavor is a new module + one entry here."""
 
+from services.webhooks.renderers.discord import DiscordRenderer
 from services.webhooks.renderers.protocol import Renderer
 from services.webhooks.renderers.raw import RawRenderer
+from services.webhooks.renderers.slack import SlackRenderer
 
 
 def default_renderers() -> dict[str, Renderer]:
-    return {RawRenderer.flavor: RawRenderer()}
+    return {
+        RawRenderer.flavor: RawRenderer(),
+        DiscordRenderer.flavor: DiscordRenderer(),
+        SlackRenderer.flavor: SlackRenderer(),
+    }
 
 
-__all__ = ["RawRenderer", "Renderer", "default_renderers"]
+__all__ = [
+    "DiscordRenderer",
+    "RawRenderer",
+    "Renderer",
+    "SlackRenderer",
+    "default_renderers",
+]

--- a/services/webhooks/renderers/__init__.py
+++ b/services/webhooks/renderers/__init__.py
@@ -1,0 +1,11 @@
+"""Flavor registry — adding a flavor is a new module + one entry here."""
+
+from services.webhooks.renderers.protocol import Renderer
+from services.webhooks.renderers.raw import RawRenderer
+
+
+def default_renderers() -> dict[str, Renderer]:
+    return {RawRenderer.flavor: RawRenderer()}
+
+
+__all__ = ["RawRenderer", "Renderer", "default_renderers"]

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -97,7 +97,7 @@ def _title(event_type: str, link: dict[str, Any]) -> str:
     label = EVENT_LABELS.get(event_type, event_type)
     alias, domain = link.get("alias"), link.get("domain")
     if _present(alias) and _present(domain):
-        return f"{label} · {domain}/{alias}"
+        return f"{label}: {domain}/{alias}"
     return label
 
 
@@ -128,29 +128,40 @@ def _age_days(created_at: Any, occurred_at: str) -> int | None:
         return None
 
 
+def _country_display(code: Any) -> str:
+    """ISO alpha-2 → flag emoji + code; anything else passes through."""
+    text = str(code)
+    if len(text) == 2 and text.isascii() and text.isalpha():
+        upper = text.upper()
+        flag = "".join(chr(0x1F1E6 + ord(c) - 65) for c in upper)
+        return f"{flag} {upper}"
+    return text
+
+
 def _clicked_pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
-    """A click always renders at least Device and From — absent analytics
-    dimensions are skipped, but a referrer-less click IS a direct visit
-    and renders as one, never as an empty card."""
+    """One field per dimension — the airy grid IS the point. Absent
+    analytics dimensions are skipped, but a referrer-less click IS a
+    direct visit and the running count is always stated, so a card is
+    never empty."""
     pairs: list[tuple[str, str]] = []
 
-    place = [
-        str(v) for v in (payload.get("city"), payload.get("country")) if _present(v)
-    ]
-    if place:
-        pairs.append(("Location", ", ".join(place)))
-
-    agent = " · ".join(
-        str(payload[k]) for k in ("browser", "os", "device") if _present(payload.get(k))
-    )
-    pairs.append(("Device", agent or "not detected"))
+    if _present(payload.get("country")):
+        pairs.append(("Country", _country_display(payload["country"])))
+    if _present(payload.get("city")):
+        pairs.append(("City", str(payload["city"])))
+    if _present(payload.get("browser")):
+        pairs.append(("Browser", str(payload["browser"])))
+    if _present(payload.get("os")):
+        pairs.append(("OS", str(payload["os"])))
+    if _present(payload.get("device")):
+        pairs.append(("Device", str(payload["device"])))
 
     referrer = payload.get("referrer")
     pairs.append(("From", _referrer_host(referrer) if _present(referrer) else "direct"))
 
     utm = payload.get("utm")
     if isinstance(utm, dict):
-        campaign = " · ".join(str(v) for v in utm.values() if _present(v))
+        campaign = " / ".join(str(v) for v in utm.values() if _present(v))
         if campaign:
             pairs.append(("UTM", campaign))
 
@@ -159,8 +170,9 @@ def _clicked_pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
         pairs.append(("Bot", str(bot) if _present(bot) else "detected"))
 
     total = payload.get("total_clicks")
-    if isinstance(total, int) and total > 0:
-        pairs.append(("Clicks", f"{total:,}"))
+    if isinstance(total, int):
+        # Count at click time — the payload snapshot precedes the increment.
+        pairs.append(("Clicks so far", f"{total:,}"))
 
     return [(name, clip(value, _VALUE_MAX)) for name, value in pairs]
 
@@ -202,10 +214,20 @@ def _lifecycle_pairs(
                 f"{max_clicks:,}" if isinstance(max_clicks, int) else "unlimited",
             )
         )
-        if link.get("password_protected"):
-            pairs.append(("Password", "protected"))
-        if link.get("block_bots"):
-            pairs.append(("Bots", "blocked"))
+        pairs.append(
+            ("Password", "protected" if link.get("password_protected") else "none")
+        )
+        pairs.append(("Bots", "blocked" if link.get("block_bots") else "allowed"))
+        pairs.append(("Meta tags", "custom" if link.get("meta_tags") else "default"))
+        geo = link.get("geo_rules")
+        pairs.append(
+            (
+                "Geo targeting",
+                f"{len(geo)} {'rule' if len(geo) == 1 else 'rules'}"
+                if isinstance(geo, dict) and geo
+                else "none",
+            )
+        )
 
     if event_type in ("link.deleted", "link.expired") and isinstance(total, int):
         pairs.append(("Lifetime clicks", f"{total:,}"))

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -77,9 +77,14 @@ class Copy:
     title_url: str | None
     # ``context`` is the full footer line (brand + time + notice) for flavors
     # without a native timestamp slot; ``notice`` alone is for flavors that
-    # render time themselves (Discord's embed timestamp).
+    # render time themselves.
     context: str
     notice: str | None = None
+    # Title split for flavors that compose their own heading markup, and
+    # the destination as a one-line subtitle for lifecycle events.
+    label: str = ""
+    display: str | None = None
+    subtitle: str | None = None
     lines: list[str] = field(default_factory=list)
     pairs: list[tuple[str, str]] = field(default_factory=list)
     changes: list[tuple[str, str, str]] = field(default_factory=list)
@@ -239,21 +244,88 @@ def _lifecycle_pairs(
     return pairs
 
 
+def clicked_summary(payload: dict[str, Any]) -> tuple[list[str], str | None]:
+    """Grouped one-per-topic lines for vertical layouts (Components V2),
+    plus the running count for the footer."""
+    lines: list[str] = []
+    if _present(payload.get("country")):
+        line = _country_display_bold(payload["country"])
+        if _present(payload.get("city")):
+            line += f"  {payload['city']}"
+        lines.append(line)
+    elif _present(payload.get("city")):
+        lines.append(str(payload["city"]))
+
+    device_bits = [
+        str(payload[k]) for k in ("browser", "os") if _present(payload.get(k))
+    ]
+    device = " on ".join(device_bits)
+    if _present(payload.get("device")):
+        device = f"{device}, {payload['device']}" if device else str(payload["device"])
+    if device:
+        lines.append(device)
+
+    referrer = payload.get("referrer")
+    source = (
+        f"from **{_referrer_host(referrer)}**" if _present(referrer) else "direct visit"
+    )
+    utm = payload.get("utm")
+    if isinstance(utm, dict):
+        campaign = " / ".join(str(v) for v in utm.values() if _present(v))
+        if campaign:
+            source += f"  ({campaign})"
+    lines.append(source)
+
+    if payload.get("is_bot"):
+        bot = payload.get("bot_name")
+        lines.append(f"bot  **{bot}**" if _present(bot) else "bot traffic")
+
+    total = payload.get("total_clicks")
+    count = f"{total:,}" if isinstance(total, int) else None
+    return [clip(line, _VALUE_MAX) for line in lines], count
+
+
+def _country_display_bold(code: Any) -> str:
+    text = str(code)
+    if len(text) == 2 and text.isascii() and text.isalpha():
+        upper = text.upper()
+        flag = "".join(chr(0x1F1E6 + ord(c) - 65) for c in upper)
+        return f"{flag} **{upper}**"
+    return str(code)
+
+
 def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy:
     link = _link_of(event_type, payload)
     title = _title(event_type, link)
     url = link.get("short_url") if _present(link.get("short_url")) else None
     notice = _notice(payload)
     context = f"spoo.me · {timestamp}" + (f" · {notice}" if notice else "")
+    label = EVENT_LABELS.get(event_type, event_type)
+    display = (
+        f"{link.get('domain')}/{link.get('alias')}"
+        if _present(link.get("alias")) and _present(link.get("domain"))
+        else None
+    )
+    subtitle = (
+        str(link.get("long_url"))
+        if event_type in ("link.created", "link.deleted", "link.expired")
+        and _present(link.get("long_url"))
+        else None
+    )
 
+    common = dict(label=label, display=display, subtitle=subtitle)
     if event_type == "link.clicked":
-        return Copy(title, url, context, notice, pairs=_clicked_pairs(payload))
+        return Copy(
+            title, url, context, notice, pairs=_clicked_pairs(payload), **common
+        )
     if event_type == "webhook.test":
         message = payload.get("message")
         lines = [clip(str(message), _VALUE_MAX)] if _present(message) else []
-        return Copy(title, url, context, notice, lines=lines)
+        return Copy(title, url, context, notice, lines=lines, **common)
     if event_type == "link.updated":
-        return Copy(title, url, context, notice, changes=_updated_changes(payload))
+        return Copy(
+            title, url, context, notice, changes=_updated_changes(payload), **common
+        )
     if event_type in ("link.created", "link.deleted", "link.expired"):
         return Copy(
             title,
@@ -261,8 +333,9 @@ def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy
             context,
             notice,
             pairs=_lifecycle_pairs(event_type, payload, timestamp),
+            **common,
         )
 
     shown = {k: v for k, v in payload.items() if k != "dropped_since_last"}
     code = clip(json.dumps(shown, separators=(",", ":"), default=str), _CODE_MAX)
-    return Copy(title, url, context, notice, code=code)
+    return Copy(title, url, context, notice, code=code, **common)

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -14,6 +14,7 @@ flavored endpoint.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -244,54 +245,66 @@ def _lifecycle_pairs(
     return pairs
 
 
-def clicked_summary(payload: dict[str, Any]) -> tuple[list[str], str | None]:
+def clicked_summary(
+    payload: dict[str, Any], escape: Callable[[str], str] | None = None
+) -> tuple[list[str], str | None]:
     """Grouped one-per-topic lines for vertical layouts (Components V2),
-    plus the running count for the footer."""
+    plus the running count for the footer.
+
+    ``escape`` runs on every payload-derived value BEFORE this function
+    adds its own markup. These values are visitor-controlled (the
+    referrer above all): a flavor whose text renders markup must
+    neutralize them, or a crafted Referer header plants live markdown in
+    the subscriber's channel."""
+    esc = escape or (lambda s: s)
     lines: list[str] = []
     if _present(payload.get("country")):
-        line = _country_display_bold(payload["country"])
+        line = _country_display_bold(payload["country"], esc)
         if _present(payload.get("city")):
-            line += f"  {payload['city']}"
+            line += f"  {esc(str(payload['city']))}"
         lines.append(line)
     elif _present(payload.get("city")):
-        lines.append(str(payload["city"]))
+        lines.append(esc(str(payload["city"])))
 
     device_bits = [
-        str(payload[k]) for k in ("browser", "os") if _present(payload.get(k))
+        esc(str(payload[k])) for k in ("browser", "os") if _present(payload.get(k))
     ]
     device = " on ".join(device_bits)
     if _present(payload.get("device")):
-        device = f"{device}, {payload['device']}" if device else str(payload["device"])
+        part = esc(str(payload["device"]))
+        device = f"{device}, {part}" if device else part
     if device:
         lines.append(device)
 
     referrer = payload.get("referrer")
     source = (
-        f"from **{_referrer_host(referrer)}**" if _present(referrer) else "direct visit"
+        f"from **{esc(_referrer_host(referrer))}**"
+        if _present(referrer)
+        else "direct visit"
     )
     utm = payload.get("utm")
     if isinstance(utm, dict):
-        campaign = " / ".join(str(v) for v in utm.values() if _present(v))
+        campaign = " / ".join(esc(str(v)) for v in utm.values() if _present(v))
         if campaign:
             source += f"  ({campaign})"
     lines.append(source)
 
     if payload.get("is_bot"):
         bot = payload.get("bot_name")
-        lines.append(f"bot  **{bot}**" if _present(bot) else "bot traffic")
+        lines.append(f"bot  **{esc(str(bot))}**" if _present(bot) else "bot traffic")
 
     total = payload.get("total_clicks")
     count = f"{total:,}" if isinstance(total, int) else None
     return [clip(line, _VALUE_MAX) for line in lines], count
 
 
-def _country_display_bold(code: Any) -> str:
+def _country_display_bold(code: Any, esc: Callable[[str], str]) -> str:
     text = str(code)
     if len(text) == 2 and text.isascii() and text.isalpha():
         upper = text.upper()
         flag = "".join(chr(0x1F1E6 + ord(c) - 65) for c in upper)
         return f"{flag} **{upper}**"
-    return str(code)
+    return esc(str(code))
 
 
 def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy:

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -1,9 +1,11 @@
 """Shared copy for the lossy flavors — one place decides wording and which
 fields earn space, so Discord and Slack never drift apart.
 
-Density is frequency-aware: ``link.clicked`` (high frequency) renders as a
-few compact lines that read well as a stream; lifecycle events (rare)
-render as label/value pairs. Event types this module does not know —
+Every event renders as label/value pairs with guaranteed substance: a
+click always carries Device and From (a referrer-less click is a
+"direct" visit, not a blank), and lifecycle cards state "never" and
+"unlimited" as the real answers they are. Event types this module does
+not know —
 including every future addition to the registry — fall back to the payload
 as a JSON code block, so adding an event can never terminal-fail a
 flavored endpoint.
@@ -13,6 +15,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
@@ -112,35 +115,54 @@ def _referrer_host(referrer: Any) -> str:
     return host or text
 
 
-def _clicked_lines(payload: dict[str, Any]) -> list[str]:
-    lines: list[str] = []
+def _date_part(value: Any) -> str:
+    return str(value)[:10] if _present(value) else "never"
+
+
+def _age_days(created_at: Any, occurred_at: str) -> int | None:
+    try:
+        created = datetime.fromisoformat(str(created_at))
+        occurred = datetime.fromisoformat(occurred_at)
+        return max(0, (occurred - created).days)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clicked_pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
+    """A click always renders at least Device and From — absent analytics
+    dimensions are skipped, but a referrer-less click IS a direct visit
+    and renders as one, never as an empty card."""
+    pairs: list[tuple[str, str]] = []
 
     place = [
         str(v) for v in (payload.get("city"), payload.get("country")) if _present(v)
     ]
-    agent = ""
-    if _present(payload.get("browser")) and _present(payload.get("os")):
-        agent = f"{payload['browser']} on {payload['os']}"
-    elif _present(payload.get("browser")):
-        agent = str(payload["browser"])
-    first = " · ".join(part for part in (", ".join(place), agent) if part)
-    if first:
-        lines.append(first)
+    if place:
+        pairs.append(("Location", ", ".join(place)))
 
-    second: list[str] = []
-    if _present(payload.get("referrer")):
-        second.append(f"from {_referrer_host(payload['referrer'])}")
-    total = payload.get("total_clicks")
-    if isinstance(total, int):
-        second.append(f"click #{total:,}")
-    if second:
-        lines.append(" · ".join(second))
+    agent = " · ".join(
+        str(payload[k]) for k in ("browser", "os", "device") if _present(payload.get(k))
+    )
+    pairs.append(("Device", agent or "not detected"))
+
+    referrer = payload.get("referrer")
+    pairs.append(("From", _referrer_host(referrer) if _present(referrer) else "direct"))
+
+    utm = payload.get("utm")
+    if isinstance(utm, dict):
+        campaign = " · ".join(str(v) for v in utm.values() if _present(v))
+        if campaign:
+            pairs.append(("UTM", campaign))
 
     if payload.get("is_bot"):
         bot = payload.get("bot_name")
-        lines.append(f"bot · {bot}" if _present(bot) else "bot traffic")
+        pairs.append(("Bot", str(bot) if _present(bot) else "detected"))
 
-    return [clip(line, _VALUE_MAX) for line in lines] or ["Tracked click recorded"]
+    total = payload.get("total_clicks")
+    if isinstance(total, int) and total > 0:
+        pairs.append(("Clicks", f"{total:,}"))
+
+    return [(name, clip(value, _VALUE_MAX)) for name, value in pairs]
 
 
 def _updated_changes(payload: dict[str, Any]) -> list[tuple[str, str, str]]:
@@ -155,9 +177,14 @@ def _updated_changes(payload: dict[str, Any]) -> list[tuple[str, str, str]]:
     return out
 
 
-def _lifecycle_pairs(event_type: str, payload: dict[str, Any]) -> list[tuple[str, str]]:
+def _lifecycle_pairs(
+    event_type: str, payload: dict[str, Any], occurred_at: str
+) -> list[tuple[str, str]]:
+    """Lifecycle cards lead with facts that always exist — an expiry of
+    "never" and a cap of "unlimited" are real answers, not blanks."""
     link = _link_of(event_type, payload)
     pairs: list[tuple[str, str]] = []
+    total = link.get("total_clicks")
 
     if event_type == "link.expired":
         reason = payload.get("reason")
@@ -165,17 +192,27 @@ def _lifecycle_pairs(event_type: str, payload: dict[str, Any]) -> list[tuple[str
 
     if _present(link.get("long_url")):
         pairs.append(("Destination", _fmt(link["long_url"])))
+
     if event_type == "link.created":
-        if _present(link.get("expires_at")):
-            pairs.append(("Expires", _fmt(link["expires_at"])))
-        if _present(link.get("max_clicks")):
-            pairs.append(("Max clicks", _fmt(link["max_clicks"])))
+        pairs.append(("Expires", _date_part(link.get("expires_at"))))
+        max_clicks = link.get("max_clicks")
+        pairs.append(
+            (
+                "Max clicks",
+                f"{max_clicks:,}" if isinstance(max_clicks, int) else "unlimited",
+            )
+        )
         if link.get("password_protected"):
-            pairs.append(("Password protected", "yes"))
-    if event_type in ("link.deleted", "link.expired") and isinstance(
-        link.get("total_clicks"), int
-    ):
-        pairs.append(("Total clicks", f"{link['total_clicks']:,}"))
+            pairs.append(("Password", "protected"))
+        if link.get("block_bots"):
+            pairs.append(("Bots", "blocked"))
+
+    if event_type in ("link.deleted", "link.expired") and isinstance(total, int):
+        pairs.append(("Lifetime clicks", f"{total:,}"))
+    if event_type == "link.deleted":
+        age = _age_days(link.get("created_at"), occurred_at)
+        if age is not None:
+            pairs.append(("Age", f"{age:,} days" if age != 1 else "1 day"))
 
     return pairs
 
@@ -188,7 +225,7 @@ def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy
     context = f"spoo.me · {timestamp}" + (f" · {notice}" if notice else "")
 
     if event_type == "link.clicked":
-        return Copy(title, url, context, notice, lines=_clicked_lines(payload))
+        return Copy(title, url, context, notice, pairs=_clicked_pairs(payload))
     if event_type == "webhook.test":
         message = payload.get("message")
         lines = [clip(str(message), _VALUE_MAX)] if _present(message) else []
@@ -197,7 +234,11 @@ def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy
         return Copy(title, url, context, notice, changes=_updated_changes(payload))
     if event_type in ("link.created", "link.deleted", "link.expired"):
         return Copy(
-            title, url, context, notice, pairs=_lifecycle_pairs(event_type, payload)
+            title,
+            url,
+            context,
+            notice,
+            pairs=_lifecycle_pairs(event_type, payload, timestamp),
         )
 
     shown = {k: v for k, v in payload.items() if k != "dropped_since_last"}

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -1,0 +1,205 @@
+"""Shared copy for the lossy flavors — one place decides wording and which
+fields earn space, so Discord and Slack never drift apart.
+
+Density is frequency-aware: ``link.clicked`` (high frequency) renders as a
+few compact lines that read well as a stream; lifecycle events (rare)
+render as label/value pairs. Event types this module does not know —
+including every future addition to the registry — fall back to the payload
+as a JSON code block, so adding an event can never terminal-fail a
+flavored endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+EVENT_LABELS = {
+    "link.created": "Link created",
+    "link.updated": "Link updated",
+    "link.deleted": "Link deleted",
+    "link.expired": "Link expired",
+    "link.clicked": "Click",
+    "webhook.test": "Test delivery",
+}
+
+_EXPIRY_REASONS = {
+    "max_clicks_reached": "Max clicks reached",
+    "time_expired": "Expiry time passed",
+}
+
+# Analytics sentinels are for querying, not for humans — a dimension that
+# resolved to one renders as absent, same as None.
+_SENTINELS = {"", "unknown", "(none)"}
+
+_VALUE_MAX = 512  # per rendered value; receivers cap harder, this is copy-level
+_CODE_MAX = 1_500  # fallback JSON block
+
+
+def clip(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _present(value: Any) -> bool:
+    if value is None:
+        return False
+    return not (isinstance(value, str) and value.strip().lower() in _SENTINELS)
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (dict, list)):
+        return clip(json.dumps(value, separators=(",", ":"), default=str), _VALUE_MAX)
+    return clip(str(value), _VALUE_MAX)
+
+
+@dataclass(frozen=True)
+class Copy:
+    """Flavor-neutral content. Exactly one of ``lines`` / ``pairs`` /
+    ``changes`` / ``code`` is populated (compact, field grid, old/new
+    change set, or fallback code block).
+
+    ``changes`` stays structured — (field, old, new) — because flavors
+    disagree on the best rendering: Discord has colored diff blocks,
+    Slack only has plain pairs."""
+
+    title: str
+    title_url: str | None
+    # ``context`` is the full footer line (brand + time + notice) for flavors
+    # without a native timestamp slot; ``notice`` alone is for flavors that
+    # render time themselves (Discord's embed timestamp).
+    context: str
+    notice: str | None = None
+    lines: list[str] = field(default_factory=list)
+    pairs: list[tuple[str, str]] = field(default_factory=list)
+    changes: list[tuple[str, str, str]] = field(default_factory=list)
+    code: str | None = None
+
+
+def _link_of(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    if event_type == "link.clicked":
+        return payload
+    link = payload.get("link")
+    return link if isinstance(link, dict) else {}
+
+
+def _title(event_type: str, link: dict[str, Any]) -> str:
+    label = EVENT_LABELS.get(event_type, event_type)
+    alias, domain = link.get("alias"), link.get("domain")
+    if _present(alias) and _present(domain):
+        return f"{label} · {domain}/{alias}"
+    return label
+
+
+def _notice(payload: dict[str, Any]) -> str | None:
+    dropped = payload.get("dropped_since_last")
+    if isinstance(dropped, int) and dropped > 0:
+        plural = "delivery" if dropped == 1 else "deliveries"
+        return f"{dropped} earlier {plural} dropped"
+    return None
+
+
+def _referrer_host(referrer: Any) -> str:
+    text = str(referrer)
+    host = urlparse(text).netloc
+    return host or text
+
+
+def _clicked_lines(payload: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+
+    place = [
+        str(v) for v in (payload.get("city"), payload.get("country")) if _present(v)
+    ]
+    agent = ""
+    if _present(payload.get("browser")) and _present(payload.get("os")):
+        agent = f"{payload['browser']} on {payload['os']}"
+    elif _present(payload.get("browser")):
+        agent = str(payload["browser"])
+    first = " · ".join(part for part in (", ".join(place), agent) if part)
+    if first:
+        lines.append(first)
+
+    second: list[str] = []
+    if _present(payload.get("referrer")):
+        second.append(f"from {_referrer_host(payload['referrer'])}")
+    total = payload.get("total_clicks")
+    if isinstance(total, int):
+        second.append(f"click #{total:,}")
+    if second:
+        lines.append(" · ".join(second))
+
+    if payload.get("is_bot"):
+        bot = payload.get("bot_name")
+        lines.append(f"bot · {bot}" if _present(bot) else "bot traffic")
+
+    return [clip(line, _VALUE_MAX) for line in lines] or ["Tracked click recorded"]
+
+
+def _updated_changes(payload: dict[str, Any]) -> list[tuple[str, str, str]]:
+    changes = payload.get("changes")
+    if not isinstance(changes, dict):
+        return []
+    out: list[tuple[str, str, str]] = []
+    for name, change in changes.items():
+        old = _fmt(change.get("old")) if isinstance(change, dict) else _fmt(None)
+        new = _fmt(change.get("new")) if isinstance(change, dict) else _fmt(change)
+        out.append((str(name), old, new))
+    return out
+
+
+def _lifecycle_pairs(event_type: str, payload: dict[str, Any]) -> list[tuple[str, str]]:
+    link = _link_of(event_type, payload)
+    pairs: list[tuple[str, str]] = []
+
+    if event_type == "link.expired":
+        reason = payload.get("reason")
+        pairs.append(("Reason", _EXPIRY_REASONS.get(reason, _fmt(reason))))
+
+    if _present(link.get("long_url")):
+        pairs.append(("Destination", _fmt(link["long_url"])))
+    if event_type == "link.created":
+        if _present(link.get("expires_at")):
+            pairs.append(("Expires", _fmt(link["expires_at"])))
+        if _present(link.get("max_clicks")):
+            pairs.append(("Max clicks", _fmt(link["max_clicks"])))
+        if link.get("password_protected"):
+            pairs.append(("Password protected", "yes"))
+    if event_type in ("link.deleted", "link.expired") and isinstance(
+        link.get("total_clicks"), int
+    ):
+        pairs.append(("Total clicks", f"{link['total_clicks']:,}"))
+
+    return pairs
+
+
+def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy:
+    link = _link_of(event_type, payload)
+    title = _title(event_type, link)
+    url = link.get("short_url") if _present(link.get("short_url")) else None
+    notice = _notice(payload)
+    context = f"spoo.me · {timestamp}" + (f" · {notice}" if notice else "")
+
+    if event_type == "link.clicked":
+        return Copy(title, url, context, notice, lines=_clicked_lines(payload))
+    if event_type == "webhook.test":
+        message = payload.get("message")
+        lines = [clip(str(message), _VALUE_MAX)] if _present(message) else []
+        return Copy(title, url, context, notice, lines=lines)
+    if event_type == "link.updated":
+        return Copy(title, url, context, notice, changes=_updated_changes(payload))
+    if event_type in ("link.created", "link.deleted", "link.expired"):
+        return Copy(
+            title, url, context, notice, pairs=_lifecycle_pairs(event_type, payload)
+        )
+
+    shown = {k: v for k, v in payload.items() if k != "dropped_since_last"}
+    code = clip(json.dumps(shown, separators=(",", ":"), default=str), _CODE_MAX)
+    return Copy(title, url, context, notice, code=code)

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -1,17 +1,23 @@
-"""Discord flavor — one embed per event, ready for a Discord webhook URL.
+"""Discord flavor — a Components V2 message, ready for a channel webhook.
 
-Receiver limits enforced locally (title 256, description 4096, field
-name 256 / value 1024, footer 2048, 6000 chars across the embed) so a
-rendered body is never rejected for size by Discord itself; the engine's
-max_payload_bytes cap still applies on top.
+The rendered body is a components-only message (flag 32768): one
+accent-colored container holding a heading, a divider, the event's
+substance, and a small-text footer with a timestamp Discord localizes
+per viewer (``<t:...>``). Delivery must carry ``with_components=true``
+on the webhook URL — declared here via ``url_query`` and appended by
+the executor, since the signature covers the body alone.
+
+Mentions are hard-disabled: text displays CAN ping (embeds never
+could), and payload values are user-controlled.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
+from datetime import datetime
+from typing import Any, ClassVar
 
-from services.webhooks.renderers.copy import build_copy, clip
+from services.webhooks.renderers.copy import build_copy, clicked_summary, clip
 
 _COLORS = {
     "link.created": 0x43B581,
@@ -25,12 +31,27 @@ _DEFAULT_COLOR = 0x99AAB5
 
 AVATAR_URL = "https://spoo.me/static/images/favicon.png"
 
-_TITLE_MAX = 256
-_DESCRIPTION_MAX = 4096
-_FIELD_NAME_MAX = 256
-_FIELD_VALUE_MAX = 1024
-_FOOTER_MAX = 2048
-_EMBED_TOTAL_MAX = 6000
+# Footer verb per event; ``f`` renders an absolute local time, ``R`` a
+# live relative one — moments for high-frequency events, dates for rare.
+_FOOTERS = {
+    "link.clicked": ("click", "R"),
+    "link.created": ("created", "f"),
+    "link.updated": ("updated", "R"),
+    "link.deleted": ("deleted", "f"),
+    "link.expired": ("expired", "R"),
+    "webhook.test": ("sent", "R"),
+}
+
+_TEXT_MAX = 3_500  # defensive budget across all text displays
+_SUBTITLE_MAX = 200
+
+
+def _td(content: str) -> dict[str, Any]:
+    return {"type": 10, "content": content}
+
+
+def _sep(spacing: int = 1, divider: bool = False) -> dict[str, Any]:
+    return {"type": 14, "spacing": spacing, "divider": divider}
 
 
 def _fence(text: str) -> str:
@@ -38,91 +59,98 @@ def _fence(text: str) -> str:
     return text.replace("```", "'''")
 
 
-def _embed_size(embed: dict[str, Any]) -> int:
-    total = len(embed.get("title", "")) + len(embed.get("description", ""))
-    total += len(embed.get("footer", {}).get("text", ""))
-    for field in embed.get("fields", []):
-        total += len(field["name"]) + len(field["value"])
-    return total
-
-
 class DiscordRenderer:
     flavor = "discord"
+    # Appended to the endpoint URL at delivery time; components-v2 bodies
+    # are rejected without it.
+    url_query: ClassVar[dict[str, str]] = {"with_components": "true"}
 
     def render(
         self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
     ) -> str:
         copy = build_copy(event_type, timestamp, payload)
+        try:
+            epoch = int(datetime.fromisoformat(timestamp).timestamp())
+        except ValueError:
+            epoch = None
 
-        # The webhook's own username and avatar carry the brand, and the
-        # embed timestamp renders natively in the viewer's timezone — the
-        # footer exists only for the drop notice.
-        embed: dict[str, Any] = {
-            "title": clip(copy.title, _TITLE_MAX),
-            "color": _COLORS.get(event_type, _DEFAULT_COLOR),
-            "timestamp": timestamp,
-        }
-        if copy.notice:
-            embed["footer"] = {"text": clip(copy.notice, _FOOTER_MAX)}
-        if copy.title_url:
-            embed["url"] = copy.title_url
+        label = copy.label or copy.title
+        components: list[dict[str, Any]] = []
 
-        if copy.changes:
-            # Discord colors diff blocks: removed lines red, added green —
-            # the old/new pair reads at a glance.
+        # Heading: linked short address, except a deleted link has no
+        # living address to point at.
+        if copy.display and copy.title_url and event_type != "link.deleted":
+            components.append(_td(f"### {label}  [{copy.display}]({copy.title_url})"))
+        elif copy.display:
+            components.append(_td(f"### {label}  {copy.display}"))
+        else:
+            components.append(_td(f"### {label}"))
+        if copy.subtitle:
+            components.append(_td(f"-# {clip(copy.subtitle, _SUBTITLE_MAX)}"))
+
+        lifecycle = event_type in ("link.created", "link.deleted", "link.expired")
+        components.append(_sep(2 if lifecycle else 1, divider=True))
+
+        count: str | None = None
+        if event_type == "link.clicked":
+            lines, count = clicked_summary(payload)
+            components.append(_td("\n".join(lines)))
+        elif copy.changes:
             diff_lines: list[str] = []
             for name, old, new in copy.changes:
                 diff_lines.append(f"- {name}: {_fence(old)}")
                 diff_lines.append(f"+ {name}: {_fence(new)}")
-            embed["description"] = clip(
-                "```diff\n" + "\n".join(diff_lines) + "\n```", _DESCRIPTION_MAX
+            components.append(_td("```diff\n" + "\n".join(diff_lines) + "\n```"))
+        elif copy.pairs:
+            components.append(
+                _td(
+                    "\n".join(
+                        f"**{name}**  {value}"
+                        for name, value in copy.pairs
+                        if name != "Destination"  # the subtitle already says it
+                    )
+                )
             )
         elif copy.code:
-            embed["description"] = clip(
-                "```json\n" + _fence(copy.code) + "\n```", _DESCRIPTION_MAX
-            )
+            components.append(_td("```json\n" + _fence(copy.code) + "\n```"))
         elif copy.lines:
-            embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
+            components.append(_td("\n".join(copy.lines)))
 
-        if copy.pairs:
-            # Two facts per row, never Discord's cramped three: a blank
-            # spacer field closes each pair so the grid stays airy. Long
-            # values like destination URLs take the full width up top.
-            fields: list[dict[str, Any]] = []
-            grid: list[tuple[str, str]] = []
-            for name, value in copy.pairs:
-                if name == "Destination" or len(value) > 32:
-                    fields.append(
-                        {
-                            "name": clip(name, _FIELD_NAME_MAX),
-                            "value": clip(value, _FIELD_VALUE_MAX),
-                            "inline": False,
-                        }
-                    )
-                else:
-                    grid.append((name, value))
-            for i, (name, value) in enumerate(grid):
-                fields.append(
-                    {
-                        "name": clip(name, _FIELD_NAME_MAX),
-                        "value": clip(value, _FIELD_VALUE_MAX),
-                        "inline": True,
-                    }
-                )
-                if i % 2 == 1 and i < len(grid) - 1:
-                    fields.append({"name": "\u200b", "value": "\u200b", "inline": True})
-            embed["fields"] = fields
+        components.append(_sep(2))
+        verb, style = _FOOTERS.get(event_type, ("received", "f"))
+        footer = f"-# {verb}"
+        if event_type == "link.clicked" and count is not None:
+            footer += f" {count}"
+        if epoch is not None:
+            footer += f"   <t:{epoch}:{style}>"
+        if copy.notice:
+            footer += f"\n-# {copy.notice}"
+        components.append(_td(footer))
 
-        while _embed_size(embed) > _EMBED_TOTAL_MAX and embed.get("fields"):
-            embed["fields"].pop()
-        if _embed_size(embed) > _EMBED_TOTAL_MAX and "description" in embed:
-            overflow = _embed_size(embed) - _EMBED_TOTAL_MAX
-            embed["description"] = clip(
-                embed["description"], max(1, len(embed["description"]) - overflow)
+        # Defensive budget: receivers reject oversize messages whole, so a
+        # pathological body gets its largest block clipped instead.
+        total = sum(len(c.get("content", "")) for c in components)
+        if total > _TEXT_MAX:
+            biggest = max(components, key=lambda c: len(c.get("content", "")))
+            overflow = total - _TEXT_MAX
+            biggest["content"] = clip(
+                biggest["content"], max(1, len(biggest["content"]) - overflow)
             )
 
         return json.dumps(
-            {"username": "spoo.me", "avatar_url": AVATAR_URL, "embeds": [embed]},
+            {
+                "username": "spoo.me",
+                "avatar_url": AVATAR_URL,
+                "flags": 32768,
+                "allowed_mentions": {"parse": []},
+                "components": [
+                    {
+                        "type": 17,
+                        "accent_color": _COLORS.get(event_type, _DEFAULT_COLOR),
+                        "components": components,
+                    }
+                ],
+            },
             separators=(",", ":"),
             default=str,
         )

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -54,6 +54,22 @@ def _sep(spacing: int = 1, divider: bool = False) -> dict[str, Any]:
     return {"type": 14, "spacing": spacing, "divider": divider}
 
 
+_MARKDOWN_CHARS = set("\\`*_~|>#[]()")
+
+
+def _md(text: str) -> str:
+    """Backslash-escape Discord markdown in user-derived text. Payload
+    values reach live text displays, and text displays render markup —
+    without this a crafted Referer header plants a clickable masked link
+    in the subscriber's channel."""
+    return "".join("\\" + ch if ch in _MARKDOWN_CHARS else ch for ch in text)
+
+
+def _link_target(url: str) -> str:
+    # Parentheses inside a masked-link target close the link early.
+    return url.replace("(", "%28").replace(")", "%29")
+
+
 def _fence(text: str) -> str:
     # A value containing ``` would break out of the block.
     return text.replace("```", "'''")
@@ -80,20 +96,25 @@ class DiscordRenderer:
         # Heading: linked short address, except a deleted link has no
         # living address to point at.
         if copy.display and copy.title_url and event_type != "link.deleted":
-            components.append(_td(f"### {label}  [{copy.display}]({copy.title_url})"))
+            components.append(
+                _td(
+                    f"### {_md(label)}  "
+                    f"[{_md(copy.display)}]({_link_target(copy.title_url)})"
+                )
+            )
         elif copy.display:
-            components.append(_td(f"### {label}  {copy.display}"))
+            components.append(_td(f"### {_md(label)}  {_md(copy.display)}"))
         else:
-            components.append(_td(f"### {label}"))
+            components.append(_td(f"### {_md(label)}"))
         if copy.subtitle:
-            components.append(_td(f"-# {clip(copy.subtitle, _SUBTITLE_MAX)}"))
+            components.append(_td(f"-# {_md(clip(copy.subtitle, _SUBTITLE_MAX))}"))
 
         lifecycle = event_type in ("link.created", "link.deleted", "link.expired")
         components.append(_sep(2 if lifecycle else 1, divider=True))
 
         count: str | None = None
         if event_type == "link.clicked":
-            lines, count = clicked_summary(payload)
+            lines, count = clicked_summary(payload, escape=_md)
             components.append(_td("\n".join(lines)))
         elif copy.changes:
             diff_lines: list[str] = []
@@ -105,7 +126,7 @@ class DiscordRenderer:
             components.append(
                 _td(
                     "\n".join(
-                        f"**{name}**  {value}"
+                        f"**{name}**  {_md(value)}"
                         for name, value in copy.pairs
                         if name != "Destination"  # the subtitle already says it
                     )
@@ -114,7 +135,7 @@ class DiscordRenderer:
         elif copy.code:
             components.append(_td("```json\n" + _fence(copy.code) + "\n```"))
         elif copy.lines:
-            components.append(_td("\n".join(copy.lines)))
+            components.append(_td("\n".join(_md(line) for line in copy.lines)))
 
         components.append(_sep(2))
         verb, style = _FOOTERS.get(event_type, ("received", "f"))

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -23,6 +23,8 @@ _COLORS = {
 }
 _DEFAULT_COLOR = 0x99AAB5
 
+AVATAR_URL = "https://spoo.me/static/images/favicon.png"
+
 _TITLE_MAX = 256
 _DESCRIPTION_MAX = 4096
 _FIELD_NAME_MAX = 256
@@ -52,15 +54,16 @@ class DiscordRenderer:
     ) -> str:
         copy = build_copy(event_type, timestamp, payload)
 
-        # Discord renders the embed timestamp natively, so the footer skips
-        # the time (unlike Slack's context line).
-        footer = "spoo.me" + (f" · {copy.notice}" if copy.notice else "")
+        # The webhook's own username and avatar carry the brand, and the
+        # embed timestamp renders natively in the viewer's timezone — the
+        # footer exists only for the drop notice.
         embed: dict[str, Any] = {
             "title": clip(copy.title, _TITLE_MAX),
             "color": _COLORS.get(event_type, _DEFAULT_COLOR),
             "timestamp": timestamp,
-            "footer": {"text": clip(footer, _FOOTER_MAX)},
         }
+        if copy.notice:
+            embed["footer"] = {"text": clip(copy.notice, _FOOTER_MAX)}
         if copy.title_url:
             embed["url"] = copy.title_url
 
@@ -82,16 +85,33 @@ class DiscordRenderer:
             embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
 
         if copy.pairs:
-            # Short facts sit side by side (Discord flows three per row);
-            # long values like destination URLs take the full width.
-            embed["fields"] = [
-                {
-                    "name": clip(name, _FIELD_NAME_MAX),
-                    "value": clip(value, _FIELD_VALUE_MAX),
-                    "inline": name != "Destination" and len(value) <= 32,
-                }
-                for name, value in copy.pairs
-            ]
+            # Two facts per row, never Discord's cramped three: a blank
+            # spacer field closes each pair so the grid stays airy. Long
+            # values like destination URLs take the full width up top.
+            fields: list[dict[str, Any]] = []
+            grid: list[tuple[str, str]] = []
+            for name, value in copy.pairs:
+                if name == "Destination" or len(value) > 32:
+                    fields.append(
+                        {
+                            "name": clip(name, _FIELD_NAME_MAX),
+                            "value": clip(value, _FIELD_VALUE_MAX),
+                            "inline": False,
+                        }
+                    )
+                else:
+                    grid.append((name, value))
+            for i, (name, value) in enumerate(grid):
+                fields.append(
+                    {
+                        "name": clip(name, _FIELD_NAME_MAX),
+                        "value": clip(value, _FIELD_VALUE_MAX),
+                        "inline": True,
+                    }
+                )
+                if i % 2 == 1 and i < len(grid) - 1:
+                    fields.append({"name": "\u200b", "value": "\u200b", "inline": True})
+            embed["fields"] = fields
 
         while _embed_size(embed) > _EMBED_TOTAL_MAX and embed.get("fields"):
             embed["fields"].pop()
@@ -102,7 +122,7 @@ class DiscordRenderer:
             )
 
         return json.dumps(
-            {"username": "spoo.me", "embeds": [embed]},
+            {"username": "spoo.me", "avatar_url": AVATAR_URL, "embeds": [embed]},
             separators=(",", ":"),
             default=str,
         )

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -1,0 +1,106 @@
+"""Discord flavor — one embed per event, ready for a Discord webhook URL.
+
+Receiver limits enforced locally (title 256, description 4096, field
+name 256 / value 1024, footer 2048, 6000 chars across the embed) so a
+rendered body is never rejected for size by Discord itself; the engine's
+max_payload_bytes cap still applies on top.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from services.webhooks.renderers.copy import build_copy, clip
+
+_COLORS = {
+    "link.created": 0x43B581,
+    "link.updated": 0x5865F2,
+    "link.deleted": 0xF04747,
+    "link.expired": 0xE67E22,
+    "link.clicked": 0x99AAB5,
+    "webhook.test": 0x99AAB5,
+}
+_DEFAULT_COLOR = 0x99AAB5
+
+_TITLE_MAX = 256
+_DESCRIPTION_MAX = 4096
+_FIELD_NAME_MAX = 256
+_FIELD_VALUE_MAX = 1024
+_FOOTER_MAX = 2048
+_EMBED_TOTAL_MAX = 6000
+
+
+def _fence(text: str) -> str:
+    # A value containing ``` would break out of the block.
+    return text.replace("```", "'''")
+
+
+def _embed_size(embed: dict[str, Any]) -> int:
+    total = len(embed.get("title", "")) + len(embed.get("description", ""))
+    total += len(embed.get("footer", {}).get("text", ""))
+    for field in embed.get("fields", []):
+        total += len(field["name"]) + len(field["value"])
+    return total
+
+
+class DiscordRenderer:
+    flavor = "discord"
+
+    def render(
+        self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
+    ) -> str:
+        copy = build_copy(event_type, timestamp, payload)
+
+        # Discord renders the embed timestamp natively, so the footer skips
+        # the time (unlike Slack's context line).
+        footer = "spoo.me" + (f" · {copy.notice}" if copy.notice else "")
+        embed: dict[str, Any] = {
+            "title": clip(copy.title, _TITLE_MAX),
+            "color": _COLORS.get(event_type, _DEFAULT_COLOR),
+            "timestamp": timestamp,
+            "footer": {"text": clip(footer, _FOOTER_MAX)},
+        }
+        if copy.title_url:
+            embed["url"] = copy.title_url
+
+        if copy.changes:
+            # Discord colors diff blocks: removed lines red, added green —
+            # the old/new pair reads at a glance.
+            diff_lines: list[str] = []
+            for name, old, new in copy.changes:
+                diff_lines.append(f"- {name}: {_fence(old)}")
+                diff_lines.append(f"+ {name}: {_fence(new)}")
+            embed["description"] = clip(
+                "```diff\n" + "\n".join(diff_lines) + "\n```", _DESCRIPTION_MAX
+            )
+        elif copy.code:
+            embed["description"] = clip(
+                "```json\n" + _fence(copy.code) + "\n```", _DESCRIPTION_MAX
+            )
+        elif copy.lines:
+            embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
+
+        if copy.pairs:
+            embed["fields"] = [
+                {
+                    "name": clip(name, _FIELD_NAME_MAX),
+                    "value": clip(value, _FIELD_VALUE_MAX),
+                    "inline": False,
+                }
+                for name, value in copy.pairs
+            ]
+
+        while _embed_size(embed) > _EMBED_TOTAL_MAX and embed.get("fields"):
+            embed["fields"].pop()
+        if _embed_size(embed) > _EMBED_TOTAL_MAX and "description" in embed:
+            overflow = _embed_size(embed) - _EMBED_TOTAL_MAX
+            embed["description"] = clip(
+                embed["description"], max(1, len(embed["description"]) - overflow)
+            )
+
+        return json.dumps(
+            {"username": "spoo.me", "embeds": [embed]},
+            separators=(",", ":"),
+            default=str,
+        )

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -82,11 +82,13 @@ class DiscordRenderer:
             embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
 
         if copy.pairs:
+            # Short facts sit side by side (Discord flows three per row);
+            # long values like destination URLs take the full width.
             embed["fields"] = [
                 {
                     "name": clip(name, _FIELD_NAME_MAX),
                     "value": clip(value, _FIELD_VALUE_MAX),
-                    "inline": False,
+                    "inline": name != "Destination" and len(value) <= 32,
                 }
                 for name, value in copy.pairs
             ]

--- a/services/webhooks/renderers/protocol.py
+++ b/services/webhooks/renderers/protocol.py
@@ -12,6 +12,10 @@ from typing import Any, Protocol
 
 
 class Renderer(Protocol):
+    # Optional: query params the executor appends to the endpoint URL at
+    # delivery time (e.g. Discord's ``with_components=true``). Absent or
+    # empty means the URL is used as stored.
+
     flavor: str
 
     def render(

--- a/services/webhooks/renderers/protocol.py
+++ b/services/webhooks/renderers/protocol.py
@@ -15,5 +15,5 @@ class Renderer(Protocol):
     flavor: str
 
     def render(
-        self, event_type: str, timestamp: str, payload: dict[str, Any]
+        self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
     ) -> str: ...

--- a/services/webhooks/renderers/protocol.py
+++ b/services/webhooks/renderers/protocol.py
@@ -1,0 +1,19 @@
+"""Renderer protocol — flavors are presentation, never a second schema.
+
+A renderer turns (event type, payload) into the exact body string that
+gets signed and sent. ``raw`` is the versioned contract; every other
+flavor is a lossy rendering of it. Docs, catalog samples, and Zapier
+speak raw only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class Renderer(Protocol):
+    flavor: str
+
+    def render(
+        self, event_type: str, timestamp: str, payload: dict[str, Any]
+    ) -> str: ...

--- a/services/webhooks/renderers/raw.py
+++ b/services/webhooks/renderers/raw.py
@@ -1,0 +1,19 @@
+"""Raw flavor — the Standard Webhooks envelope, THE versioned contract."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class RawRenderer:
+    flavor = "raw"
+
+    def render(self, event_type: str, timestamp: str, payload: dict[str, Any]) -> str:
+        # Compact separators: the rendered body is stored per delivery row
+        # and capped at max_payload_bytes — no cosmetic whitespace.
+        return json.dumps(
+            {"type": event_type, "timestamp": timestamp, "data": payload},
+            separators=(",", ":"),
+            default=str,
+        )

--- a/services/webhooks/renderers/raw.py
+++ b/services/webhooks/renderers/raw.py
@@ -9,11 +9,20 @@ from typing import Any
 class RawRenderer:
     flavor = "raw"
 
-    def render(self, event_type: str, timestamp: str, payload: dict[str, Any]) -> str:
+    def render(
+        self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
+    ) -> str:
+        # ``id`` is the EVENT identity (evt_…, same fact across endpoints);
+        # the webhook-id header is the DELIVERY identity (msg_…, dedup key).
         # Compact separators: the rendered body is stored per delivery row
         # and capped at max_payload_bytes — no cosmetic whitespace.
         return json.dumps(
-            {"type": event_type, "timestamp": timestamp, "data": payload},
+            {
+                "id": event_id,
+                "type": event_type,
+                "timestamp": timestamp,
+                "data": payload,
+            },
             separators=(",", ":"),
             default=str,
         )

--- a/services/webhooks/renderers/slack.py
+++ b/services/webhooks/renderers/slack.py
@@ -1,0 +1,96 @@
+"""Slack flavor — Block Kit body for a Slack incoming webhook URL.
+
+Top-level ``text`` is the notification fallback Slack shows in toasts and
+unexpanded previews. Receiver limits enforced locally (section text 3000,
+10 fields per section); Slack code blocks do not colorize, so link.updated
+renders old → new pairs instead of Discord's diff block.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from services.webhooks.renderers.copy import build_copy, clip
+
+_TEXT_MAX = 3000
+_FIELD_MAX = 2000
+_FIELDS_PER_SECTION = 10
+
+
+def _escape(text: str) -> str:
+    # Slack mrkdwn control characters.
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _mrkdwn(text: str) -> dict[str, str]:
+    return {"type": "mrkdwn", "text": clip(text, _TEXT_MAX)}
+
+
+def _title_text(title: str, url: str | None) -> str:
+    escaped = _escape(title)
+    return f"*<{url}|{escaped}>*" if url else f"*{escaped}*"
+
+
+def _field_sections(pairs: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    sections: list[dict[str, Any]] = []
+    for start in range(0, len(pairs), _FIELDS_PER_SECTION):
+        chunk = pairs[start : start + _FIELDS_PER_SECTION]
+        sections.append(
+            {
+                "type": "section",
+                "fields": [
+                    _mrkdwn(clip(f"*{_escape(name)}*\n{_escape(value)}", _FIELD_MAX))
+                    for name, value in chunk
+                ],
+            }
+        )
+    return sections
+
+
+class SlackRenderer:
+    flavor = "slack"
+
+    def render(
+        self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
+    ) -> str:
+        copy = build_copy(event_type, timestamp, payload)
+
+        blocks: list[dict[str, Any]] = []
+        if copy.lines:
+            body = "\n".join(_escape(line) for line in copy.lines)
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": _mrkdwn(
+                        f"{_title_text(copy.title, copy.title_url)}\n{body}"
+                    ),
+                }
+            )
+        else:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": _mrkdwn(_title_text(copy.title, copy.title_url)),
+                }
+            )
+            if copy.changes:
+                blocks.extend(
+                    _field_sections(
+                        [(name, f"{old} → {new}") for name, old, new in copy.changes]
+                    )
+                )
+            elif copy.pairs:
+                blocks.extend(_field_sections(copy.pairs))
+            elif copy.code:
+                blocks.append(
+                    {"type": "section", "text": _mrkdwn(f"```{_escape(copy.code)}```")}
+                )
+
+        blocks.append({"type": "context", "elements": [_mrkdwn(_escape(copy.context))]})
+
+        return json.dumps(
+            {"text": clip(copy.title, _TEXT_MAX), "blocks": blocks},
+            separators=(",", ":"),
+            default=str,
+        )

--- a/services/webhooks/service.py
+++ b/services/webhooks/service.py
@@ -1,0 +1,262 @@
+"""WebhookService — endpoint CRUD, test sends, delivery log reads.
+
+Owns the WHY: quota, URL safety at registration, pattern validation,
+secret lifecycle (generated here, shown once, stored encrypted), and
+owner-cache invalidation on every mutation. The flag gate lives at the
+route layer (write-side only, TRD §8); dispatch never sees this class.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+
+from errors import NotFoundError, ValidationError
+from infrastructure.crypto import encrypt_secret
+from infrastructure.logging import get_logger
+from infrastructure.safe_fetch import FetchHardError, validate_public_https_url
+from repositories.webhook_delivery_repository import WebhookDeliveryRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from repositories.webhook_event_repository import WebhookEventRepository
+from schemas.enums.webhook import DeliveryStatus, WebhookFlavor, WebhookStatus
+from schemas.models.webhook import (
+    WebhookDeliveryDoc,
+    WebhookEndpointDoc,
+    WebhookScope,
+)
+from services.events.contract import DomainEvent
+from services.webhooks.executor import SECRET_ENC_DOMAIN, DeliveryExecutor
+from services.webhooks.matcher import OwnerSubscriptionCache
+from services.webhooks.registry import (
+    EVENT_REGISTRY,
+    TEST_EVENT_SPEC,
+    TEST_EVENT_TYPE,
+    validate_patterns,
+)
+from services.webhooks.signing import (
+    generate_signing_secret,
+    new_webhook_id,
+    secret_display_prefix,
+)
+
+log = get_logger(__name__)
+
+
+class WebhookService:
+    def __init__(
+        self,
+        endpoint_repo: WebhookEndpointRepository,
+        delivery_repo: WebhookDeliveryRepository,
+        event_repo: WebhookEventRepository,
+        executor: DeliveryExecutor,
+        owner_cache: OwnerSubscriptionCache,
+        *,
+        master_secret: str,
+        max_endpoints: int = 5,
+    ) -> None:
+        self._endpoints = endpoint_repo
+        self._deliveries = delivery_repo
+        self._events = event_repo
+        self._executor = executor
+        self._cache = owner_cache
+        self._master_secret = master_secret
+        self._max_endpoints = max_endpoints
+
+    # ── CRUD ─────────────────────────────────────────────────────────────
+
+    async def create_endpoint(
+        self,
+        user_id: ObjectId,
+        *,
+        url: str,
+        events: list[str],
+        description: str | None,
+        scope_links: list[str] | None,
+        flavor: WebhookFlavor,
+    ) -> tuple[WebhookEndpointDoc, str]:
+        """Returns (doc, raw signing secret). The secret's only appearance."""
+        await self._validate_url(url)
+        validate_patterns(events)
+        if await self._endpoints.count_by_user(user_id) >= self._max_endpoints:
+            raise ValidationError(
+                f"Endpoint limit reached ({self._max_endpoints}). "
+                "Delete an endpoint to add a new one."
+            )
+
+        secret = generate_signing_secret()
+        now = datetime.now(timezone.utc)
+        doc = WebhookEndpointDoc(
+            user_id=user_id,
+            url=url,
+            description=description,
+            events=events,
+            scope=_scope_from_links(scope_links),
+            flavor=flavor,
+            status=WebhookStatus.ACTIVE,
+            signing_secret_enc=encrypt_secret(
+                secret, self._master_secret, domain=SECRET_ENC_DOMAIN
+            ),
+            signing_secret_prefix=secret_display_prefix(secret),
+            created_at=now,
+        )
+        doc.id = await self._endpoints.insert_endpoint(doc)
+        await self._cache.invalidate(str(user_id))
+        log.info("webhook_endpoint_created", endpoint_id=str(doc.id))
+        return doc, secret
+
+    async def get_endpoint(
+        self, endpoint_id: ObjectId, user_id: ObjectId
+    ) -> WebhookEndpointDoc:
+        doc = await self._endpoints.find_owned(endpoint_id, user_id)
+        if doc is None:
+            raise NotFoundError("Webhook endpoint not found")
+        return doc
+
+    async def list_endpoints(self, user_id: ObjectId) -> list[WebhookEndpointDoc]:
+        return await self._endpoints.find_by_user(user_id)
+
+    async def update_endpoint(
+        self, endpoint_id: ObjectId, user_id: ObjectId, fields: dict[str, Any]
+    ) -> WebhookEndpointDoc:
+        doc = await self.get_endpoint(endpoint_id, user_id)
+        updates: dict[str, Any] = {}
+        if "url" in fields and fields["url"] != doc.url:
+            await self._validate_url(fields["url"])
+            updates["url"] = fields["url"]
+        if "events" in fields:
+            validate_patterns(fields["events"])
+            updates["events"] = fields["events"]
+        if "scope_links" in fields:
+            updates["scope"] = _scope_from_links(fields["scope_links"]).model_dump()
+        if "description" in fields:
+            updates["description"] = fields["description"]
+        if "flavor" in fields:
+            updates["flavor"] = WebhookFlavor(fields["flavor"]).value
+        if "status" in fields:
+            updates.update(_status_transition(doc, fields["status"]))
+        if updates:
+            await self._endpoints.update_fields(endpoint_id, updates)
+            await self._cache.invalidate(str(user_id))
+        return await self.get_endpoint(endpoint_id, user_id)
+
+    async def delete_endpoint(self, endpoint_id: ObjectId, user_id: ObjectId) -> None:
+        if not await self._endpoints.delete_endpoint(endpoint_id, user_id):
+            raise NotFoundError("Webhook endpoint not found")
+        await self._cache.invalidate(str(user_id))
+        log.info("webhook_endpoint_deleted", endpoint_id=str(endpoint_id))
+
+    # ── Test sends ───────────────────────────────────────────────────────
+
+    async def send_test(
+        self, endpoint_id: ObjectId, user_id: ObjectId, event_type: str
+    ) -> WebhookDeliveryDoc:
+        """Send a sample of any catalog event through the REAL pipeline —
+        rendered in the endpoint's flavor, signed for real, logged with
+        ``is_test`` — synchronously, so the caller gets the outcome."""
+        endpoint = await self.get_endpoint(endpoint_id, user_id)
+        spec = (
+            TEST_EVENT_SPEC
+            if event_type == TEST_EVENT_TYPE
+            else EVENT_REGISTRY.get(event_type)
+        )
+        if spec is None:
+            raise ValidationError(f"Unknown event type '{event_type}'")
+
+        event = DomainEvent(type=spec.name, owner_id=str(user_id), data=spec.sample())
+        event_oid = await self._events.insert_event(event, is_test=True)
+        now = datetime.now(timezone.utc)
+        delivery_id = await self._deliveries.insert_row(
+            {
+                "endpoint_id": endpoint.id,
+                "user_id": endpoint.user_id,
+                "event_oid": event_oid,
+                "event_type": event.type,
+                "webhook_id": new_webhook_id(),
+                "is_test": True,
+                "rendered_body": None,
+                "dropped_since_last": 0,
+                "status": DeliveryStatus.PENDING.value,
+                "attempts": [],
+                "attempt_count": 0,
+                # Never claimable by the background loop — the synchronous
+                # attempt below is the only executor this row meets.
+                "next_attempt_at": None,
+                "claimed_until": None,
+                "created_at": now,
+                "completed_at": None,
+            }
+        )
+        row = await self._deliveries.find_by_id(delivery_id)
+        await self._executor.attempt(row)
+        return await self._deliveries.find_by_id(delivery_id)
+
+    # ── Delivery log ─────────────────────────────────────────────────────
+
+    async def list_deliveries(
+        self,
+        endpoint_id: ObjectId,
+        user_id: ObjectId,
+        *,
+        page: int,
+        page_size: int,
+        status: DeliveryStatus | None,
+    ) -> tuple[list[WebhookDeliveryDoc], int]:
+        await self.get_endpoint(endpoint_id, user_id)  # ownership gate
+        return await self._deliveries.list_by_endpoint(
+            endpoint_id, page=page, page_size=page_size, status=status
+        )
+
+    async def retry_delivery(
+        self, endpoint_id: ObjectId, delivery_id: ObjectId, user_id: ObjectId
+    ) -> WebhookDeliveryDoc:
+        """Manual redelivery: same webhook_id, same rendered body, fresh
+        attempt — run synchronously like a test send."""
+        await self.get_endpoint(endpoint_id, user_id)
+        row = await self._deliveries.find_owned(delivery_id, user_id)
+        if row is None or row.endpoint_id != endpoint_id:
+            raise NotFoundError("Delivery not found")
+        if row.status == DeliveryStatus.PENDING:
+            raise ValidationError("Delivery is still pending")
+        await self._executor.attempt(row)
+        return await self._deliveries.find_by_id(delivery_id)
+
+    # ── Internals ────────────────────────────────────────────────────────
+
+    async def _validate_url(self, url: str) -> None:
+        if len(url) > 2048:
+            raise ValidationError("URL too long (max 2048 characters)")
+        try:
+            await validate_public_https_url(url)
+        except FetchHardError as exc:
+            raise ValidationError(f"Endpoint URL rejected: {exc}") from exc
+
+
+def _scope_from_links(scope_links: list[str] | None) -> WebhookScope:
+    if scope_links is None:
+        return WebhookScope()
+    ids = []
+    for raw in scope_links:
+        if not ObjectId.is_valid(raw):
+            raise ValidationError(f"Invalid link id in scope: '{raw}'")
+        ids.append(ObjectId(raw))
+    if not ids:
+        raise ValidationError("scope.links must be 'all' or a non-empty list of ids")
+    return WebhookScope(links=ids)
+
+
+def _status_transition(doc: WebhookEndpointDoc, target: str) -> dict[str, Any]:
+    """Users may pause/resume; DISABLED is system-set and only exits via
+    explicit re-activation (which also clears the failure bookkeeping)."""
+    status = WebhookStatus(target)
+    if status == WebhookStatus.DISABLED:
+        raise ValidationError(
+            "'disabled' is system-set; use 'paused' to stop deliveries"
+        )
+    updates: dict[str, Any] = {"status": status.value}
+    if status == WebhookStatus.ACTIVE and doc.status == WebhookStatus.DISABLED:
+        updates.update(
+            {"disabled_reason": None, "consecutive_failures": 0, "dropped_count": 0}
+        )
+    return updates

--- a/services/webhooks/service.py
+++ b/services/webhooks/service.py
@@ -3,7 +3,7 @@
 Owns the WHY: quota, URL safety at registration, pattern validation,
 secret lifecycle (generated here, shown once, stored encrypted), and
 owner-cache invalidation on every mutation. The flag gate lives at the
-route layer (write-side only, TRD §8); dispatch never sees this class.
+route layer (write-side only); dispatch never sees this class.
 """
 
 from __future__ import annotations

--- a/services/webhooks/service.py
+++ b/services/webhooks/service.py
@@ -14,7 +14,7 @@ from typing import Any
 from bson import ObjectId
 
 from errors import NotFoundError, ValidationError
-from infrastructure.crypto import encrypt_secret
+from infrastructure.crypto import decrypt_secret, encrypt_secret
 from infrastructure.logging import get_logger
 from infrastructure.safe_fetch import FetchHardError, validate_public_https_url
 from repositories.webhook_delivery_repository import WebhookDeliveryRepository
@@ -140,6 +140,27 @@ class WebhookService:
             await self._endpoints.update_fields(endpoint_id, updates)
             await self._cache.invalidate(str(user_id))
         return await self.get_endpoint(endpoint_id, user_id)
+
+    async def reveal_secret(self, endpoint_id: ObjectId, user_id: ObjectId) -> str:
+        """The stored secret is encrypted, never hashed (the executor must
+        read it back to sign), so revealing it to its owner is an ordinary
+        read. A secret the master key can no longer open is reported
+        instead of raising a bare crypto error."""
+        doc = await self.get_endpoint(endpoint_id, user_id)
+        try:
+            return decrypt_secret(
+                doc.signing_secret_enc, self._master_secret, domain=SECRET_ENC_DOMAIN
+            )
+        except Exception as exc:
+            log.error(
+                "webhook_secret_reveal_failed",
+                endpoint_id=str(endpoint_id),
+                error_type=type(exc).__name__,
+            )
+            raise ValidationError(
+                "The stored secret can no longer be read. Delete this "
+                "endpoint and create it again."
+            ) from exc
 
     async def delete_endpoint(self, endpoint_id: ObjectId, user_id: ObjectId) -> None:
         if not await self._endpoints.delete_endpoint(endpoint_id, user_id):

--- a/services/webhooks/signing.py
+++ b/services/webhooks/signing.py
@@ -3,8 +3,9 @@
 Headers: ``webhook-id`` / ``webhook-timestamp`` / ``webhook-signature``.
 Signature: ``v1,`` + base64(HMAC-SHA256(secret, "{msg_id}.{timestamp}.{body}")).
 
-The secret is ``whsec_`` + base64(24 random bytes); stored hash-only
-(SHA-256), shown once at creation. The BODY is frozen across retries
+The secret is ``whsec_`` + base64(24 random bytes); shown once at
+creation, stored AES-GCM encrypted (infrastructure/crypto.py) because
+the server signs with it at delivery time. The BODY is frozen across retries
 but the timestamp — and therefore the signature — is fresh per
 attempt: replay protection requires it.
 """
@@ -32,10 +33,6 @@ def new_webhook_id() -> str:
 
 def generate_signing_secret() -> str:
     return SECRET_PREFIX + base64.b64encode(secrets.token_bytes(_SECRET_BYTES)).decode()
-
-
-def hash_signing_secret(secret: str) -> str:
-    return hashlib.sha256(secret.encode()).hexdigest()
 
 
 def secret_display_prefix(secret: str) -> str:

--- a/services/webhooks/signing.py
+++ b/services/webhooks/signing.py
@@ -1,0 +1,67 @@
+"""Standard Webhooks signing — https://www.standardwebhooks.com/
+
+Headers: ``webhook-id`` / ``webhook-timestamp`` / ``webhook-signature``.
+Signature: ``v1,`` + base64(HMAC-SHA256(secret, "{msg_id}.{timestamp}.{body}")).
+
+The secret is ``whsec_`` + base64(24 random bytes); stored hash-only
+(SHA-256), shown once at creation. The BODY is frozen across retries
+(D15) but the timestamp — and therefore the signature — is fresh per
+attempt: replay protection requires it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+import uuid
+
+SECRET_PREFIX = "whsec_"
+_SECRET_BYTES = 24
+DISPLAY_PREFIX_LEN = 8  # chars of the secret shown for identification
+
+HEADER_ID = "webhook-id"
+HEADER_TIMESTAMP = "webhook-timestamp"
+HEADER_SIGNATURE = "webhook-signature"
+
+
+def new_webhook_id() -> str:
+    return f"msg_{uuid.uuid4().hex}"
+
+
+def generate_signing_secret() -> str:
+    return SECRET_PREFIX + base64.b64encode(secrets.token_bytes(_SECRET_BYTES)).decode()
+
+
+def hash_signing_secret(secret: str) -> str:
+    return hashlib.sha256(secret.encode()).hexdigest()
+
+
+def secret_display_prefix(secret: str) -> str:
+    return secret[: len(SECRET_PREFIX) + DISPLAY_PREFIX_LEN]
+
+
+def _secret_key_bytes(secret: str) -> bytes:
+    """Per Standard Webhooks, the HMAC key is the base64-DECODED portion
+    after the ``whsec_`` prefix."""
+    return base64.b64decode(secret.removeprefix(SECRET_PREFIX))
+
+
+def sign(msg_id: str, timestamp: int, body: str, secret: str) -> str:
+    to_sign = f"{msg_id}.{timestamp}.{body}".encode()
+    digest = hmac.new(_secret_key_bytes(secret), to_sign, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def verify(msg_id: str, timestamp: int, body: str, secret: str, signature: str) -> bool:
+    """Constant-time verification — used by tests and by consumers' docs
+    examples; the server itself only signs."""
+    expected = sign(msg_id, timestamp, body, secret)
+    # A receiver may get multiple space-delimited signatures during
+    # secret-rotation grace; accept if ANY matches.
+    return any(
+        hmac.compare_digest(expected, candidate)
+        for candidate in signature.split(" ")
+        if candidate
+    )

--- a/services/webhooks/signing.py
+++ b/services/webhooks/signing.py
@@ -5,7 +5,7 @@ Signature: ``v1,`` + base64(HMAC-SHA256(secret, "{msg_id}.{timestamp}.{body}")).
 
 The secret is ``whsec_`` + base64(24 random bytes); stored hash-only
 (SHA-256), shown once at creation. The BODY is frozen across retries
-(D15) but the timestamp — and therefore the signature — is fresh per
+but the timestamp — and therefore the signature — is fresh per
 attempt: replay protection requires it.
 """
 

--- a/shared/scopes.py
+++ b/shared/scopes.py
@@ -18,6 +18,8 @@ SCOPE_DESCRIPTIONS: dict[ApiKeyScope, str] = {
     ApiKeyScope.DOMAINS_READ: "List custom domains",
     ApiKeyScope.DOMAINS_MANAGE: "Add and remove domains",
     ApiKeyScope.REPORTS_CREATE: "Submit abuse reports",
+    ApiKeyScope.WEBHOOKS_MANAGE: "Create and manage webhook endpoints",
+    ApiKeyScope.WEBHOOKS_READ: "List webhook endpoints and delivery logs",
     ApiKeyScope.KEYS_MANAGE: "List and revoke your API keys",
     ApiKeyScope.ADMIN_ALL: "Full access, overrides all scopes",
 }

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -544,3 +544,19 @@ def test_create_rejects_unknown_flavor_422():
     with _NO_SSRF, TestClient(app) as c:
         resp = c.post(_URL, json=_create_body(flavor="teams"))
         assert resp.status_code == 422
+
+
+def test_reveal_secret_returns_the_created_secret():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        revealed = c.get(f"{_URL}/{created['id']}/secret")
+        assert revealed.status_code == 200
+        assert revealed.json()["signing_secret"] == created["signing_secret"]
+
+
+def test_reveal_secret_unknown_endpoint_404():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        resp = c.get(f"{_URL}/{ObjectId()}/secret")
+        assert resp.status_code == 404

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -107,7 +107,6 @@ class _FakeEndpointRepo:
             {
                 "consecutive_failures": 0,
                 "dropped_count": 0,
-                "total_deliveries": doc.total_deliveries + 1,
                 "total_successes": doc.total_successes + 1,
                 "last_delivery_at": datetime.now(timezone.utc),
                 "last_success_at": datetime.now(timezone.utc),
@@ -122,11 +121,16 @@ class _FakeEndpointRepo:
             endpoint_id,
             {
                 "consecutive_failures": streak,
-                "total_deliveries": doc.total_deliveries + 1,
                 "last_failure_reason": reason,
             },
         )
         return streak
+
+    async def increment_deliveries(self, endpoint_id, by=1):
+        doc = self.docs[endpoint_id]
+        await self.update_fields(
+            endpoint_id, {"total_deliveries": doc.total_deliveries + by}
+        )
 
     async def increment_dropped(self, endpoint_id):
         doc = self.docs[endpoint_id]

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -1,0 +1,483 @@
+"""Tests for /api/v1/webhooks — endpoint CRUD, test sends, delivery log.
+
+The service under test is REAL end to end: real WebhookService, real
+DeliveryExecutor (renders + signs for real), real matcher/registry — over
+in-memory repo fakes. Only outbound HTTP (post_public) and creation-time
+SSRF resolution are patched; the flag service and auth are injected.
+
+Wire shapes here are FROZEN — the dashboard webhooks page builds against
+the exact bodies asserted in this file.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from dependencies import get_current_user, get_feature_flag_service, get_webhook_service
+from errors import ForbiddenError
+from infrastructure.safe_fetch import PostResult
+from middleware.rate_limiter import limiter
+from routes.api_v1 import router as api_v1_router
+from schemas.enums.webhook import DeliveryStatus, WebhookStatus
+from schemas.models.webhook import (
+    WebhookDeliveryDoc,
+    WebhookEndpointDoc,
+    WebhookEventDoc,
+)
+from services.webhooks import DeliveryExecutor, OwnerSubscriptionCache, WebhookService
+from services.webhooks.renderers import default_renderers
+from services.webhooks.signing import verify
+from tests.conftest import build_test_app
+
+from .conftest import _make_user
+
+_URL = "/api/v1/webhooks"
+_MASTER = "test-master-secret"
+_HOOK_URL = "https://example.com/hooks/spoo"
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter_between_tests():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+# ── In-memory repo fakes (duck-typed; services never isinstance-check) ───────
+
+
+class _FakeEndpointRepo:
+    def __init__(self) -> None:
+        self.docs: dict[ObjectId, WebhookEndpointDoc] = {}
+
+    async def insert_endpoint(self, doc: WebhookEndpointDoc) -> ObjectId:
+        oid = ObjectId()
+        stored = doc.model_copy()
+        stored.id = oid
+        self.docs[oid] = stored
+        return oid
+
+    async def find_by_id(self, endpoint_id):
+        return self.docs.get(endpoint_id)
+
+    async def find_owned(self, endpoint_id, user_id):
+        doc = self.docs.get(endpoint_id)
+        return doc if doc is not None and doc.user_id == user_id else None
+
+    async def find_by_user(self, user_id):
+        return [d for d in self.docs.values() if d.user_id == user_id]
+
+    async def find_active_for_owner(self, owner_id):
+        return [
+            d
+            for d in self.docs.values()
+            if d.user_id == owner_id and d.status == WebhookStatus.ACTIVE
+        ]
+
+    async def count_by_user(self, user_id):
+        return len(await self.find_by_user(user_id))
+
+    async def update_fields(self, endpoint_id, fields):
+        doc = self.docs[endpoint_id]
+        merged = doc.model_dump(by_alias=True)
+        merged.update(fields)
+        merged["_id"] = endpoint_id
+        self.docs[endpoint_id] = WebhookEndpointDoc.from_mongo(merged)
+        return True
+
+    async def delete_endpoint(self, endpoint_id, user_id):
+        doc = self.docs.get(endpoint_id)
+        if doc is None or doc.user_id != user_id:
+            return False
+        del self.docs[endpoint_id]
+        return True
+
+    async def record_success(self, endpoint_id):
+        doc = self.docs[endpoint_id]
+        dropped = doc.dropped_count
+        await self.update_fields(
+            endpoint_id,
+            {
+                "consecutive_failures": 0,
+                "dropped_count": 0,
+                "total_deliveries": doc.total_deliveries + 1,
+                "total_successes": doc.total_successes + 1,
+                "last_delivery_at": datetime.now(timezone.utc),
+                "last_success_at": datetime.now(timezone.utc),
+            },
+        )
+        return dropped
+
+    async def record_exhausted(self, endpoint_id, reason):
+        doc = self.docs[endpoint_id]
+        streak = doc.consecutive_failures + 1
+        await self.update_fields(
+            endpoint_id,
+            {
+                "consecutive_failures": streak,
+                "total_deliveries": doc.total_deliveries + 1,
+                "last_failure_reason": reason,
+            },
+        )
+        return streak
+
+    async def increment_dropped(self, endpoint_id):
+        doc = self.docs[endpoint_id]
+        await self.update_fields(endpoint_id, {"dropped_count": doc.dropped_count + 1})
+
+    async def disable(self, endpoint_id, reason):
+        await self.update_fields(
+            endpoint_id,
+            {"status": WebhookStatus.DISABLED.value, "disabled_reason": reason.value},
+        )
+        return True
+
+
+class _FakeDeliveryRepo:
+    def __init__(self) -> None:
+        self.docs: dict[ObjectId, WebhookDeliveryDoc] = {}
+
+    async def insert_row(self, row: dict) -> ObjectId:
+        oid = ObjectId()
+        row = dict(row)
+        row["_id"] = oid
+        self.docs[oid] = WebhookDeliveryDoc.from_mongo(row)
+        return oid
+
+    async def insert_many_rows(self, rows: list[dict]) -> None:
+        for row in rows:
+            await self.insert_row(row)
+
+    async def find_by_id(self, delivery_id):
+        return self.docs.get(delivery_id)
+
+    async def find_owned(self, delivery_id, user_id):
+        doc = self.docs.get(delivery_id)
+        return doc if doc is not None and doc.user_id == user_id else None
+
+    async def count_pending(self, endpoint_id):
+        return sum(
+            1
+            for d in self.docs.values()
+            if d.endpoint_id == endpoint_id and d.status == DeliveryStatus.PENDING
+        )
+
+    async def list_by_endpoint(self, endpoint_id, *, page, page_size, status=None):
+        rows = [
+            d
+            for d in self.docs.values()
+            if d.endpoint_id == endpoint_id and (status is None or d.status == status)
+        ]
+        rows.sort(key=lambda d: d.created_at or datetime.min, reverse=True)
+        start = (page - 1) * page_size
+        return rows[start : start + page_size], len(rows)
+
+    def _update(self, delivery_id, **fields):
+        merged = self.docs[delivery_id].model_dump(by_alias=True)
+        merged.update(fields)
+        merged["_id"] = delivery_id
+        self.docs[delivery_id] = WebhookDeliveryDoc.from_mongo(merged)
+
+    async def set_rendered_body(self, delivery_id, body):
+        if self.docs[delivery_id].rendered_body is None:
+            self._update(delivery_id, rendered_body=body)
+
+    async def record_attempt_and_reschedule(
+        self, delivery_id, attempt, next_attempt_at
+    ):
+        doc = self.docs[delivery_id]
+        self._update(
+            delivery_id,
+            attempts=[*[a.model_dump() for a in doc.attempts], attempt.model_dump()],
+            attempt_count=doc.attempt_count + 1,
+            next_attempt_at=next_attempt_at,
+            claimed_until=None,
+        )
+
+    async def record_attempt_and_finish(self, delivery_id, attempt, status):
+        doc = self.docs[delivery_id]
+        self._update(
+            delivery_id,
+            attempts=[*[a.model_dump() for a in doc.attempts], attempt.model_dump()],
+            attempt_count=doc.attempt_count + 1,
+            status=status.value,
+            completed_at=datetime.now(timezone.utc),
+            next_attempt_at=None,
+        )
+
+    async def mark_failed(self, delivery_id, reason):
+        self._update(delivery_id, status=DeliveryStatus.FAILED.value)
+
+
+class _FakeEventRepo:
+    def __init__(self) -> None:
+        self.docs: dict[ObjectId, WebhookEventDoc] = {}
+
+    async def insert_event(self, event, *, is_test: bool = False) -> ObjectId:
+        oid = ObjectId()
+        self.docs[oid] = WebhookEventDoc(
+            **{
+                "_id": oid,
+                "event_id": event.event_id,
+                "type": event.type,
+                "v": event.v,
+                "owner_id": ObjectId(event.owner_id),
+                "occurred_at": event.occurred_at,
+                "payload": event.data,
+                "is_test": is_test,
+                "created_at": datetime.now(timezone.utc),
+            }
+        )
+        return oid
+
+    async def find_by_oid(self, oid):
+        return self.docs.get(oid)
+
+
+class _AllowFlags:
+    async def require(self, name, user):
+        return None
+
+
+class _DenyFlags:
+    async def require(self, name, user):
+        raise ForbiddenError("This feature is not available on your account")
+
+
+# ── Harness ───────────────────────────────────────────────────────────────────
+
+
+def _build(max_endpoints: int = 5, flags: Any | None = None):
+    endpoint_repo = _FakeEndpointRepo()
+    delivery_repo = _FakeDeliveryRepo()
+    event_repo = _FakeEventRepo()
+    executor = DeliveryExecutor(
+        delivery_repo,
+        endpoint_repo,
+        event_repo,
+        default_renderers(),
+        master_secret=_MASTER,
+    )
+    service = WebhookService(
+        endpoint_repo,
+        delivery_repo,
+        event_repo,
+        executor,
+        OwnerSubscriptionCache(None, ttl_seconds=60),
+        master_secret=_MASTER,
+        max_endpoints=max_endpoints,
+    )
+    user = _make_user()
+    app = build_test_app(
+        api_v1_router,
+        overrides={
+            get_webhook_service: lambda: service,
+            get_current_user: lambda: user,
+            get_feature_flag_service: lambda: flags or _AllowFlags(),
+        },
+    )
+    return app, user, endpoint_repo, delivery_repo
+
+
+def _create_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {"url": _HOOK_URL, "events": ["link.clicked"]}
+    body.update(overrides)
+    return body
+
+
+_NO_SSRF = patch("services.webhooks.service.validate_public_https_url", new=AsyncMock())
+_POST_OK = patch(
+    "services.webhooks.executor.post_public",
+    new=AsyncMock(return_value=PostResult(204, None, None)),
+)
+
+
+# ── Create / list / secret handling ──────────────────────────────────────────
+
+
+def test_create_returns_secret_exactly_once():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body())
+        assert created.status_code == 201
+        body = created.json()
+        assert body["signing_secret"].startswith("whsec_")
+        assert body["signing_secret_prefix"] == body["signing_secret"][:14]
+        assert body["events"] == ["link.clicked"]
+        assert body["scope_links"] is None  # all links
+        assert body["flavor"] == "raw"
+        assert body["status"] == "active"
+
+        listed = c.get(_URL)
+        assert listed.status_code == 200
+        (entry,) = listed.json()["endpoints"]
+        assert "signing_secret" not in entry
+        assert entry["signing_secret_prefix"] == body["signing_secret_prefix"]
+
+
+def test_create_flag_denied_is_403_not_404():
+    app, _, _, _ = _build(flags=_DenyFlags())
+    with _NO_SSRF, TestClient(app) as c:
+        resp = c.post(_URL, json=_create_body())
+    assert resp.status_code == 403
+
+
+def test_create_unknown_event_gets_typo_suggestion():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        resp = c.post(_URL, json=_create_body(events=["link.clickd"]))
+    assert resp.status_code == 400
+    assert "link.clicked" in resp.json()["error"]
+
+
+def test_create_over_quota_rejected():
+    app, _, _, _ = _build(max_endpoints=1)
+    with _NO_SSRF, TestClient(app) as c:
+        assert c.post(_URL, json=_create_body()).status_code == 201
+        resp = c.post(_URL, json=_create_body())
+    assert resp.status_code == 400
+    assert "limit" in resp.json()["error"].lower()
+
+
+def test_create_rejects_non_https_url():
+    # No SSRF patch — the real validator rejects http before any DNS work.
+    app, _, _, _ = _build()
+    with TestClient(app) as c:
+        resp = c.post(_URL, json=_create_body(url="http://example.com/hook"))
+    assert resp.status_code == 400
+    assert "https" in resp.json()["error"]
+
+
+def test_event_catalog_is_public_and_complete():
+    app, _, _, _ = _build()
+    # No auth override needed — but user is injected anyway; the route has
+    # no auth dependency, which is the property under test via no scopes.
+    with TestClient(app) as c:
+        resp = c.get(f"{_URL}/event-types")
+    assert resp.status_code == 200
+    types = resp.json()["event_types"]
+    assert len(types) == 10
+    clicked = next(t for t in types if t["type"] == "link.clicked")
+    assert clicked["category"] == "link"
+    assert clicked["sample"]["alias"] == "summer-drop"
+
+
+# ── Test sends (real executor, patched HTTP) ─────────────────────────────────
+
+
+def test_send_test_delivers_signed_sample_synchronously():
+    app, _, _, _ = _build()
+    post = AsyncMock(return_value=PostResult(204, None, None))
+    with (
+        _NO_SSRF,
+        patch("services.webhooks.executor.post_public", post),
+        TestClient(app) as c,
+    ):
+        created = c.post(_URL, json=_create_body()).json()
+        secret = created["signing_secret"]
+
+        resp = c.post(
+            f"{_URL}/{created['id']}/test", json={"event_type": "link.clicked"}
+        )
+        assert resp.status_code == 200
+        delivery = resp.json()
+        assert delivery["is_test"] is True
+        assert delivery["status"] == "success"
+        assert delivery["event_type"] == "link.clicked"
+        assert delivery["attempt_count"] == 1
+        assert delivery["attempts"][0]["status_code"] == 204
+
+        # The POST that left the building verifies against the secret the
+        # user was shown — the full Standard Webhooks loop, end to end.
+        url, body = post.await_args[0]
+        headers = post.await_args.kwargs["headers"]
+        assert url == _HOOK_URL
+        assert verify(
+            headers["webhook-id"],
+            int(headers["webhook-timestamp"]),
+            body,
+            secret,
+            headers["webhook-signature"],
+        )
+
+
+def test_send_test_unknown_type_400():
+    app, _, _, _ = _build()
+    with _NO_SSRF, _POST_OK, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        resp = c.post(f"{_URL}/{created['id']}/test", json={"event_type": "nope"})
+    assert resp.status_code == 400
+
+
+# ── Delivery log + retry ─────────────────────────────────────────────────────
+
+
+def test_delivery_log_lists_test_send():
+    app, _, _, _ = _build()
+    with _NO_SSRF, _POST_OK, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        c.post(f"{_URL}/{created['id']}/test", json={})
+
+        resp = c.get(f"{_URL}/{created['id']}/deliveries")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        (row,) = body["deliveries"]
+        assert row["webhook_id"].startswith("msg_")
+        assert row["rendered_body"] is not None
+        assert row["status"] == "success"
+
+
+def test_manual_retry_reuses_webhook_id():
+    app, _, _, _ = _build()
+    with _NO_SSRF, _POST_OK, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        first = c.post(f"{_URL}/{created['id']}/test", json={}).json()
+        retried = c.post(
+            f"{_URL}/{created['id']}/deliveries/{first['id']}/retry"
+        ).json()
+    assert retried["webhook_id"] == first["webhook_id"]
+    assert retried["attempt_count"] == 2
+
+
+# ── Update / pause / delete ──────────────────────────────────────────────────
+
+
+def test_patch_pause_and_resume():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        paused = c.patch(f"{_URL}/{created['id']}", json={"status": "paused"})
+        assert paused.json()["status"] == "paused"
+        resumed = c.patch(f"{_URL}/{created['id']}", json={"status": "active"})
+        assert resumed.json()["status"] == "active"
+
+
+def test_patch_disabled_is_rejected():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        resp = c.patch(f"{_URL}/{created['id']}", json={"status": "disabled"})
+    assert resp.status_code == 400
+
+
+def test_delete_endpoint_204_then_404():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        assert c.delete(f"{_URL}/{created['id']}").status_code == 204
+        assert c.get(f"{_URL}/{created['id']}").status_code == 404
+
+
+def test_scoped_endpoint_roundtrips_link_ids():
+    app, _, _, _ = _build()
+    link_id = str(ObjectId())
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body(scope_links=[link_id])).json()
+    assert created["scope_links"] == [link_id]

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -362,7 +362,7 @@ def test_event_catalog_is_public_and_complete():
         resp = c.get(f"{_URL}/event-types")
     assert resp.status_code == 200
     types = resp.json()["event_types"]
-    assert len(types) == 10
+    assert len(types) == 8
     clicked = next(t for t in types if t["type"] == "link.clicked")
     assert clicked["category"] == "link"
     assert clicked["sample"]["alias"] == "summer-drop"

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -11,6 +11,7 @@ the exact bodies asserted in this file.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -502,3 +503,44 @@ def test_scoped_endpoint_roundtrips_link_ids():
     with _NO_SSRF, TestClient(app) as c:
         created = c.post(_URL, json=_create_body(scope_links=[link_id])).json()
     assert created["scope_links"] == [link_id]
+
+
+def test_send_test_renders_discord_flavor_and_signature_covers_it():
+    """A discord-flavor endpoint delivers an embed body, and the signature
+    verifies over that rendered body (the raw envelope never leaves)."""
+    app, _, _, _ = _build()
+    post = AsyncMock(return_value=PostResult(204, None, None))
+    with (
+        _NO_SSRF,
+        patch("services.webhooks.executor.post_public", post),
+        TestClient(app) as c,
+    ):
+        created = c.post(_URL, json=_create_body(flavor="discord")).json()
+        assert created["flavor"] == "discord"
+        secret = created["signing_secret"]
+
+        resp = c.post(
+            f"{_URL}/{created['id']}/test", json={"event_type": "link.clicked"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+
+        _, body = post.await_args[0]
+        headers = post.await_args.kwargs["headers"]
+        sent = json.loads(body)
+        assert sent["username"] == "spoo.me"
+        assert sent["embeds"][0]["title"].startswith("Click")
+        assert verify(
+            headers["webhook-id"],
+            int(headers["webhook-timestamp"]),
+            body,
+            secret,
+            headers["webhook-signature"],
+        )
+
+
+def test_create_rejects_unknown_flavor_422():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        resp = c.post(_URL, json=_create_body(flavor="teams"))
+        assert resp.status_code == 422

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -36,7 +36,7 @@ from services.webhooks.renderers import default_renderers
 from services.webhooks.signing import verify
 from tests.conftest import build_test_app
 
-from .conftest import _make_user
+from .conftest import _make_api_key_doc, _make_user
 
 _URL = "/api/v1/webhooks"
 _MASTER = "test-master-secret"
@@ -569,3 +569,16 @@ def test_reveal_secret_unknown_endpoint_404():
     with _NO_SSRF, TestClient(app) as c:
         resp = c.get(f"{_URL}/{ObjectId()}/secret")
         assert resp.status_code == 404
+
+
+def test_reveal_secret_refuses_api_key_auth():
+    """Secret reveal is credential material: interactive sessions only,
+    like key creation."""
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+    key_user = _make_user(api_key_doc=_make_api_key_doc(scopes=["webhooks:manage"]))
+    app.dependency_overrides[get_current_user] = lambda: key_user
+    with TestClient(app) as c:
+        resp = c.get(f"{_URL}/{created['id']}/secret")
+        assert resp.status_code == 403

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -362,7 +362,7 @@ def test_event_catalog_is_public_and_complete():
         resp = c.get(f"{_URL}/event-types")
     assert resp.status_code == 200
     types = resp.json()["event_types"]
-    assert len(types) == 6
+    assert len(types) == 5
     clicked = next(t for t in types if t["type"] == "link.clicked")
     assert clicked["category"] == "link"
     assert clicked["sample"]["alias"] == "summer-drop"

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -529,11 +529,16 @@ def test_send_test_renders_discord_flavor_and_signature_covers_it():
         assert resp.status_code == 200
         assert resp.json()["status"] == "success"
 
-        _, body = post.await_args[0]
+        url, body = post.await_args[0]
         headers = post.await_args.kwargs["headers"]
+        assert url.endswith("?with_components=true")
         sent = json.loads(body)
         assert sent["username"] == "spoo.me"
-        assert sent["embeds"][0]["title"].startswith("Click")
+        assert sent["flags"] == 32768
+        texts = [
+            c["content"] for c in sent["components"][0]["components"] if c["type"] == 10
+        ]
+        assert texts[0].startswith("### Click")
         assert verify(
             headers["webhook-id"],
             int(headers["webhook-timestamp"]),

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -362,7 +362,7 @@ def test_event_catalog_is_public_and_complete():
         resp = c.get(f"{_URL}/event-types")
     assert resp.status_code == 200
     types = resp.json()["event_types"]
-    assert len(types) == 8
+    assert len(types) == 6
     clicked = next(t for t in types if t["type"] == "link.clicked")
     assert clicked["category"] == "link"
     assert clicked["sample"]["alias"] == "summer-drop"

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -407,6 +407,27 @@ def test_send_test_delivers_signed_sample_synchronously():
         )
 
 
+def test_send_test_flag_denied_403():
+    """Test sends initiate outbound calls, so they carry the create gate."""
+    app, _, _endpoint_repo, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+    app2, _, _, _ = _build(flags=_DenyFlags())
+    # Same service state is not shared across builds; recreate inline:
+    # simpler to flip flags on one app via override swap.
+    del app2
+    app.dependency_overrides[_flag_override_key()] = lambda: _DenyFlags()
+    with _POST_OK, TestClient(app) as c:
+        resp = c.post(f"{_URL}/{created['id']}/test", json={})
+    assert resp.status_code == 403
+
+
+def _flag_override_key():
+    from dependencies import get_feature_flag_service
+
+    return get_feature_flag_service
+
+
 def test_send_test_unknown_type_400():
     app, _, _, _ = _build()
     with _NO_SSRF, _POST_OK, TestClient(app) as c:

--- a/tests/smoke/test_click_sink_wiring.py
+++ b/tests/smoke/test_click_sink_wiring.py
@@ -30,6 +30,9 @@ _COLLECTIONS = (
     "blocked_domains",
     "reports",
     "report_submissions",
+    "webhook-events",
+    "webhook-endpoints",
+    "webhook-deliveries",
 )
 
 

--- a/tests/smoke/test_custom_domain_cf_wiring.py
+++ b/tests/smoke/test_custom_domain_cf_wiring.py
@@ -40,6 +40,9 @@ def _wire(custom_domains: CustomDomainSettings):
         "blocked_domains": MagicMock(name="blocked_domains"),
         "reports": MagicMock(name="reports"),
         "report_submissions": MagicMock(name="report_submissions"),
+        "webhook-events": MagicMock(name="webhook-events"),
+        "webhook-endpoints": MagicMock(name="webhook-endpoints"),
+        "webhook-deliveries": MagicMock(name="webhook-deliveries"),
     }
     app.state.http_client = MagicMock()
     app.state.geoip = MagicMock()

--- a/tests/unit/infrastructure/test_safe_fetch_post.py
+++ b/tests/unit/infrastructure/test_safe_fetch_post.py
@@ -1,0 +1,117 @@
+"""Direct tests for the webhook delivery POST layer (post_public) and the
+address policy behind it — pinned here so a refactor cannot silently
+regress SSRF behavior at the delivery layer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from infrastructure.safe_fetch import (
+    FetchHardError,
+    FetchTransientError,
+    _is_public,
+    post_public,
+)
+
+
+class TestIsPublic:
+    def test_public_v4(self):
+        assert _is_public("93.184.216.34") is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.1",  # RFC1918
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",  # link-local / cloud metadata
+            "100.64.0.1",  # CGNAT
+            "0.0.0.0",
+            "::1",  # v6 loopback
+            "fc00::1",  # ULA
+            "fe80::1",  # v6 link-local
+            "::ffff:10.0.0.1",  # IPv4-mapped private
+            "64:ff9b::7f00:1",  # NAT64-wrapped 127.0.0.1
+            "64:ff9b::a00:1",  # NAT64-wrapped 10.0.0.1
+            "ff02::1",  # multicast
+        ],
+    )
+    def test_non_public_rejected(self, ip):
+        assert _is_public(ip) is False
+
+    def test_nat64_rejected_even_for_public_embedded(self):
+        # The whole translation prefix is refused: a NAT64 literal is never
+        # a legitimate webhook target, regardless of the embedded address.
+        assert _is_public("64:ff9b::5db8:d822") is False
+
+
+class TestPostPublic:
+    @pytest.mark.asyncio
+    async def test_http_rejected_without_any_network(self):
+        result = await post_public("http://example.com/hook", "{}", headers={})
+        assert result.status_code is None
+        assert "https" in result.error
+
+    @pytest.mark.asyncio
+    async def test_private_resolution_is_an_outcome_not_an_exception(self):
+        with patch(
+            "infrastructure.safe_fetch._resolve_public_ip",
+            AsyncMock(side_effect=FetchHardError("address is not public")),
+        ):
+            result = await post_public("https://internal.corp/hook", "{}", headers={})
+        assert result.status_code is None
+        assert "not public" in result.error
+
+    @pytest.mark.asyncio
+    async def test_transient_dns_failure_is_an_outcome_not_an_exception(self):
+        """A DNS timeout must land in the retry ladder as a recorded
+        attempt, never escape as an exception that skips bookkeeping."""
+        with patch(
+            "infrastructure.safe_fetch._resolve_public_ip",
+            AsyncMock(side_effect=FetchTransientError("dns timeout")),
+        ):
+            result = await post_public("https://example.com/hook", "{}", headers={})
+        assert result.status_code is None
+        assert "dns timeout" in result.error
+
+    @pytest.mark.asyncio
+    async def test_redirects_are_refused(self):
+        """Following a redirect would defeat IP pinning — 3xx is reported,
+        never chased."""
+
+        class _FakeResponse:
+            status_code = 302
+            headers = {"location": "https://10.0.0.1/"}  # noqa: RUF012
+
+            async def aclose(self):
+                return None
+
+        class _FakeClient:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            def build_request(self, *a, **k):
+                return object()
+
+            async def send(self, *a, **k):
+                return _FakeResponse()
+
+        with (
+            patch(
+                "infrastructure.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch("infrastructure.safe_fetch.httpx.AsyncClient", _FakeClient),
+        ):
+            result = await post_public("https://example.com/hook", "{}", headers={})
+        assert result.status_code == 302
+        assert "redirect" in result.error

--- a/tests/unit/infrastructure/test_safe_fetch_post.py
+++ b/tests/unit/infrastructure/test_safe_fetch_post.py
@@ -11,7 +11,9 @@ import pytest
 from infrastructure.safe_fetch import (
     FetchHardError,
     FetchTransientError,
+    PostResult,
     _is_public,
+    _parse_retry_after,
     post_public,
 )
 
@@ -115,3 +117,25 @@ class TestPostPublic:
             result = await post_public("https://example.com/hook", "{}", headers={})
         assert result.status_code == 302
         assert "redirect" in result.error
+
+
+class TestRetryAfter:
+    @pytest.mark.parametrize(
+        ("header", "expected"),
+        [
+            ("5", 5.0),
+            ("0", 0.0),
+            (" 12 ", 12.0),
+            ("1.5", 1.5),
+            ("-3", None),  # negative is nonsense, ignore
+            ("Wed, 21 Oct 2026 07:28:00 GMT", None),  # HTTP-date form not parsed
+            ("soon", None),
+            (None, None),
+        ],
+    )
+    def test_parse_retry_after(self, header, expected):
+        assert _parse_retry_after(header) == expected
+
+    def test_post_result_defaults_to_no_retry_after(self):
+        # Three-arg construction (every non-header call site) stays valid.
+        assert PostResult(500, None, None).retry_after_seconds is None

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -64,7 +64,7 @@ class TestEnsureIndexes:
             [("domain", 1), ("alias", 1)], unique=True
         )
         urls_v2_col.drop_index.assert_any_await("alias_1")
-        # Webhooks: the claim index and the coupled TTL pair (TRD §11.4).
+        # Webhooks: the claim index and the coupled TTL pair.
         webhook_deliveries_col.create_index.assert_any_await(
             [("status", 1), ("next_attempt_at", 1)], name="ix_claim"
         )

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -27,6 +27,9 @@ class TestEnsureIndexes:
         custom_domains_col = AsyncMock()
         reports_col = AsyncMock()
         report_submissions_col = AsyncMock()
+        webhook_events_col = AsyncMock()
+        webhook_endpoints_col = AsyncMock()
+        webhook_deliveries_col = AsyncMock()
 
         db.__getitem__ = lambda self, name: {
             "users": users_col,
@@ -40,6 +43,9 @@ class TestEnsureIndexes:
             "custom_domains": custom_domains_col,
             "reports": reports_col,
             "report_submissions": report_submissions_col,
+            "webhook-events": webhook_events_col,
+            "webhook-endpoints": webhook_endpoints_col,
+            "webhook-deliveries": webhook_deliveries_col,
         }[name]
 
         # create_collection raises CollectionInvalid when collection already exists
@@ -58,6 +64,20 @@ class TestEnsureIndexes:
             [("domain", 1), ("alias", 1)], unique=True
         )
         urls_v2_col.drop_index.assert_any_await("alias_1")
+        # Webhooks: the claim index and the coupled TTL pair (TRD §11.4).
+        webhook_deliveries_col.create_index.assert_any_await(
+            [("status", 1), ("next_attempt_at", 1)], name="ix_claim"
+        )
+        webhook_deliveries_col.create_index.assert_any_await(
+            [("webhook_id", 1)], unique=True
+        )
+        webhook_events_col.create_index.assert_any_await([("event_id", 1)], unique=True)
+        webhook_events_col.create_index.assert_any_await(
+            [("created_at", 1)], expireAfterSeconds=2_592_000, name="ttl_created_at"
+        )
+        webhook_deliveries_col.create_index.assert_any_await(
+            [("created_at", 1)], expireAfterSeconds=2_592_000, name="ttl_created_at"
+        )
         urls_v2_col.create_index.assert_any_await([("owner_id", 1)])
         clicks_col.create_index.assert_any_await(
             [("meta.url_id", 1), ("clicked_at", -1)]

--- a/tests/unit/services/test_bulk_url_service.py
+++ b/tests/unit/services/test_bulk_url_service.py
@@ -38,7 +38,7 @@ def _oid(n: int) -> ObjectId:
 
 
 def make_bulk_service(
-    url_repo=None, url_cache=None, kv=None, url_service=None
+    url_repo=None, url_cache=None, kv=None, url_service=None, events=None
 ) -> BulkUrlService:
     # The default url_service mock answers "available" for every alias
     # (AsyncMock truthiness); move tests override check_alias_available.
@@ -49,6 +49,7 @@ def make_bulk_service(
         kv=kv,
         system_default_domain=SYSTEM_DEFAULT_DOMAIN,
         og_ttl_seconds=86_400,
+        events=events,
     )
 
 
@@ -1037,3 +1038,57 @@ class TestMoveDomainParity:
         report = await bulk.bulk_move_domain([_oid(1)], TENANT, USER_OID)
         assert report.results[0].ok is True
         bulk_repo.update_by_ids_and_owner.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Webhook event emission — bulk must be indistinguishable from a loop
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _CapturingSink:
+    def __init__(self) -> None:
+        self.events = []
+
+    async def emit(self, event) -> None:
+        self.events.append(event)
+
+
+class TestBulkEventEmission:
+    @pytest.mark.asyncio
+    async def test_set_status_emits_one_updated_per_changed_item(self):
+        active = make_url_v2_doc(url_id=_oid(1), alias="one")
+        already = make_url_v2_doc(url_id=_oid(2), alias="two", status="INACTIVE")
+        url_repo = AsyncMock()
+        url_repo.find_by_ids_and_owner.return_value = [active, already]
+        url_repo.update_by_ids_and_owner.return_value = 1
+        sink = _CapturingSink()
+        svc = make_bulk_service(url_repo, AsyncMock(), events=sink)
+
+        await svc.bulk_set_status([_oid(1), _oid(2)], UrlStatus.INACTIVE, USER_OID)
+        await drain_edge_tasks(svc)
+
+        # One event for the changed item; the same-status no-op emits nothing.
+        assert len(sink.events) == 1
+        event = sink.events[0]
+        assert event.type == "link.updated"
+        assert event.owner_id == str(USER_OID)
+        assert event.data["link"]["status"] == "INACTIVE"  # post-state snapshot
+        assert event.data["changes"]["status"] == {"old": "ACTIVE", "new": "INACTIVE"}
+
+    @pytest.mark.asyncio
+    async def test_delete_emits_one_deleted_per_item(self):
+        docs = [
+            make_url_v2_doc(url_id=_oid(1), alias="one"),
+            make_url_v2_doc(url_id=_oid(2), alias="two"),
+        ]
+        url_repo = AsyncMock()
+        url_repo.find_by_ids_and_owner.return_value = docs
+        url_repo.delete_by_ids_and_owner.return_value = 2
+        sink = _CapturingSink()
+        svc = make_bulk_service(url_repo, AsyncMock(), events=sink)
+
+        await svc.bulk_delete([_oid(1), _oid(2)], USER_OID)
+        await drain_edge_tasks(svc)
+
+        assert [e.type for e in sink.events] == ["link.deleted", "link.deleted"]
+        assert {e.data["link"]["alias"] for e in sink.events} == {"one", "two"}

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -208,12 +208,75 @@ class TestFailurePaths:
         )
 
     @pytest.mark.asyncio
-    async def test_inactive_endpoint_terminal(self):
-        executor, deliveries, _, _ = _make(_endpoint(status=WebhookStatus.PAUSED))
+    async def test_disabled_endpoint_terminal(self):
+        executor, deliveries, _, _ = _make(_endpoint(status=WebhookStatus.DISABLED))
         with patch("services.webhooks.executor.post_public", _post(204)) as post:
             await executor.attempt(_delivery())
         deliveries.mark_failed.assert_awaited_once()
         post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_paused_endpoint_defers_instead_of_failing(self):
+        """Paused is owner-controlled and temporary: the delivery waits."""
+        executor, deliveries, _, _ = _make(_endpoint(status=WebhookStatus.PAUSED))
+        with patch("services.webhooks.executor.post_public", _post(204)) as post:
+            await executor.attempt(_delivery())
+        deliveries.defer.assert_awaited_once()
+        deliveries.mark_failed.assert_not_awaited()
+        post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_secret_terminates_and_disables(self):
+        """SECRET_KEY rotation must degrade loudly, never livelock: the row
+        is terminally failed and the endpoint disabled with its own reason."""
+        endpoint = _endpoint(signing_secret_enc="bm90LXJlYWwtY2lwaGVydGV4dA==")
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        with patch("services.webhooks.executor.post_public", _post(204)) as post:
+            await executor.attempt(_delivery())
+        deliveries.mark_failed.assert_awaited_once()
+        assert deliveries.mark_failed.await_args[0][1] == "secret_unreadable"
+        endpoints.disable.assert_awaited_once_with(
+            endpoint.id, EndpointDisabledReason.SECRET_UNREADABLE
+        )
+        post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_test_send_is_single_shot(self):
+        """A failing TEST send records one attempt and stops: no reschedule,
+        no exhaustion counting, no auto-disable — testing a broken endpoint
+        must never mutate its real health."""
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        with patch("services.webhooks.executor.post_public", _post(500)):
+            await executor.attempt(_delivery(is_test=True))
+        assert (
+            deliveries.record_attempt_and_finish.await_args[0][2]
+            is DeliveryStatus.FAILED
+        )
+        deliveries.record_attempt_and_reschedule.assert_not_awaited()
+        endpoints.record_exhausted.assert_not_awaited()
+        endpoints.disable.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_passing_test_send_does_not_reset_streak(self):
+        endpoint = _endpoint(consecutive_failures=7)
+        executor, _, endpoints, _ = _make(endpoint)
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(_delivery(is_test=True))
+        endpoints.record_success.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_manual_retry_of_completed_row_is_single_shot(self):
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        row = _delivery(
+            status=DeliveryStatus.FAILED,
+            rendered_body='{"type":"link.clicked","data":{}}',
+        )
+        with patch("services.webhooks.executor.post_public", _post(410)):
+            await executor.attempt(row)
+        endpoints.disable.assert_not_awaited()
+        deliveries.record_attempt_and_reschedule.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_event_ttl_race_terminal_not_crash(self):

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -1,0 +1,245 @@
+"""DeliveryExecutor — render-once, signing headers, retry ladder, disable
+paths. post_public is patched; repos are AsyncMocks shaped per call."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from infrastructure.crypto import encrypt_secret
+from infrastructure.safe_fetch import PostResult
+from schemas.enums.webhook import (
+    DeliveryStatus,
+    EndpointDisabledReason,
+    WebhookFlavor,
+    WebhookStatus,
+)
+from schemas.models.webhook import (
+    WebhookDeliveryDoc,
+    WebhookEndpointDoc,
+    WebhookEventDoc,
+)
+from services.webhooks.executor import (
+    RETRY_SCHEDULE_SECONDS,
+    SECRET_ENC_DOMAIN,
+    DeliveryExecutor,
+)
+from services.webhooks.renderers import default_renderers
+from services.webhooks.signing import (
+    HEADER_ID,
+    HEADER_SIGNATURE,
+    HEADER_TIMESTAMP,
+    verify,
+)
+
+_MASTER = "test-master-secret"
+_SECRET = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+
+
+def _endpoint(**overrides: Any) -> WebhookEndpointDoc:
+    doc = WebhookEndpointDoc(
+        user_id=ObjectId(),
+        url="https://example.com/hook",
+        events=["*"],
+        status=WebhookStatus.ACTIVE,
+        flavor=WebhookFlavor.RAW,
+        signing_secret_enc=encrypt_secret(_SECRET, _MASTER, domain=SECRET_ENC_DOMAIN),
+        signing_secret_prefix=_SECRET[:14],
+    )
+    doc.id = ObjectId()
+    return doc.model_copy(update=overrides)
+
+
+def _delivery(**overrides: Any) -> WebhookDeliveryDoc:
+    doc = WebhookDeliveryDoc(
+        endpoint_id=ObjectId(),
+        user_id=ObjectId(),
+        event_oid=ObjectId(),
+        event_type="link.clicked",
+        webhook_id="msg_test",
+        next_attempt_at=datetime.now(timezone.utc),
+    )
+    doc.id = ObjectId()
+    return doc.model_copy(update=overrides)
+
+
+def _event() -> WebhookEventDoc:
+    doc = WebhookEventDoc(
+        event_id="evt_test",
+        type="link.clicked",
+        owner_id=ObjectId(),
+        occurred_at=datetime(2026, 7, 22, tzinfo=timezone.utc),
+        payload={"alias": "a", "link_id": "x"},
+    )
+    doc.id = ObjectId()
+    return doc
+
+
+def _make(endpoint: WebhookEndpointDoc | None, *, max_consecutive: int = 10):
+    deliveries = AsyncMock()
+    endpoints = AsyncMock()
+    endpoints.find_by_id.return_value = endpoint
+    endpoints.record_exhausted.return_value = 1
+    events = AsyncMock()
+    events.find_by_oid.return_value = _event()
+    executor = DeliveryExecutor(
+        deliveries,
+        endpoints,
+        events,
+        default_renderers(),
+        master_secret=_MASTER,
+        max_consecutive_failures=max_consecutive,
+    )
+    return executor, deliveries, endpoints, events
+
+
+def _post(status: int | None, error: str | None = None):
+    return AsyncMock(return_value=PostResult(status, error, None))
+
+
+class TestSuccessPath:
+    @pytest.mark.asyncio
+    async def test_delivers_with_valid_standard_webhooks_headers(self):
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        post = _post(204)
+        with patch("services.webhooks.executor.post_public", post):
+            await executor.attempt(_delivery())
+
+        url, body = post.await_args[0]
+        headers = post.await_args.kwargs["headers"]
+        assert url == endpoint.url
+        assert headers[HEADER_ID] == "msg_test"
+        # The signature verifies against the raw secret — the whole point.
+        assert verify(
+            headers[HEADER_ID],
+            int(headers[HEADER_TIMESTAMP]),
+            body,
+            _SECRET,
+            headers[HEADER_SIGNATURE],
+        )
+        deliveries.record_attempt_and_finish.assert_awaited_once()
+        assert (
+            deliveries.record_attempt_and_finish.await_args[0][2]
+            is DeliveryStatus.SUCCESS
+        )
+        endpoints.record_success.assert_awaited_once_with(endpoint.id)
+
+    @pytest.mark.asyncio
+    async def test_renders_once_and_freezes_body(self):
+        executor, deliveries, _, _events = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(_delivery())
+        deliveries.set_rendered_body.assert_awaited_once()
+        body = deliveries.set_rendered_body.await_args[0][1]
+        assert '"type":"link.clicked"' in body
+
+    @pytest.mark.asyncio
+    async def test_prerendered_body_skips_event_read(self):
+        """Retries resend the frozen body — the event row is not re-read."""
+        executor, _, _, events = _make(_endpoint())
+        row = _delivery(rendered_body='{"type":"link.clicked","data":{}}')
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(row)
+        events.find_by_oid.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dropped_since_last_rides_the_payload(self):
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(_delivery(dropped_since_last=42))
+        body = deliveries.set_rendered_body.await_args[0][1]
+        assert '"dropped_since_last":42' in body
+
+
+class TestFailurePaths:
+    @pytest.mark.asyncio
+    async def test_failure_reschedules_per_ladder(self):
+        executor, deliveries, _, _ = _make(_endpoint())
+        before = datetime.now(timezone.utc)
+        with patch("services.webhooks.executor.post_public", _post(500)):
+            await executor.attempt(_delivery(attempt_count=1))
+        next_at = deliveries.record_attempt_and_reschedule.await_args[0][2]
+        # attempt 2 of the ladder → RETRY_SCHEDULE_SECONDS[2] = 300s
+        assert next_at >= before + timedelta(seconds=RETRY_SCHEDULE_SECONDS[2] - 1)
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_marks_failed_and_counts_streak(self):
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        last = len(RETRY_SCHEDULE_SECONDS) - 1
+        with patch("services.webhooks.executor.post_public", _post(500)):
+            await executor.attempt(_delivery(attempt_count=last))
+        assert (
+            deliveries.record_attempt_and_finish.await_args[0][2]
+            is DeliveryStatus.FAILED
+        )
+        endpoints.record_exhausted.assert_awaited_once()
+        endpoints.disable.assert_not_awaited()  # streak=1 < 10
+
+    @pytest.mark.asyncio
+    async def test_streak_at_threshold_disables(self):
+        endpoint = _endpoint()
+        executor, _, endpoints, _ = _make(endpoint, max_consecutive=3)
+        endpoints.record_exhausted.return_value = 3
+        last = len(RETRY_SCHEDULE_SECONDS) - 1
+        with patch("services.webhooks.executor.post_public", _post(None, "boom")):
+            await executor.attempt(_delivery(attempt_count=last))
+        endpoints.disable.assert_awaited_once_with(
+            endpoint.id, EndpointDisabledReason.CONSECUTIVE_FAILURES
+        )
+
+    @pytest.mark.asyncio
+    async def test_410_disables_immediately(self):
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        with patch("services.webhooks.executor.post_public", _post(410)):
+            await executor.attempt(_delivery())
+        endpoints.disable.assert_awaited_once_with(
+            endpoint.id, EndpointDisabledReason.GONE
+        )
+        assert (
+            deliveries.record_attempt_and_finish.await_args[0][2]
+            is DeliveryStatus.FAILED
+        )
+
+    @pytest.mark.asyncio
+    async def test_inactive_endpoint_terminal(self):
+        executor, deliveries, _, _ = _make(_endpoint(status=WebhookStatus.PAUSED))
+        with patch("services.webhooks.executor.post_public", _post(204)) as post:
+            await executor.attempt(_delivery())
+        deliveries.mark_failed.assert_awaited_once()
+        post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_event_ttl_race_terminal_not_crash(self):
+        executor, deliveries, _, events = _make(_endpoint())
+        events.find_by_oid.return_value = None
+        with patch("services.webhooks.executor.post_public", _post(204)) as post:
+            await executor.attempt(_delivery())
+        deliveries.mark_failed.assert_awaited_once()
+        assert deliveries.mark_failed.await_args[0][1] == "event_expired"
+        post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_after_grace_secret_sends_dual_signatures(self):
+        old_secret = "whsec_b2xkLXNlY3JldC1vbGQtc2VjcmV0"
+        endpoint = _endpoint(
+            previous_secret_enc=encrypt_secret(
+                old_secret, _MASTER, domain=SECRET_ENC_DOMAIN
+            ),
+            previous_secret_expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        executor, _, _, _ = _make(endpoint)
+        post = _post(204)
+        with patch("services.webhooks.executor.post_public", post):
+            await executor.attempt(_delivery())
+        headers = post.await_args.kwargs["headers"]
+        _, body = post.await_args[0]
+        ts = int(headers[HEADER_TIMESTAMP])
+        assert verify("msg_test", ts, body, _SECRET, headers[HEADER_SIGNATURE])
+        assert verify("msg_test", ts, body, old_secret, headers[HEADER_SIGNATURE])

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -24,6 +24,8 @@ from schemas.models.webhook import (
     WebhookEventDoc,
 )
 from services.webhooks.executor import (
+    RATE_LIMIT_FALLBACK_SECONDS,
+    RATE_LIMIT_MAX_DEFER_SECONDS,
     RETRY_SCHEDULE_SECONDS,
     SECRET_ENC_DOMAIN,
     DeliveryExecutor,
@@ -306,3 +308,54 @@ class TestFailurePaths:
         ts = int(headers[HEADER_TIMESTAMP])
         assert verify("msg_test", ts, body, _SECRET, headers[HEADER_SIGNATURE])
         assert verify("msg_test", ts, body, old_secret, headers[HEADER_SIGNATURE])
+
+
+class TestRateLimit:
+    """429 is receiver flow control: defer without burning the ladder."""
+
+    def _post_429(self, retry_after: float | None):
+        return AsyncMock(return_value=PostResult(429, None, None, retry_after))
+
+    @pytest.mark.asyncio
+    async def test_429_defers_without_ladder_or_streak(self):
+        executor, deliveries, endpoints, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(None)):
+            await executor.attempt(_delivery(attempt_count=1))
+        deliveries.defer.assert_awaited_once()
+        assert (
+            deliveries.defer.await_args.kwargs["delay_seconds"]
+            == RATE_LIMIT_FALLBACK_SECONDS
+        )
+        deliveries.record_attempt_and_reschedule.assert_not_awaited()
+        deliveries.record_attempt_and_finish.assert_not_awaited()
+        endpoints.record_exhausted.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_429_honors_retry_after(self):
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(5.0)):
+            await executor.attempt(_delivery())
+        assert deliveries.defer.await_args.kwargs["delay_seconds"] == 5
+
+    @pytest.mark.asyncio
+    async def test_429_retry_after_is_capped(self):
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(3600.0)):
+            await executor.attempt(_delivery())
+        assert (
+            deliveries.defer.await_args.kwargs["delay_seconds"]
+            == RATE_LIMIT_MAX_DEFER_SECONDS
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_shot_429_is_terminal_not_deferred(self):
+        # A rate-limited test send must report its outcome synchronously,
+        # not silently park the row.
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(5.0)):
+            await executor.attempt(_delivery(is_test=True, next_attempt_at=None))
+        deliveries.defer.assert_not_awaited()
+        assert (
+            deliveries.record_attempt_and_finish.await_args[0][2]
+            is DeliveryStatus.FAILED
+        )

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -359,3 +359,24 @@ class TestRateLimit:
             deliveries.record_attempt_and_finish.await_args[0][2]
             is DeliveryStatus.FAILED
         )
+
+
+class TestDeliveryUrl:
+    @pytest.mark.asyncio
+    async def test_discord_flavor_appends_components_param(self):
+        endpoint = _endpoint(flavor=WebhookFlavor.DISCORD)
+        executor, _, _, _ = _make(endpoint)
+        post = _post(204)
+        with patch("services.webhooks.executor.post_public", post):
+            await executor.attempt(_delivery())
+        url = post.await_args[0][0]
+        assert url == f"{endpoint.url}?with_components=true"
+
+    @pytest.mark.asyncio
+    async def test_raw_flavor_url_is_untouched(self):
+        endpoint = _endpoint()
+        executor, _, _, _ = _make(endpoint)
+        post = _post(204)
+        with patch("services.webhooks.executor.post_public", post):
+            await executor.attempt(_delivery())
+        assert post.await_args[0][0] == endpoint.url

--- a/tests/unit/services/webhooks/test_matcher_dispatcher.py
+++ b/tests/unit/services/webhooks/test_matcher_dispatcher.py
@@ -1,0 +1,171 @@
+"""Matcher + dispatcher — scope evaluation, cache short-circuit, fan-out,
+pending cap. All fakes are in-memory; no Mongo, no Redis."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from bson import ObjectId
+
+from schemas.enums.webhook import WebhookStatus
+from schemas.models.webhook import WebhookEndpointDoc, WebhookScope
+from services.events.contract import DomainEvent
+from services.webhooks.dispatcher import WebhookDispatcher
+from services.webhooks.matcher import (
+    OwnerSubscriptionCache,
+    SubscriptionMatcher,
+    event_link_id,
+)
+
+_OWNER = ObjectId()
+_LINK = ObjectId()
+
+
+def _endpoint(**overrides: Any) -> WebhookEndpointDoc:
+    doc = WebhookEndpointDoc(
+        user_id=_OWNER,
+        url="https://example.com/hook",
+        events=["link.*"],
+        status=WebhookStatus.ACTIVE,
+        signing_secret_enc="enc",
+        signing_secret_prefix="whsec_ab",
+    )
+    doc.id = ObjectId()
+    return doc.model_copy(update=overrides)
+
+
+def _click_event(link_id: ObjectId = _LINK) -> DomainEvent:
+    return DomainEvent(
+        type="link.clicked",
+        owner_id=str(_OWNER),
+        data={"link_id": str(link_id), "alias": "a"},
+    )
+
+
+def _no_cache() -> OwnerSubscriptionCache:
+    return OwnerSubscriptionCache(None, ttl_seconds=60)
+
+
+class TestEventLinkId:
+    def test_top_level_link_id(self):
+        assert event_link_id(_click_event()) == _LINK
+
+    def test_nested_snapshot_link_id(self):
+        event = DomainEvent(
+            type="link.updated",
+            owner_id=str(_OWNER),
+            data={"link": {"link_id": str(_LINK)}, "changes": {}},
+        )
+        assert event_link_id(event) == _LINK
+
+    def test_non_link_event_is_none(self):
+        event = DomainEvent(
+            type="domain.verified", owner_id=str(_OWNER), data={"fqdn": "x.com"}
+        )
+        assert event_link_id(event) is None
+
+
+class TestMatcher:
+    @pytest.mark.asyncio
+    async def test_matches_wildcard_subscription(self):
+        repo = AsyncMock()
+        repo.find_active_for_owner.return_value = [_endpoint()]
+        matcher = SubscriptionMatcher(repo, _no_cache())
+        assert len(await matcher.match(_click_event())) == 1
+
+    @pytest.mark.asyncio
+    async def test_event_type_mismatch_filters_out(self):
+        repo = AsyncMock()
+        repo.find_active_for_owner.return_value = [_endpoint(events=["domain.*"])]
+        matcher = SubscriptionMatcher(repo, _no_cache())
+        assert await matcher.match(_click_event()) == []
+
+    @pytest.mark.asyncio
+    async def test_scope_excludes_other_links(self):
+        repo = AsyncMock()
+        repo.find_active_for_owner.return_value = [
+            _endpoint(scope=WebhookScope(links=[ObjectId()]))
+        ]
+        matcher = SubscriptionMatcher(repo, _no_cache())
+        assert await matcher.match(_click_event()) == []
+
+    @pytest.mark.asyncio
+    async def test_scope_includes_listed_link(self):
+        repo = AsyncMock()
+        repo.find_active_for_owner.return_value = [
+            _endpoint(scope=WebhookScope(links=[_LINK]))
+        ]
+        matcher = SubscriptionMatcher(repo, _no_cache())
+        assert len(await matcher.match(_click_event())) == 1
+
+    @pytest.mark.asyncio
+    async def test_scope_never_excludes_non_link_events(self):
+        repo = AsyncMock()
+        repo.find_active_for_owner.return_value = [
+            _endpoint(events=["*"], scope=WebhookScope(links=[ObjectId()]))
+        ]
+        matcher = SubscriptionMatcher(repo, _no_cache())
+        event = DomainEvent(
+            type="domain.verified", owner_id=str(_OWNER), data={"fqdn": "x.com"}
+        )
+        assert len(await matcher.match(event)) == 1
+
+    @pytest.mark.asyncio
+    async def test_cached_zero_short_circuits_mongo(self):
+        repo = AsyncMock()
+        cache = AsyncMock()
+        cache.get.return_value = 0
+        matcher = SubscriptionMatcher(repo, cache)
+        assert await matcher.match(_click_event()) == []
+        repo.find_active_for_owner.assert_not_awaited()
+
+
+class TestDispatcher:
+    def _make(self, endpoints, pending: int = 0):
+        matcher = AsyncMock()
+        matcher.match.return_value = endpoints
+        event_repo = AsyncMock()
+        event_repo.insert_event.return_value = ObjectId()
+        delivery_repo = AsyncMock()
+        delivery_repo.count_pending.return_value = pending
+        endpoint_repo = AsyncMock()
+        dispatcher = WebhookDispatcher(
+            matcher,
+            event_repo,
+            delivery_repo,
+            endpoint_repo,
+            max_pending_per_endpoint=10,
+        )
+        return dispatcher, event_repo, delivery_repo, endpoint_repo
+
+    @pytest.mark.asyncio
+    async def test_no_match_writes_nothing(self):
+        dispatcher, event_repo, delivery_repo, _ = self._make([])
+        await dispatcher.dispatch(_click_event())
+        event_repo.insert_event.assert_not_awaited()
+        delivery_repo.insert_many_rows.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_event_stored_once_rows_per_endpoint(self):
+        eps = [_endpoint(), _endpoint()]
+        dispatcher, event_repo, delivery_repo, _ = self._make(eps)
+        await dispatcher.dispatch(_click_event())
+        event_repo.insert_event.assert_awaited_once()
+        rows = delivery_repo.insert_many_rows.await_args[0][0]
+        assert len(rows) == 2
+        # webhook_ids minted per (event x endpoint) and unique
+        assert rows[0]["webhook_id"] != rows[1]["webhook_id"]
+        # thin rows: no payload, no rendered body at dispatch (D14/D15)
+        assert "payload" not in rows[0]
+        assert rows[0]["rendered_body"] is None
+
+    @pytest.mark.asyncio
+    async def test_pending_cap_drops_and_counts(self):
+        ep = _endpoint()
+        dispatcher, _, delivery_repo, endpoint_repo = self._make([ep], pending=10)
+        await dispatcher.dispatch(_click_event())
+        endpoint_repo.increment_dropped.assert_awaited_once_with(ep.id)
+        rows = delivery_repo.insert_many_rows.await_args[0][0]
+        assert rows == []

--- a/tests/unit/services/webhooks/test_matcher_dispatcher.py
+++ b/tests/unit/services/webhooks/test_matcher_dispatcher.py
@@ -157,7 +157,7 @@ class TestDispatcher:
         assert len(rows) == 2
         # webhook_ids minted per (event x endpoint) and unique
         assert rows[0]["webhook_id"] != rows[1]["webhook_id"]
-        # thin rows: no payload, no rendered body at dispatch (D14/D15)
+        # thin rows: no payload, no rendered body at dispatch
         assert "payload" not in rows[0]
         assert rows[0]["rendered_body"] is None
 

--- a/tests/unit/services/webhooks/test_matcher_dispatcher.py
+++ b/tests/unit/services/webhooks/test_matcher_dispatcher.py
@@ -160,6 +160,16 @@ class TestDispatcher:
         assert rows[0]["rendered_body"] is None
 
     @pytest.mark.asyncio
+    async def test_rows_carry_endpoint_dropped_count(self):
+        """The drop counter accumulated over the pending cap rides the next
+        dispatched row so the subscriber learns what it missed."""
+        ep = _endpoint(dropped_count=7)
+        dispatcher, _, delivery_repo, _ = self._make([ep])
+        await dispatcher.dispatch(_click_event())
+        rows = delivery_repo.insert_many_rows.await_args[0][0]
+        assert rows[0]["dropped_since_last"] == 7
+
+    @pytest.mark.asyncio
     async def test_pending_cap_drops_and_counts(self):
         ep = _endpoint()
         dispatcher, _, delivery_repo, endpoint_repo = self._make([ep], pending=10)

--- a/tests/unit/services/webhooks/test_matcher_dispatcher.py
+++ b/tests/unit/services/webhooks/test_matcher_dispatcher.py
@@ -60,9 +60,9 @@ class TestEventLinkId:
         )
         assert event_link_id(event) == _LINK
 
-    def test_non_link_event_is_none(self):
+    def test_event_without_link_shape_is_none(self):
         event = DomainEvent(
-            type="domain.verified", owner_id=str(_OWNER), data={"fqdn": "x.com"}
+            type="webhook.test", owner_id=str(_OWNER), data={"message": "hi"}
         )
         assert event_link_id(event) is None
 
@@ -101,16 +101,14 @@ class TestMatcher:
         assert len(await matcher.match(_click_event())) == 1
 
     @pytest.mark.asyncio
-    async def test_scope_never_excludes_non_link_events(self):
+    async def test_unknown_event_type_never_matches(self):
+        """Types outside the registry match nothing, even against `*` —
+        wildcard expansion is registry-bounded by construction."""
         repo = AsyncMock()
-        repo.find_active_for_owner.return_value = [
-            _endpoint(events=["*"], scope=WebhookScope(links=[ObjectId()]))
-        ]
+        repo.find_active_for_owner.return_value = [_endpoint(events=["*"])]
         matcher = SubscriptionMatcher(repo, _no_cache())
-        event = DomainEvent(
-            type="domain.verified", owner_id=str(_OWNER), data={"fqdn": "x.com"}
-        )
-        assert len(await matcher.match(event)) == 1
+        event = DomainEvent(type="totally.unknown", owner_id=str(_OWNER), data={})
+        assert await matcher.match(event) == []
 
     @pytest.mark.asyncio
     async def test_cached_zero_short_circuits_mongo(self):

--- a/tests/unit/services/webhooks/test_payloads.py
+++ b/tests/unit/services/webhooks/test_payloads.py
@@ -89,6 +89,15 @@ class TestLinkClicked:
         validate_payload("link.clicked", event.data)
         assert "203.0.113.9" not in str(event.data)
         assert event.data["is_bot"] is False
+        assert event.data["user_agent"] == "Mozilla/5.0 (X11; Linux x86_64)"
+
+    def test_user_agent_bounded_and_stripped(self):
+        crafted = "Mozilla/5.0 \x00\x1b[31m" + "A" * 2000
+        event = build_link_clicked(_click_event(user_agent=crafted), "spoo.me")
+        assert event is not None
+        ua = event.data["user_agent"]
+        assert len(ua) <= 512
+        assert "\x00" not in ua and "\x1b" not in ua
 
     def test_bot_click_flagged_not_suppressed(self):
         event = build_link_clicked(_click_event(user_agent="curl/8.0"), "spoo.me")

--- a/tests/unit/services/webhooks/test_payloads.py
+++ b/tests/unit/services/webhooks/test_payloads.py
@@ -94,3 +94,45 @@ class TestLinkClicked:
         event = build_link_clicked(_click_event(user_agent="curl/8.0"), "spoo.me")
         assert event is not None
         assert event.data["is_bot"] is True
+
+
+class TestEventChanges:
+    def test_meta_tags_change_strips_internal_fields(self):
+        from schemas.models.url import LinkMetaTags
+        from services.url_service import _event_changes
+
+        existing = _doc()
+        update_ops = {
+            "meta_tags": {
+                "title": "New",
+                "description": None,
+                "image": None,
+                "color": "#112233",
+                "image_meta": None,
+                "updated_at": datetime.now(timezone.utc),
+                "updated_ip": "203.0.113.9",
+            },
+            "password": "new-argon2-hash",
+            "expire_after": datetime(2026, 8, 1, tzinfo=timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+        changes = _event_changes(existing, update_ops)
+
+        assert "updated_at" not in changes
+        assert changes["meta_tags"]["new"] == {
+            "title": "New",
+            "description": None,
+            "image": None,
+            "color": "#112233",
+        }
+        assert "203.0.113.9" not in str(changes)
+        assert "argon2" not in str(changes)
+        assert changes["password_protected"] == {"old": True, "new": True}
+        assert changes["expire_after"]["new"] == "2026-08-01T00:00:00+00:00"
+        # old side of a model-typed field sanitizes the same way
+        existing_with_meta = existing.model_copy(
+            update={"meta_tags": LinkMetaTags(title="Old", updated_ip="198.51.100.7")}
+        )
+        changes2 = _event_changes(existing_with_meta, update_ops)
+        assert changes2["meta_tags"]["old"]["title"] == "Old"
+        assert "198.51.100.7" not in str(changes2)

--- a/tests/unit/services/webhooks/test_payloads.py
+++ b/tests/unit/services/webhooks/test_payloads.py
@@ -99,7 +99,7 @@ class TestLinkClicked:
 class TestEventChanges:
     def test_meta_tags_change_strips_internal_fields(self):
         from schemas.models.url import LinkMetaTags
-        from services.url_service import _event_changes
+        from services.webhooks.payloads import event_changes
 
         existing = _doc()
         update_ops = {
@@ -116,7 +116,7 @@ class TestEventChanges:
             "expire_after": datetime(2026, 8, 1, tzinfo=timezone.utc),
             "updated_at": datetime.now(timezone.utc),
         }
-        changes = _event_changes(existing, update_ops)
+        changes = event_changes(existing, update_ops)
 
         assert "updated_at" not in changes
         assert changes["meta_tags"]["new"] == {
@@ -133,6 +133,6 @@ class TestEventChanges:
         existing_with_meta = existing.model_copy(
             update={"meta_tags": LinkMetaTags(title="Old", updated_ip="198.51.100.7")}
         )
-        changes2 = _event_changes(existing_with_meta, update_ops)
+        changes2 = event_changes(existing_with_meta, update_ops)
         assert changes2["meta_tags"]["old"]["title"] == "Old"
         assert "198.51.100.7" not in str(changes2)

--- a/tests/unit/services/webhooks/test_payloads.py
+++ b/tests/unit/services/webhooks/test_payloads.py
@@ -128,7 +128,10 @@ class TestEventChanges:
         assert "203.0.113.9" not in str(changes)
         assert "argon2" not in str(changes)
         assert changes["password_protected"] == {"old": True, "new": True}
-        assert changes["expire_after"]["new"] == "2026-08-01T00:00:00+00:00"
+        # Public vocabulary on the wire: internal expire_after surfaces as
+        # the snapshot's expires_at, never the Mongo field name.
+        assert "expire_after" not in changes
+        assert changes["expires_at"]["new"] == "2026-08-01T00:00:00+00:00"
         # old side of a model-typed field sanitizes the same way
         existing_with_meta = existing.model_copy(
             update={"meta_tags": LinkMetaTags(title="Old", updated_ip="198.51.100.7")}

--- a/tests/unit/services/webhooks/test_payloads.py
+++ b/tests/unit/services/webhooks/test_payloads.py
@@ -1,0 +1,96 @@
+"""Payload builders — internal facts → public payloads, privacy guarantees."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from infrastructure.cache.url_cache import UrlCacheData
+from schemas.models.base import ANONYMOUS_OWNER_ID
+from schemas.models.url import UrlV2Doc
+from services.click.events import ClickEvent
+from services.webhooks.payloads import (
+    build_link_clicked,
+    build_link_expired,
+    link_snapshot,
+)
+from services.webhooks.registry import validate_payload
+
+_OWNER = ObjectId()
+
+
+def _doc(owner_id: ObjectId = _OWNER) -> UrlV2Doc:
+    doc = UrlV2Doc(
+        alias="drop",
+        owner_id=owner_id,
+        domain="spoo.me",
+        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        long_url="https://example.com/x",
+        password="argon2-hash-material",
+        max_clicks=100,
+        total_clicks=100,
+    )
+    doc.id = ObjectId()
+    return doc
+
+
+def _click_event(user_agent: str = "Mozilla/5.0 (X11; Linux x86_64)") -> ClickEvent:
+    return ClickEvent(
+        short_code="drop",
+        schema_key="v2",
+        is_emoji=False,
+        url=UrlCacheData(
+            _id=str(ObjectId()),
+            alias="drop",
+            long_url="https://example.com/x",
+            block_bots=False,
+            password_hash=None,
+            expiration_time=None,
+            max_clicks=None,
+            url_status="ACTIVE",
+            schema_version="v2",
+            owner_id=str(_OWNER),
+            domain="spoo.me",
+        ),
+        client_ip="203.0.113.9",
+        user_agent=user_agent,
+        referrer=None,
+        cf_city=None,
+        redirect_ms=4,
+    )
+
+
+class TestLinkSnapshot:
+    def test_password_becomes_presence_boolean(self):
+        snap = link_snapshot(_doc())
+        assert snap["password_protected"] is True
+        assert "password" not in snap
+        assert "argon2" not in str(snap)
+
+
+class TestLinkExpired:
+    def test_anonymous_owner_returns_none(self):
+        assert build_link_expired(_doc(owner_id=ANONYMOUS_OWNER_ID), "x") is None
+
+    def test_owned_link_builds_valid_payload(self):
+        event = build_link_expired(_doc(), "max_clicks_reached")
+        assert event is not None
+        assert event.type == "link.expired"
+        assert event.owner_id == str(_OWNER)
+        assert event.data["reason"] == "max_clicks_reached"
+        validate_payload("link.expired", event.data)
+
+
+class TestLinkClicked:
+    def test_builds_valid_payload_with_no_ip(self):
+        event = build_link_clicked(_click_event(), "spoo.me")
+        assert event is not None
+        validate_payload("link.clicked", event.data)
+        assert "203.0.113.9" not in str(event.data)
+        assert event.data["is_bot"] is False
+
+    def test_bot_click_flagged_not_suppressed(self):
+        event = build_link_clicked(_click_event(user_agent="curl/8.0"), "spoo.me")
+        assert event is not None
+        assert event.data["is_bot"] is True

--- a/tests/unit/services/webhooks/test_payloads.py
+++ b/tests/unit/services/webhooks/test_payloads.py
@@ -83,24 +83,35 @@ class TestLinkExpired:
 
 
 class TestLinkClicked:
-    def test_builds_valid_payload_with_no_ip(self):
-        event = build_link_clicked(_click_event(), "spoo.me")
+    async def test_builds_valid_payload_with_no_ip(self):
+        event = await build_link_clicked(_click_event(), "spoo.me")
         assert event is not None
         validate_payload("link.clicked", event.data)
         assert "203.0.113.9" not in str(event.data)
         assert event.data["is_bot"] is False
         assert event.data["user_agent"] == "Mozilla/5.0 (X11; Linux x86_64)"
 
-    def test_user_agent_bounded_and_stripped(self):
+    async def test_user_agent_bounded_and_stripped(self):
         crafted = "Mozilla/5.0 \x00\x1b[31m" + "A" * 2000
-        event = build_link_clicked(_click_event(user_agent=crafted), "spoo.me")
+        event = await build_link_clicked(_click_event(user_agent=crafted), "spoo.me")
         assert event is not None
         ua = event.data["user_agent"]
         assert len(ua) <= 512
         assert "\x00" not in ua and "\x1b" not in ua
 
-    def test_bot_click_flagged_not_suppressed(self):
-        event = build_link_clicked(_click_event(user_agent="curl/8.0"), "spoo.me")
+    async def test_geoip_fallback_is_awaited(self):
+        """The geoip country fallback is async; a regression to an
+        unawaited call would leak a coroutine into the payload."""
+        from unittest.mock import AsyncMock
+
+        geoip = AsyncMock()
+        geoip.get_country_code = AsyncMock(return_value="DE")
+        event = await build_link_clicked(_click_event(), "spoo.me", geoip=geoip)
+        assert event.data["country"] == "DE"
+        validate_payload("link.clicked", event.data)
+
+    async def test_bot_click_flagged_not_suppressed(self):
+        event = await build_link_clicked(_click_event(user_agent="curl/8.0"), "spoo.me")
         assert event is not None
         assert event.data["is_bot"] is True
 

--- a/tests/unit/services/webhooks/test_registry.py
+++ b/tests/unit/services/webhooks/test_registry.py
@@ -1,0 +1,89 @@
+"""Event catalog — wildcard expansion, validation, sample/model lockstep."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from errors import ValidationError
+from services.webhooks.registry import (
+    EVENT_REGISTRY,
+    TEST_EVENT_SPEC,
+    expand,
+    valid_patterns,
+    validate_patterns,
+    validate_payload,
+)
+
+EXPECTED_EVENTS = {
+    "link.created",
+    "link.updated",
+    "link.deleted",
+    "link.status_changed",
+    "link.clicked",
+    "link.expired",
+    "bot.detected",
+    "domain.verified",
+    "domain.suspended",
+    "key.created",
+}
+
+
+class TestCatalog:
+    def test_the_ten_events(self):
+        assert set(EVENT_REGISTRY) == EXPECTED_EVENTS
+
+    def test_every_sample_validates_against_its_payload_model(self):
+        """Samples double as docs AND test-send fixtures — they can never
+        drift from the payload models because this test pins them."""
+        for spec in [*EVENT_REGISTRY.values(), TEST_EVENT_SPEC]:
+            spec.payload_model.model_validate(spec.sample())
+
+    def test_click_sample_has_no_ip_shaped_fields(self):
+        sample = EVENT_REGISTRY["link.clicked"].sample()
+        assert "ip" not in sample
+        assert "client_ip" not in sample
+
+
+class TestExpansion:
+    def test_star_is_everything(self):
+        assert expand(["*"]) == frozenset(EVENT_REGISTRY)
+
+    def test_category_wildcard(self):
+        assert expand(["link.*"]) == {
+            name for name, spec in EVENT_REGISTRY.items() if spec.category == "link"
+        }
+
+    def test_concrete_names(self):
+        assert expand(["link.clicked", "domain.verified"]) == {
+            "link.clicked",
+            "domain.verified",
+        }
+
+    def test_unknown_patterns_expand_to_nothing(self):
+        assert expand(["nope.*", "nope"]) == frozenset()
+
+
+class TestValidation:
+    def test_valid_patterns_include_wildcards(self):
+        patterns = valid_patterns()
+        assert "*" in patterns
+        assert "link.*" in patterns
+        assert "link.clicked" in patterns
+
+    def test_typo_gets_a_suggestion(self):
+        with pytest.raises(ValidationError, match=r"link\.clicked"):
+            validate_patterns(["link.clickd"])
+
+    def test_unknown_event_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_patterns(["payments.settled"])
+
+    def test_payload_validation_rejects_missing_required(self):
+        with pytest.raises(PydanticValidationError):
+            validate_payload("link.created", {})
+
+    def test_payload_validation_allows_additive_fields(self):
+        sample = EVENT_REGISTRY["link.clicked"].sample()
+        sample["brand_new_field"] = "future"
+        validate_payload("link.clicked", sample)

--- a/tests/unit/services/webhooks/test_registry.py
+++ b/tests/unit/services/webhooks/test_registry.py
@@ -22,10 +22,8 @@ EXPECTED_EVENTS = {
     "link.status_changed",
     "link.clicked",
     "link.expired",
-    "bot.detected",
     "domain.verified",
     "domain.suspended",
-    "key.created",
 }
 
 

--- a/tests/unit/services/webhooks/test_registry.py
+++ b/tests/unit/services/webhooks/test_registry.py
@@ -22,8 +22,6 @@ EXPECTED_EVENTS = {
     "link.status_changed",
     "link.clicked",
     "link.expired",
-    "domain.verified",
-    "domain.suspended",
 }
 
 
@@ -53,9 +51,9 @@ class TestExpansion:
         }
 
     def test_concrete_names(self):
-        assert expand(["link.clicked", "domain.verified"]) == {
+        assert expand(["link.clicked", "link.expired"]) == {
             "link.clicked",
-            "domain.verified",
+            "link.expired",
         }
 
     def test_unknown_patterns_expand_to_nothing(self):

--- a/tests/unit/services/webhooks/test_registry.py
+++ b/tests/unit/services/webhooks/test_registry.py
@@ -19,7 +19,6 @@ EXPECTED_EVENTS = {
     "link.created",
     "link.updated",
     "link.deleted",
-    "link.status_changed",
     "link.clicked",
     "link.expired",
 }

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -45,26 +45,33 @@ class TestRegistry:
 
 
 class TestDiscord:
-    def test_clicked_renders_an_inline_field_grid(self):
+    def test_clicked_renders_a_two_column_grid(self):
         doc = _discord("link.clicked", _clicked_payload())
         assert doc["username"] == "spoo.me"
+        assert doc["avatar_url"].startswith("https://spoo.me/")
         (embed,) = doc["embeds"]
-        assert embed["title"] == "Click · spoo.me/summer-drop"
+        assert embed["title"] == "Click: spoo.me/summer-drop"
         assert embed["url"] == "https://spoo.me/summer-drop"
         assert embed["timestamp"] == _TS
         fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Location"] == "Mumbai, IN"
-        assert fields["Device"] == "Chrome · Android · mobile"
+        assert fields["Country"] == "🇮🇳 IN"
+        assert fields["City"] == "Mumbai"
+        assert fields["Browser"] == "Chrome"
+        assert fields["OS"] == "Android"
+        assert fields["Device"] == "mobile"
         assert fields["From"] == "x.com"
-        assert fields["UTM"] == "newsletter · email"
-        assert fields["Clicks"] == "4,102"
+        assert fields["UTM"] == "newsletter / email"
+        assert fields["Clicks so far"] == "4,102"
         assert all(f["inline"] for f in embed["fields"])
-        # Discord renders the embed timestamp itself; footer is brand only.
-        assert embed["footer"]["text"] == "spoo.me"
+        # Spacer fields close each pair so rows hold two facts, not three.
+        assert "\u200b" in fields
+        # The webhook identity carries the brand; no footer without a notice.
+        assert "footer" not in embed
+        assert "·" not in json.dumps(embed, ensure_ascii=False)
 
     def test_sparse_click_is_never_an_empty_card(self):
-        # A local/direct click has no geo and no referrer; it still carries
-        # Device and shows the truth: a direct visit.
+        # A local/direct click has no geo and no referrer; the truth still
+        # renders: a direct visit, count stated even at zero.
         doc = _discord(
             "link.clicked",
             _clicked_payload(
@@ -76,10 +83,11 @@ class TestDiscord:
             ),
         )
         fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
-        assert "Location" not in fields
-        assert "Clicks" not in fields
+        assert "Country" not in fields
+        assert "City" not in fields
         assert fields["From"] == "direct"
-        assert fields["Device"] == "Chrome · Android · mobile"
+        assert fields["Browser"] == "Chrome"
+        assert fields["Clicks so far"] == "0"
 
     def test_clicked_bot_field(self):
         doc = _discord(
@@ -90,9 +98,7 @@ class TestDiscord:
 
     def test_dropped_notice_rides_the_footer(self):
         doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
-        assert doc["embeds"][0]["footer"]["text"] == (
-            "spoo.me · 3 earlier deliveries dropped"
-        )
+        assert doc["embeds"][0]["footer"]["text"] == "3 earlier deliveries dropped"
 
     def test_updated_renders_a_diff_block(self):
         payload = EVENT_REGISTRY["link.updated"].sample()
@@ -117,9 +123,10 @@ class TestDiscord:
         (embed,) = _discord("link.expired", EVENT_REGISTRY["link.expired"].sample())[
             "embeds"
         ]
-        names = [f["name"] for f in embed["fields"]]
-        assert names == ["Reason", "Destination", "Lifetime clicks"]
-        assert embed["fields"][0]["value"] == "Max clicks reached"
+        fields = {f["name"]: f["value"] for f in embed["fields"]}
+        assert fields["Reason"] == "Max clicks reached"
+        assert "Destination" in fields
+        assert "Lifetime clicks" in fields
 
         (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
             "embeds"
@@ -129,7 +136,8 @@ class TestDiscord:
         assert "days" in fields["Age"]
 
     def test_bare_created_link_still_fills_the_card(self):
-        # No expiry and no cap are answers, not blanks.
+        # Every configuration fact renders with its real answer, absent
+        # settings included.
         payload = {"link": {**EVENT_REGISTRY["link.created"].sample()["link"]}}
         payload["link"]["expires_at"] = None
         payload["link"]["max_clicks"] = None
@@ -139,6 +147,10 @@ class TestDiscord:
         }
         assert fields["Expires"] == "never"
         assert fields["Max clicks"] == "unlimited"
+        assert fields["Password"] == "none"
+        assert fields["Bots"] == "allowed"
+        assert fields["Meta tags"] == "default"
+        assert fields["Geo targeting"] == "none"
 
     def test_destination_field_is_full_width(self):
         (embed,) = _discord("link.created", EVENT_REGISTRY["link.created"].sample())[
@@ -171,25 +183,21 @@ class TestDiscord:
         (embed,) = _discord("link.updated", payload)["embeds"]
         assert len(embed["title"]) <= 256
         assert len(embed["description"]) <= 4096
-        total = (
-            len(embed["title"])
-            + len(embed["description"])
-            + len(embed["footer"]["text"])
-        )
+        total = len(embed["title"]) + len(embed["description"])
         assert total <= _EMBED_TOTAL_MAX
 
 
 class TestSlack:
     def test_clicked_is_title_fields_context(self):
         doc = _slack("link.clicked", _clicked_payload())
-        assert doc["text"] == "Click · spoo.me/summer-drop"
+        assert doc["text"] == "Click: spoo.me/summer-drop"
         first, last = doc["blocks"][0], doc["blocks"][-1]
         assert first["type"] == "section"
         assert first["text"]["text"].startswith(
-            "*<https://spoo.me/summer-drop|Click · spoo.me/summer-drop>*"
+            "*<https://spoo.me/summer-drop|Click: spoo.me/summer-drop>*"
         )
         fields = [f["text"] for f in doc["blocks"][1]["fields"]]
-        assert "*Location*\nMumbai, IN" in fields
+        assert "*Country*\n🇮🇳 IN" in fields
         assert "*From*\nx.com" in fields
         assert last["type"] == "context"
         assert last["elements"][0]["text"] == f"spoo.me · {_TS}"

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -45,36 +45,48 @@ class TestRegistry:
 
 
 class TestDiscord:
-    def test_clicked_is_compact_description(self):
+    def test_clicked_renders_an_inline_field_grid(self):
         doc = _discord("link.clicked", _clicked_payload())
         assert doc["username"] == "spoo.me"
         (embed,) = doc["embeds"]
         assert embed["title"] == "Click · spoo.me/summer-drop"
         assert embed["url"] == "https://spoo.me/summer-drop"
         assert embed["timestamp"] == _TS
-        assert "Mumbai, IN · Chrome on Android" in embed["description"]
-        assert "from x.com · click #4,102" in embed["description"]
-        assert "fields" not in embed
+        fields = {f["name"]: f["value"] for f in embed["fields"]}
+        assert fields["Location"] == "Mumbai, IN"
+        assert fields["Device"] == "Chrome · Android · mobile"
+        assert fields["From"] == "x.com"
+        assert fields["UTM"] == "newsletter · email"
+        assert fields["Clicks"] == "4,102"
+        assert all(f["inline"] for f in embed["fields"])
         # Discord renders the embed timestamp itself; footer is brand only.
         assert embed["footer"]["text"] == "spoo.me"
 
-    def test_clicked_omits_absent_dimensions(self):
+    def test_sparse_click_is_never_an_empty_card(self):
+        # A local/direct click has no geo and no referrer; it still carries
+        # Device and shows the truth: a direct visit.
         doc = _discord(
             "link.clicked",
             _clicked_payload(
-                city=None, country="unknown", referrer="(none)", browser=None, os=None
+                city=None,
+                country="unknown",
+                referrer="(none)",
+                utm=None,
+                total_clicks=0,
             ),
         )
-        description = doc["embeds"][0]["description"]
-        assert "unknown" not in description
-        assert "none" not in description
-        assert "from" not in description
+        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
+        assert "Location" not in fields
+        assert "Clicks" not in fields
+        assert fields["From"] == "direct"
+        assert fields["Device"] == "Chrome · Android · mobile"
 
-    def test_clicked_bot_line(self):
+    def test_clicked_bot_field(self):
         doc = _discord(
             "link.clicked", _clicked_payload(is_bot=True, bot_name="GoogleBot")
         )
-        assert "bot · GoogleBot" in doc["embeds"][0]["description"]
+        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
+        assert fields["Bot"] == "GoogleBot"
 
     def test_dropped_notice_rides_the_footer(self):
         doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
@@ -106,13 +118,35 @@ class TestDiscord:
             "embeds"
         ]
         names = [f["name"] for f in embed["fields"]]
-        assert names == ["Reason", "Destination", "Total clicks"]
+        assert names == ["Reason", "Destination", "Lifetime clicks"]
         assert embed["fields"][0]["value"] == "Max clicks reached"
 
         (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
             "embeds"
         ]
-        assert [f["name"] for f in embed["fields"]] == ["Destination", "Total clicks"]
+        fields = {f["name"]: f["value"] for f in embed["fields"]}
+        assert fields["Lifetime clicks"] == "4,102"
+        assert "days" in fields["Age"]
+
+    def test_bare_created_link_still_fills_the_card(self):
+        # No expiry and no cap are answers, not blanks.
+        payload = {"link": {**EVENT_REGISTRY["link.created"].sample()["link"]}}
+        payload["link"]["expires_at"] = None
+        payload["link"]["max_clicks"] = None
+        fields = {
+            f["name"]: f["value"]
+            for f in _discord("link.created", payload)["embeds"][0]["fields"]
+        }
+        assert fields["Expires"] == "never"
+        assert fields["Max clicks"] == "unlimited"
+
+    def test_destination_field_is_full_width(self):
+        (embed,) = _discord("link.created", EVENT_REGISTRY["link.created"].sample())[
+            "embeds"
+        ]
+        by_name = {f["name"]: f for f in embed["fields"]}
+        assert by_name["Destination"]["inline"] is False
+        assert by_name["Expires"]["inline"] is True
 
     def test_test_event_renders_its_message(self):
         (embed,) = _discord("webhook.test", TEST_EVENT_SPEC.sample())["embeds"]
@@ -146,7 +180,7 @@ class TestDiscord:
 
 
 class TestSlack:
-    def test_clicked_is_one_section_plus_context(self):
+    def test_clicked_is_title_fields_context(self):
         doc = _slack("link.clicked", _clicked_payload())
         assert doc["text"] == "Click · spoo.me/summer-drop"
         first, last = doc["blocks"][0], doc["blocks"][-1]
@@ -154,7 +188,9 @@ class TestSlack:
         assert first["text"]["text"].startswith(
             "*<https://spoo.me/summer-drop|Click · spoo.me/summer-drop>*"
         )
-        assert "Mumbai, IN · Chrome on Android" in first["text"]["text"]
+        fields = [f["text"] for f in doc["blocks"][1]["fields"]]
+        assert "*Location*\nMumbai, IN" in fields
+        assert "*From*\nx.com" in fields
         assert last["type"] == "context"
         assert last["elements"][0]["text"] == f"spoo.me · {_TS}"
 
@@ -176,9 +212,10 @@ class TestSlack:
 
     def test_mrkdwn_control_characters_escaped(self):
         payload = _clicked_payload(city="<Berlin & Brandenburg>")
-        text = _slack("link.clicked", payload)["blocks"][0]["text"]["text"]
-        assert "&lt;Berlin &amp; Brandenburg&gt;" in text
-        assert "<Berlin" not in text
+        doc = _slack("link.clicked", payload)
+        fields = " ".join(f["text"] for f in doc["blocks"][1]["fields"])
+        assert "&lt;Berlin &amp; Brandenburg&gt;" in fields
+        assert "<Berlin" not in fields
 
     def test_dropped_notice_rides_the_context_line(self):
         doc = _slack("link.clicked", _clicked_payload(dropped_since_last=1))

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -1,0 +1,217 @@
+"""Discord and Slack flavors — full-shape pins per event type, receiver
+size limits, escaping, and the fallback that keeps future event types from
+terminal-failing flavored endpoints. Raw stays pinned via the executor
+tests; these cover the lossy renderings."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from schemas.enums.webhook import WebhookFlavor
+from services.webhooks.registry import EVENT_REGISTRY, TEST_EVENT_SPEC
+from services.webhooks.renderers import default_renderers
+from services.webhooks.renderers.discord import _EMBED_TOTAL_MAX, DiscordRenderer
+from services.webhooks.renderers.slack import SlackRenderer
+
+_TS = "2026-07-24T14:32:00+00:00"
+
+
+def _discord(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    body = DiscordRenderer().render("evt_x", event_type, _TS, payload)
+    return json.loads(body)
+
+
+def _slack(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    body = SlackRenderer().render("evt_x", event_type, _TS, payload)
+    return json.loads(body)
+
+
+def _clicked_payload(**overrides: Any) -> dict[str, Any]:
+    payload = EVENT_REGISTRY["link.clicked"].sample()
+    payload.update(overrides)
+    return payload
+
+
+class TestRegistry:
+    def test_every_flavor_has_a_renderer(self):
+        # Enum and registry must never drift: a flavor an endpoint can be
+        # created with must be renderable, or deliveries terminal-fail.
+        assert set(default_renderers()) == {f.value for f in WebhookFlavor}
+
+    def test_renderers_expose_matching_flavor_attribute(self):
+        for key, renderer in default_renderers().items():
+            assert renderer.flavor == key
+
+
+class TestDiscord:
+    def test_clicked_is_compact_description(self):
+        doc = _discord("link.clicked", _clicked_payload())
+        assert doc["username"] == "spoo.me"
+        (embed,) = doc["embeds"]
+        assert embed["title"] == "Click · spoo.me/summer-drop"
+        assert embed["url"] == "https://spoo.me/summer-drop"
+        assert embed["timestamp"] == _TS
+        assert "Mumbai, IN · Chrome on Android" in embed["description"]
+        assert "from x.com · click #4,102" in embed["description"]
+        assert "fields" not in embed
+        # Discord renders the embed timestamp itself; footer is brand only.
+        assert embed["footer"]["text"] == "spoo.me"
+
+    def test_clicked_omits_absent_dimensions(self):
+        doc = _discord(
+            "link.clicked",
+            _clicked_payload(
+                city=None, country="unknown", referrer="(none)", browser=None, os=None
+            ),
+        )
+        description = doc["embeds"][0]["description"]
+        assert "unknown" not in description
+        assert "none" not in description
+        assert "from" not in description
+
+    def test_clicked_bot_line(self):
+        doc = _discord(
+            "link.clicked", _clicked_payload(is_bot=True, bot_name="GoogleBot")
+        )
+        assert "bot · GoogleBot" in doc["embeds"][0]["description"]
+
+    def test_dropped_notice_rides_the_footer(self):
+        doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
+        assert doc["embeds"][0]["footer"]["text"] == (
+            "spoo.me · 3 earlier deliveries dropped"
+        )
+
+    def test_updated_renders_a_diff_block(self):
+        payload = EVENT_REGISTRY["link.updated"].sample()
+        payload["changes"]["max_clicks"] = {"old": 5000, "new": 10000}
+        description = _discord("link.updated", payload)["embeds"][0]["description"]
+        assert description.startswith("```diff\n")
+        assert description.endswith("\n```")
+        assert "- long_url: https://example.com/old" in description
+        assert "+ long_url: https://example.com/campaign" in description
+        assert "- max_clicks: 5000" in description
+        assert "+ max_clicks: 10000" in description
+
+    def test_diff_values_cannot_break_out_of_the_block(self):
+        payload = {
+            "link": {"alias": "a", "domain": "spoo.me"},
+            "changes": {"long_url": {"old": "x", "new": "```@everyone"}},
+        }
+        description = _discord("link.updated", payload)["embeds"][0]["description"]
+        assert description.count("```") == 2  # only the fence itself
+
+    def test_lifecycle_field_grids(self):
+        (embed,) = _discord("link.expired", EVENT_REGISTRY["link.expired"].sample())[
+            "embeds"
+        ]
+        names = [f["name"] for f in embed["fields"]]
+        assert names == ["Reason", "Destination", "Total clicks"]
+        assert embed["fields"][0]["value"] == "Max clicks reached"
+
+        (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
+            "embeds"
+        ]
+        assert [f["name"] for f in embed["fields"]] == ["Destination", "Total clicks"]
+
+    def test_test_event_renders_its_message(self):
+        (embed,) = _discord("webhook.test", TEST_EVENT_SPEC.sample())["embeds"]
+        assert embed["description"] == "If you can read this, your endpoint works."
+
+    def test_unknown_event_type_falls_back_to_json(self):
+        # A future registry addition must degrade, never terminal-fail.
+        (embed,) = _discord("link.blocked", {"link_id": "x", "reason": "phishing"})[
+            "embeds"
+        ]
+        assert embed["title"] == "link.blocked"
+        assert embed["description"].startswith("```json\n")
+        assert '"reason":"phishing"' in embed["description"]
+
+    def test_receiver_limits_hold_under_pathological_changes(self):
+        payload = {
+            "link": {"alias": "a" * 500, "domain": "spoo.me"},
+            "changes": {
+                f"field_{i}": {"old": "x" * 900, "new": "y" * 900} for i in range(10)
+            },
+        }
+        (embed,) = _discord("link.updated", payload)["embeds"]
+        assert len(embed["title"]) <= 256
+        assert len(embed["description"]) <= 4096
+        total = (
+            len(embed["title"])
+            + len(embed["description"])
+            + len(embed["footer"]["text"])
+        )
+        assert total <= _EMBED_TOTAL_MAX
+
+
+class TestSlack:
+    def test_clicked_is_one_section_plus_context(self):
+        doc = _slack("link.clicked", _clicked_payload())
+        assert doc["text"] == "Click · spoo.me/summer-drop"
+        first, last = doc["blocks"][0], doc["blocks"][-1]
+        assert first["type"] == "section"
+        assert first["text"]["text"].startswith(
+            "*<https://spoo.me/summer-drop|Click · spoo.me/summer-drop>*"
+        )
+        assert "Mumbai, IN · Chrome on Android" in first["text"]["text"]
+        assert last["type"] == "context"
+        assert last["elements"][0]["text"] == f"spoo.me · {_TS}"
+
+    def test_updated_renders_old_to_new_pairs(self):
+        doc = _slack("link.updated", EVENT_REGISTRY["link.updated"].sample())
+        fields = doc["blocks"][1]["fields"]
+        assert fields[0]["text"] == (
+            "*long_url*\nhttps://example.com/old → https://example.com/campaign"
+        )
+
+    def test_field_sections_chunk_at_ten(self):
+        payload = {
+            "link": {"alias": "a", "domain": "spoo.me"},
+            "changes": {f"f{i}": {"old": i, "new": i + 1} for i in range(12)},
+        }
+        doc = _slack("link.updated", payload)
+        field_sections = [b for b in doc["blocks"] if "fields" in b]
+        assert [len(s["fields"]) for s in field_sections] == [10, 2]
+
+    def test_mrkdwn_control_characters_escaped(self):
+        payload = _clicked_payload(city="<Berlin & Brandenburg>")
+        text = _slack("link.clicked", payload)["blocks"][0]["text"]["text"]
+        assert "&lt;Berlin &amp; Brandenburg&gt;" in text
+        assert "<Berlin" not in text
+
+    def test_dropped_notice_rides_the_context_line(self):
+        doc = _slack("link.clicked", _clicked_payload(dropped_since_last=1))
+        assert doc["blocks"][-1]["elements"][0]["text"] == (
+            f"spoo.me · {_TS} · 1 earlier delivery dropped"
+        )
+
+    def test_unknown_event_type_falls_back_to_json(self):
+        doc = _slack("link.blocked", {"link_id": "x", "reason": "phishing"})
+        assert doc["text"] == "link.blocked"
+        code = doc["blocks"][1]["text"]["text"]
+        assert code.startswith("```")
+        assert "phishing" in code
+
+    def test_output_stays_under_the_engine_payload_cap(self):
+        payload = {
+            "link": {"alias": "a" * 500, "domain": "spoo.me"},
+            "changes": {
+                f"field_{i}": {"old": "x" * 900, "new": "y" * 900} for i in range(10)
+            },
+        }
+        body = SlackRenderer().render("evt_x", "link.updated", _TS, payload)
+        assert len(body.encode()) < 20_480
+        assert len(json.loads(body)["blocks"]) <= 50
+
+
+class TestAllEventsBothFlavors:
+    def test_every_registered_sample_renders_valid_json(self):
+        renderers = default_renderers()
+        specs = [*EVENT_REGISTRY.values(), TEST_EVENT_SPEC]
+        for spec in specs:
+            for flavor in ("discord", "slack"):
+                body = renderers[flavor].render("evt_x", spec.name, _TS, spec.sample())
+                parsed = json.loads(body)
+                assert parsed  # non-empty, valid JSON
+                assert len(body.encode()) < 20_480

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -11,7 +11,7 @@ from typing import Any
 from schemas.enums.webhook import WebhookFlavor
 from services.webhooks.registry import EVENT_REGISTRY, TEST_EVENT_SPEC
 from services.webhooks.renderers import default_renderers
-from services.webhooks.renderers.discord import _EMBED_TOTAL_MAX, DiscordRenderer
+from services.webhooks.renderers.discord import DiscordRenderer
 from services.webhooks.renderers.slack import SlackRenderer
 
 _TS = "2026-07-24T14:32:00+00:00"
@@ -45,33 +45,41 @@ class TestRegistry:
 
 
 class TestDiscord:
-    def test_clicked_renders_a_two_column_grid(self):
+    """Components V2: one accent container, heading, divider, substance,
+    small-text localized footer. Never embeds, never pings."""
+
+    def _container(self, doc):
+        assert doc["flags"] == 32768
+        assert doc["allowed_mentions"] == {"parse": []}
+        assert "embeds" not in doc and "content" not in doc
+        (container,) = doc["components"]
+        assert container["type"] == 17
+        return container
+
+    def _texts(self, container):
+        return [c["content"] for c in container["components"] if c["type"] == 10]
+
+    def test_clicked_message_shape(self):
         doc = _discord("link.clicked", _clicked_payload())
         assert doc["username"] == "spoo.me"
         assert doc["avatar_url"].startswith("https://spoo.me/")
-        (embed,) = doc["embeds"]
-        assert embed["title"] == "Click: spoo.me/summer-drop"
-        assert embed["url"] == "https://spoo.me/summer-drop"
-        assert embed["timestamp"] == _TS
-        fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Country"] == "🇮🇳 IN"
-        assert fields["City"] == "Mumbai"
-        assert fields["Browser"] == "Chrome"
-        assert fields["OS"] == "Android"
-        assert fields["Device"] == "mobile"
-        assert fields["From"] == "x.com"
-        assert fields["UTM"] == "newsletter / email"
-        assert fields["Clicks so far"] == "4,102"
-        assert all(f["inline"] for f in embed["fields"])
-        # Spacer fields close each pair so rows hold two facts, not three.
-        assert "\u200b" in fields
-        # The webhook identity carries the brand; no footer without a notice.
-        assert "footer" not in embed
-        assert "·" not in json.dumps(embed, ensure_ascii=False)
+        container = self._container(doc)
+        texts = self._texts(container)
+        assert texts[0] == (
+            "### Click  [spoo.me/summer-drop](https://spoo.me/summer-drop)"
+        )
+        body = texts[1]
+        assert "🇮🇳 **IN**  Mumbai" in body
+        assert "Chrome on Android, mobile" in body
+        assert "from **x.com**  (newsletter / email)" in body
+        footer = texts[-1]
+        assert footer.startswith("-# click 4,102")
+        assert "<t:" in footer and footer.rstrip().endswith(":R>")
+        # A divider separates the heading from the substance.
+        assert any(c["type"] == 14 and c["divider"] for c in container["components"])
+        assert "·" not in json.dumps(doc, ensure_ascii=False)
 
     def test_sparse_click_is_never_an_empty_card(self):
-        # A local/direct click has no geo and no referrer; the truth still
-        # renders: a direct visit, count stated even at zero.
         doc = _discord(
             "link.clicked",
             _clicked_payload(
@@ -82,109 +90,100 @@ class TestDiscord:
                 total_clicks=0,
             ),
         )
-        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
-        assert "Country" not in fields
-        assert "City" not in fields
-        assert fields["From"] == "direct"
-        assert fields["Browser"] == "Chrome"
-        assert fields["Clicks so far"] == "0"
+        texts = self._texts(self._container(doc))
+        assert "Chrome on Android, mobile" in texts[1]
+        assert "direct visit" in texts[1]
+        assert texts[-1].startswith("-# click 0")
 
-    def test_clicked_bot_field(self):
+    def test_clicked_bot_line(self):
         doc = _discord(
             "link.clicked", _clicked_payload(is_bot=True, bot_name="GoogleBot")
         )
-        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
-        assert fields["Bot"] == "GoogleBot"
+        texts = self._texts(self._container(doc))
+        assert "bot  **GoogleBot**" in texts[1]
 
     def test_dropped_notice_rides_the_footer(self):
         doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
-        assert doc["embeds"][0]["footer"]["text"] == "3 earlier deliveries dropped"
+        footer = self._texts(self._container(doc))[-1]
+        assert "-# 3 earlier deliveries dropped" in footer
 
     def test_updated_renders_a_diff_block(self):
         payload = EVENT_REGISTRY["link.updated"].sample()
         payload["changes"]["max_clicks"] = {"old": 5000, "new": 10000}
-        description = _discord("link.updated", payload)["embeds"][0]["description"]
-        assert description.startswith("```diff\n")
-        assert description.endswith("\n```")
-        assert "- long_url: https://example.com/old" in description
-        assert "+ long_url: https://example.com/campaign" in description
-        assert "- max_clicks: 5000" in description
-        assert "+ max_clicks: 10000" in description
+        texts = self._texts(self._container(_discord("link.updated", payload)))
+        diff = next(t for t in texts if t.startswith("```diff"))
+        assert "- long_url: https://example.com/old" in diff
+        assert "+ long_url: https://example.com/campaign" in diff
+        assert "- max_clicks: 5000" in diff
+        assert "+ max_clicks: 10000" in diff
 
     def test_diff_values_cannot_break_out_of_the_block(self):
         payload = {
             "link": {"alias": "a", "domain": "spoo.me"},
             "changes": {"long_url": {"old": "x", "new": "```@everyone"}},
         }
-        description = _discord("link.updated", payload)["embeds"][0]["description"]
-        assert description.count("```") == 2  # only the fence itself
+        texts = self._texts(self._container(_discord("link.updated", payload)))
+        diff = next(t for t in texts if t.startswith("```diff"))
+        assert diff.count("```") == 2  # only the fence itself
 
-    def test_lifecycle_field_grids(self):
-        (embed,) = _discord("link.expired", EVENT_REGISTRY["link.expired"].sample())[
-            "embeds"
-        ]
-        fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Reason"] == "Max clicks reached"
-        assert "Destination" in fields
-        assert "Lifetime clicks" in fields
-
-        (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
-            "embeds"
-        ]
-        fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Lifetime clicks"] == "4,102"
-        assert "days" in fields["Age"]
-
-    def test_bare_created_link_still_fills_the_card(self):
-        # Every configuration fact renders with its real answer, absent
-        # settings included.
+    def test_created_states_the_full_configuration(self):
         payload = {"link": {**EVENT_REGISTRY["link.created"].sample()["link"]}}
         payload["link"]["expires_at"] = None
         payload["link"]["max_clicks"] = None
-        fields = {
-            f["name"]: f["value"]
-            for f in _discord("link.created", payload)["embeds"][0]["fields"]
-        }
-        assert fields["Expires"] == "never"
-        assert fields["Max clicks"] == "unlimited"
-        assert fields["Password"] == "none"
-        assert fields["Bots"] == "allowed"
-        assert fields["Meta tags"] == "default"
-        assert fields["Geo targeting"] == "none"
+        container = self._container(_discord("link.created", payload))
+        texts = self._texts(container)
+        # Destination rides as a small subtitle under the heading.
+        assert texts[1] == "-# https://example.com/campaign"
+        facts = texts[2]
+        assert "**Expires**  never" in facts
+        assert "**Max clicks**  unlimited" in facts
+        assert "**Password**  none" in facts
+        assert "**Bots**  allowed" in facts
+        assert "**Meta tags**  default" in facts
+        assert "**Geo targeting**  none" in facts
+        assert container["accent_color"] == 0x43B581
 
-    def test_destination_field_is_full_width(self):
-        (embed,) = _discord("link.created", EVENT_REGISTRY["link.created"].sample())[
-            "embeds"
-        ]
-        by_name = {f["name"]: f for f in embed["fields"]}
-        assert by_name["Destination"]["inline"] is False
-        assert by_name["Expires"]["inline"] is True
+    def test_deleted_heading_is_not_a_link(self):
+        texts = self._texts(
+            self._container(
+                _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())
+            )
+        )
+        assert texts[0] == "### Link deleted  spoo.me/summer-drop"
+        assert "**Lifetime clicks**  4,102" in texts[2]
+        assert "**Age**" in texts[2]
 
     def test_test_event_renders_its_message(self):
-        (embed,) = _discord("webhook.test", TEST_EVENT_SPEC.sample())["embeds"]
-        assert embed["description"] == "If you can read this, your endpoint works."
+        texts = self._texts(
+            self._container(_discord("webhook.test", TEST_EVENT_SPEC.sample()))
+        )
+        assert "If you can read this, your endpoint works." in texts
 
     def test_unknown_event_type_falls_back_to_json(self):
         # A future registry addition must degrade, never terminal-fail.
-        (embed,) = _discord("link.blocked", {"link_id": "x", "reason": "phishing"})[
-            "embeds"
-        ]
-        assert embed["title"] == "link.blocked"
-        assert embed["description"].startswith("```json\n")
-        assert '"reason":"phishing"' in embed["description"]
+        texts = self._texts(
+            self._container(
+                _discord("link.blocked", {"link_id": "x", "reason": "phishing"})
+            )
+        )
+        assert texts[0] == "### link.blocked"
+        code = next(t for t in texts if t.startswith("```json"))
+        assert '"reason":"phishing"' in code
 
-    def test_receiver_limits_hold_under_pathological_changes(self):
+    def test_text_budget_holds_under_pathological_changes(self):
         payload = {
             "link": {"alias": "a" * 500, "domain": "spoo.me"},
             "changes": {
                 f"field_{i}": {"old": "x" * 900, "new": "y" * 900} for i in range(10)
             },
         }
-        (embed,) = _discord("link.updated", payload)["embeds"]
-        assert len(embed["title"]) <= 256
-        assert len(embed["description"]) <= 4096
-        total = len(embed["title"]) + len(embed["description"])
-        assert total <= _EMBED_TOTAL_MAX
+        container = self._container(_discord("link.updated", payload))
+        total = sum(len(t) for t in self._texts(container))
+        assert total <= 3_500
+        assert len(container["components"]) <= 40
+
+    def test_delivery_url_query_declared(self):
+        assert DiscordRenderer.url_query == {"with_components": "true"}
 
 
 class TestSlack:

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -259,3 +259,51 @@ class TestAllEventsBothFlavors:
                 parsed = json.loads(body)
                 assert parsed  # non-empty, valid JSON
                 assert len(body.encode()) < 20_480
+
+
+class TestDiscordInjection:
+    """Visitor-controlled payload values must never render as live
+    Discord markdown in the subscriber's channel."""
+
+    def _body_text(self, doc):
+        return "\n".join(
+            c["content"] for c in doc["components"][0]["components"] if c["type"] == 10
+        )
+
+    def test_masked_link_in_referrer_is_neutralized(self):
+        doc = _discord(
+            "link.clicked", _clicked_payload(referrer="[x](https://evil.phish)")
+        )
+        text = self._body_text(doc)
+        assert "[x](https://evil.phish)" not in text
+        assert "\\[x\\]" in text
+
+    def test_markdown_in_dimensions_is_neutralized(self):
+        doc = _discord(
+            "link.clicked",
+            _clicked_payload(browser="**bold**", city="`code`", os="||spoiler||"),
+        )
+        text = self._body_text(doc)
+        assert "**bold**" not in text
+        assert "`code`" not in text
+        assert "||spoiler||" not in text
+
+    def test_lifecycle_values_are_neutralized(self):
+        payload = {
+            "link": {
+                "alias": "a",
+                "domain": "spoo.me",
+                "long_url": "https://example.com/a(b)[c]",
+                "short_url": "https://spoo.me/a",
+            }
+        }
+        doc = _discord("link.created", payload)
+        text = self._body_text(doc)
+        assert "(b)[c]" not in text  # subtitle rides escaped
+
+    def test_link_target_parens_cannot_close_the_masked_link(self):
+        payload = _clicked_payload()
+        payload["short_url"] = "https://spoo.me/a)b"
+        doc = _discord("link.clicked", payload)
+        heading = doc["components"][0]["components"][0]["content"]
+        assert "](https://spoo.me/a%29b)" in heading

--- a/tests/unit/services/webhooks/test_signing.py
+++ b/tests/unit/services/webhooks/test_signing.py
@@ -7,7 +7,6 @@ import base64
 from services.webhooks.signing import (
     SECRET_PREFIX,
     generate_signing_secret,
-    hash_signing_secret,
     new_webhook_id,
     secret_display_prefix,
     sign,
@@ -30,11 +29,6 @@ class TestSecrets:
         prefix = secret_display_prefix(secret)
         assert secret.startswith(prefix)
         assert len(prefix) == len(SECRET_PREFIX) + 8
-
-    def test_hash_is_stable_and_not_the_secret(self):
-        secret = generate_signing_secret()
-        assert hash_signing_secret(secret) == hash_signing_secret(secret)
-        assert secret not in hash_signing_secret(secret)
 
 
 class TestSigning:

--- a/tests/unit/services/webhooks/test_signing.py
+++ b/tests/unit/services/webhooks/test_signing.py
@@ -1,0 +1,75 @@
+"""Standard Webhooks signing — shape, roundtrip, rotation grace."""
+
+from __future__ import annotations
+
+import base64
+
+from services.webhooks.signing import (
+    SECRET_PREFIX,
+    generate_signing_secret,
+    hash_signing_secret,
+    new_webhook_id,
+    secret_display_prefix,
+    sign,
+    verify,
+)
+
+
+class TestSecrets:
+    def test_secret_shape(self):
+        secret = generate_signing_secret()
+        assert secret.startswith(SECRET_PREFIX)
+        # base64(24 bytes) after the prefix
+        assert len(base64.b64decode(secret.removeprefix(SECRET_PREFIX))) == 24
+
+    def test_secrets_unique(self):
+        assert generate_signing_secret() != generate_signing_secret()
+
+    def test_display_prefix(self):
+        secret = generate_signing_secret()
+        prefix = secret_display_prefix(secret)
+        assert secret.startswith(prefix)
+        assert len(prefix) == len(SECRET_PREFIX) + 8
+
+    def test_hash_is_stable_and_not_the_secret(self):
+        secret = generate_signing_secret()
+        assert hash_signing_secret(secret) == hash_signing_secret(secret)
+        assert secret not in hash_signing_secret(secret)
+
+
+class TestSigning:
+    def test_known_vector(self):
+        # Fixed vector: pin the exact Standard Webhooks construction —
+        # v1,base64(HMAC-SHA256(key, "{id}.{ts}.{body}")) with the key being
+        # the base64-DECODED portion after whsec_.
+        secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+        signature = sign(
+            "msg_p5jXN8AQM9LWM0D4loKWxJek", 1614265330, '{"test": 2432232314}', secret
+        )
+        assert signature == "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="
+
+    def test_verify_roundtrip(self):
+        secret = generate_signing_secret()
+        sig = sign("msg_1", 1700000000, '{"a":1}', secret)
+        assert verify("msg_1", 1700000000, '{"a":1}', secret, sig)
+
+    def test_verify_rejects_tampered_body(self):
+        secret = generate_signing_secret()
+        sig = sign("msg_1", 1700000000, '{"a":1}', secret)
+        assert not verify("msg_1", 1700000000, '{"a":2}', secret, sig)
+
+    def test_verify_accepts_any_of_space_delimited_signatures(self):
+        """Rotation grace: old + new signatures ride one header."""
+        old, new = generate_signing_secret(), generate_signing_secret()
+        header = " ".join(
+            [sign("msg_1", 1700000000, "{}", new), sign("msg_1", 1700000000, "{}", old)]
+        )
+        assert verify("msg_1", 1700000000, "{}", old, header)
+        assert verify("msg_1", 1700000000, "{}", new, header)
+
+
+class TestIds:
+    def test_webhook_id_shape_and_uniqueness(self):
+        a, b = new_webhook_id(), new_webhook_id()
+        assert a.startswith("msg_") and b.startswith("msg_")
+        assert a != b

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -233,3 +233,25 @@ class TestCustomDomainSettings:
     def test_prefixed_max_per_user_overrides_default(self, monkeypatch):
         monkeypatch.setenv("CUSTOM_DOMAINS_MAX_PER_USER", "10")
         assert CustomDomainSettings().max_per_user == 10
+
+
+class TestWebhookSettingsGuard:
+    def test_enabled_webhooks_require_secret_key(self, monkeypatch):
+        """An empty master secret would derive a predictable encryption
+        key for signing secrets — startup must refuse, not warn."""
+        import pytest as _pytest
+
+        from config import AppSettings
+
+        monkeypatch.setenv("WEBHOOKS_ENABLED", "true")
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.delenv("FLASK_SECRET_KEY", raising=False)
+        with _pytest.raises(Exception, match="SECRET_KEY"):
+            AppSettings(secret_key="", flask_secret_key="")
+
+    def test_enabled_webhooks_accept_configured_secret(self, monkeypatch):
+        from config import AppSettings
+
+        monkeypatch.setenv("WEBHOOKS_ENABLED", "true")
+        settings = AppSettings(secret_key="a-real-secret")
+        assert settings.webhooks.enabled is True

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -70,6 +70,7 @@ from services.click.consumers.hotness import HotUrlAction
 from services.edge_cache import PromoteToEdgeCacheAction
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
 from services.events.contract import DOMAIN_EVENTS_STREAM
+from services.events.sinks import InlineDomainEventSink
 from services.meta_tags.validator import MetaImageValidator
 from services.webhooks import (
     DeliveryExecutor,
@@ -158,6 +159,53 @@ async def _build_runtime(
         counter_redis=None,
     )
 
+    # Built FIRST so the stats consumer can carry the sink (link.expired
+    # fires from its max-clicks branch). In-process dispatch — same process
+    # as the dispatcher, no re-queue round trip.
+    worker_domain_sink = None
+    if run_webhooks:
+        # Webhooks stack: dispatcher fed by two consumer-group
+        # feeds (clicks + domain events), executor as a background task —
+        # Mongo-only, so it shares this process without extra infra.
+        wh = settings.webhooks
+        webhook_event_repo = WebhookEventRepository(db["webhook-events"])
+        webhook_endpoint_repo = WebhookEndpointRepository(db["webhook-endpoints"])
+        webhook_delivery_repo = WebhookDeliveryRepository(db["webhook-deliveries"])
+        dispatcher = WebhookDispatcher(
+            SubscriptionMatcher(
+                webhook_endpoint_repo,
+                OwnerSubscriptionCache(
+                    cache_redis, ttl_seconds=wh.matcher_cache_ttl_seconds
+                ),
+            ),
+            webhook_event_repo,
+            webhook_delivery_repo,
+            webhook_endpoint_repo,
+            max_pending_per_endpoint=wh.max_pending_per_endpoint,
+        )
+        worker_domain_sink = InlineDomainEventSink(dispatcher)
+        webhook_geoip = GeoIPService(settings.geoip_country_db, settings.geoip_city_db)
+        runtime.consumers["webhooks"] = WebhookClickConsumer(
+            dispatcher, webhook_geoip, settings.system_default_domain
+        )
+        runtime.webhook_domain_consumer = WebhookDomainConsumer(dispatcher)
+        executor = DeliveryExecutor(
+            webhook_delivery_repo,
+            webhook_endpoint_repo,
+            webhook_event_repo,
+            default_renderers(),
+            master_secret=settings.secret_key,
+            delivery_timeout=wh.delivery_timeout_seconds,
+            max_payload_bytes=wh.max_payload_bytes,
+            max_consecutive_failures=wh.max_consecutive_failures,
+            poll_interval=wh.executor_poll_seconds,
+            lease_seconds=wh.executor_lease_seconds,
+        )
+        runtime.telemetry_tasks.append(
+            asyncio.create_task(executor.run(), name="webhook-delivery-executor")
+        )
+        log.info("webhooks_worker_registered", stream=DOMAIN_EVENTS_STREAM)
+
     if "stats" in groups:
         geoip = GeoIPService(settings.geoip_country_db, settings.geoip_city_db)
         url_cache = UrlCache(cache_redis, ttl_seconds=settings.redis.redis_ttl_seconds)
@@ -169,6 +217,7 @@ async def _build_runtime(
                 EmojiUrlRepository(db["emojis"]),
                 geoip,
                 url_cache,
+                events=worker_domain_sink,
             )
         )
 
@@ -262,48 +311,6 @@ async def _build_runtime(
         )
         log.info("meta_image_validator_registered", stream=mt.stream)
 
-    if run_webhooks:
-        # Webhooks stack (TRD §13-14): dispatcher fed by two consumer-group
-        # feeds (clicks + domain events), executor as a background task —
-        # Mongo-only, so it shares this process without extra infra.
-        wh = settings.webhooks
-        webhook_event_repo = WebhookEventRepository(db["webhook-events"])
-        webhook_endpoint_repo = WebhookEndpointRepository(db["webhook-endpoints"])
-        webhook_delivery_repo = WebhookDeliveryRepository(db["webhook-deliveries"])
-        dispatcher = WebhookDispatcher(
-            SubscriptionMatcher(
-                webhook_endpoint_repo,
-                OwnerSubscriptionCache(
-                    cache_redis, ttl_seconds=wh.matcher_cache_ttl_seconds
-                ),
-            ),
-            webhook_event_repo,
-            webhook_delivery_repo,
-            webhook_endpoint_repo,
-            max_pending_per_endpoint=wh.max_pending_per_endpoint,
-        )
-        geoip = GeoIPService(settings.geoip_country_db, settings.geoip_city_db)
-        runtime.consumers["webhooks"] = WebhookClickConsumer(
-            dispatcher, geoip, settings.system_default_domain
-        )
-        runtime.webhook_domain_consumer = WebhookDomainConsumer(dispatcher)
-        executor = DeliveryExecutor(
-            webhook_delivery_repo,
-            webhook_endpoint_repo,
-            webhook_event_repo,
-            default_renderers(),
-            master_secret=settings.secret_key,
-            delivery_timeout=wh.delivery_timeout_seconds,
-            max_payload_bytes=wh.max_payload_bytes,
-            max_consecutive_failures=wh.max_consecutive_failures,
-            poll_interval=wh.executor_poll_seconds,
-            lease_seconds=wh.executor_lease_seconds,
-        )
-        runtime.telemetry_tasks.append(
-            asyncio.create_task(executor.run(), name="webhook-delivery-executor")
-        )
-        log.info("webhooks_worker_registered", stream=DOMAIN_EVENTS_STREAM)
-
     # Telemetry: periodic backlog/lag stats (the Axiom alert signal) and
     # cleanup of restart-leftover consumer names. Best-effort — a missing
     # telemetry connection never blocks consumption.
@@ -312,16 +319,21 @@ async def _build_runtime(
     )
     if telemetry_redis is not None:
         runtime.telemetry_redis = telemetry_redis
-        runtime.telemetry_tasks = [
-            asyncio.create_task(
-                StreamMetricsReporter(
-                    telemetry_redis, ce.stream, ce.stats_interval_seconds
-                ).run_forever()
-            ),
-            asyncio.create_task(
-                StaleConsumerJanitor(telemetry_redis, ce.stream).run_forever()
-            ),
-        ]
+        # extend, never assign — the webhooks executor task is already in
+        # this list and an assignment would orphan it (uncancellable at
+        # shutdown).
+        runtime.telemetry_tasks.extend(
+            [
+                asyncio.create_task(
+                    StreamMetricsReporter(
+                        telemetry_redis, ce.stream, ce.stats_interval_seconds
+                    ).run_forever()
+                ),
+                asyncio.create_task(
+                    StaleConsumerJanitor(telemetry_redis, ce.stream).run_forever()
+                ),
+            ]
+        )
 
     return runtime
 

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -57,6 +57,9 @@ from repositories.click_repository import ClickRepository
 from repositories.legacy.emoji_url_repository import EmojiUrlRepository
 from repositories.legacy.legacy_url_repository import LegacyUrlRepository
 from repositories.url_repository import UrlRepository
+from repositories.webhook_delivery_repository import WebhookDeliveryRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from repositories.webhook_event_repository import WebhookEventRepository
 from services.click.consumers import (
     ClickConsumer,
     HotUrlDetector,
@@ -66,7 +69,16 @@ from services.click.consumers import (
 from services.click.consumers.hotness import HotUrlAction
 from services.edge_cache import PromoteToEdgeCacheAction
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
+from services.events.contract import DOMAIN_EVENTS_STREAM
 from services.meta_tags.validator import MetaImageValidator
+from services.webhooks import (
+    DeliveryExecutor,
+    OwnerSubscriptionCache,
+    SubscriptionMatcher,
+    WebhookDispatcher,
+)
+from services.webhooks.consumers import WebhookClickConsumer, WebhookDomainConsumer
+from services.webhooks.renderers import default_renderers
 from workers.dlq import ClaimDeadLetterGuard
 from workers.telemetry import StaleConsumerJanitor, StreamMetricsReporter
 
@@ -88,6 +100,7 @@ class _WorkerRuntime:
     telemetry_tasks: list[asyncio.Task] = field(default_factory=list)
     consumers: dict[str, ClickConsumer] = field(default_factory=dict)
     meta_validator: MetaImageValidator | None = None
+    webhook_domain_consumer: WebhookDomainConsumer | None = None
 
     async def aclose(self) -> None:
         for task in self.telemetry_tasks:
@@ -118,7 +131,11 @@ def enabled_groups(ce: ClickEventsSettings) -> list[str]:
 
 
 async def _build_runtime(
-    settings: AppSettings, groups: list[str], *, run_meta: bool = False
+    settings: AppSettings,
+    groups: list[str],
+    *,
+    run_meta: bool = False,
+    run_webhooks: bool = False,
 ) -> _WorkerRuntime:
     ce = settings.click_events
     mongo_client: AsyncMongoClient = AsyncMongoClient(
@@ -245,6 +262,48 @@ async def _build_runtime(
         )
         log.info("meta_image_validator_registered", stream=mt.stream)
 
+    if run_webhooks:
+        # Webhooks stack (TRD §13-14): dispatcher fed by two consumer-group
+        # feeds (clicks + domain events), executor as a background task —
+        # Mongo-only, so it shares this process without extra infra.
+        wh = settings.webhooks
+        webhook_event_repo = WebhookEventRepository(db["webhook-events"])
+        webhook_endpoint_repo = WebhookEndpointRepository(db["webhook-endpoints"])
+        webhook_delivery_repo = WebhookDeliveryRepository(db["webhook-deliveries"])
+        dispatcher = WebhookDispatcher(
+            SubscriptionMatcher(
+                webhook_endpoint_repo,
+                OwnerSubscriptionCache(
+                    cache_redis, ttl_seconds=wh.matcher_cache_ttl_seconds
+                ),
+            ),
+            webhook_event_repo,
+            webhook_delivery_repo,
+            webhook_endpoint_repo,
+            max_pending_per_endpoint=wh.max_pending_per_endpoint,
+        )
+        geoip = GeoIPService(settings.geoip_country_db, settings.geoip_city_db)
+        runtime.consumers["webhooks"] = WebhookClickConsumer(
+            dispatcher, geoip, settings.system_default_domain
+        )
+        runtime.webhook_domain_consumer = WebhookDomainConsumer(dispatcher)
+        executor = DeliveryExecutor(
+            webhook_delivery_repo,
+            webhook_endpoint_repo,
+            webhook_event_repo,
+            default_renderers(),
+            master_secret=settings.secret_key,
+            delivery_timeout=wh.delivery_timeout_seconds,
+            max_payload_bytes=wh.max_payload_bytes,
+            max_consecutive_failures=wh.max_consecutive_failures,
+            poll_interval=wh.executor_poll_seconds,
+            lease_seconds=wh.executor_lease_seconds,
+        )
+        runtime.telemetry_tasks.append(
+            asyncio.create_task(executor.run(), name="webhook-delivery-executor")
+        )
+        log.info("webhooks_worker_registered", stream=DOMAIN_EVENTS_STREAM)
+
     # Telemetry: periodic backlog/lag stats (the Axiom alert signal) and
     # cleanup of restart-leftover consumer names. Best-effort — a missing
     # telemetry connection never blocks consumption.
@@ -360,6 +419,56 @@ def _register_meta_image(
     )(claimer)
 
 
+def _register_domain_webhooks(
+    broker: RedisBroker,
+    ce: ClickEventsSettings,
+    consumer_suffix: str,
+    domain_consumer_for: Any,
+) -> None:
+    """Reader + claimer pair for the ``webhooks`` group on events:domain.
+
+    Reuses the click pipeline's batch/claim tunables — domain events are a
+    tiny fraction of click volume, so dedicated knobs would be dead config.
+    """
+    guard = ClaimDeadLetterGuard(
+        stream=DOMAIN_EVENTS_STREAM,
+        group="webhooks",
+        dlq_stream=f"{DOMAIN_EVENTS_STREAM}:dlq",
+        max_deliveries=ce.max_deliveries,
+    )
+
+    async def reader(body: Any) -> None:
+        await domain_consumer_for().consume(body)
+
+    reader.__name__ = "webhooks_domain_reader"
+    broker.subscriber(
+        stream=StreamSub(
+            DOMAIN_EVENTS_STREAM,
+            group="webhooks",
+            consumer=f"webhooks-{consumer_suffix}",
+            max_records=ce.batch_size,
+            polling_interval=ce.block_ms,
+        )
+    )(reader)
+
+    async def claimer(body: Any, msg: RedisMessage, redis: Redis) -> None:
+        message_id = _first_message_id(msg)
+        if message_id and await guard.intercept(redis, message_id, body):
+            return
+        await domain_consumer_for().consume(body)
+
+    claimer.__name__ = "webhooks_domain_claimer"
+    broker.subscriber(
+        stream=StreamSub(
+            DOMAIN_EVENTS_STREAM,
+            group="webhooks",
+            consumer=f"webhooks-{consumer_suffix}-claim",
+            min_idle_time=ce.claim_idle_ms,
+            polling_interval=ce.block_ms,
+        )
+    )(claimer)
+
+
 def _first_message_id(msg: Any) -> str | None:
     ids = (getattr(msg, "raw_message", None) or {}).get("message_ids") or []
     if not ids:
@@ -375,14 +484,18 @@ def create_worker_app(settings: AppSettings | None = None) -> AsgiFastStream:
     ce = settings.click_events
 
     mt = settings.meta_tags
+    wh = settings.webhooks
     run_clicks = ce.sink == "stream" and bool(ce.queue_redis_uri)
     run_meta = mt.async_image_validation and bool(ce.queue_redis_uri)
-    if not run_clicks and not run_meta:
+    run_webhooks = (
+        wh.enabled and wh.runtime in ("auto", "worker") and bool(ce.queue_redis_uri)
+    )
+    if not run_clicks and not run_meta and not run_webhooks:
         raise RuntimeError(
-            "The worker requires CLICK_EVENTS_QUEUE_REDIS_URI plus either "
-            "CLICK_EVENTS_SINK=stream or META_TAGS_ASYNC_IMAGE_VALIDATION. "
-            "Refusing to start so a misconfigured deployment fails loudly "
-            "instead of idling."
+            "The worker requires CLICK_EVENTS_QUEUE_REDIS_URI plus at least "
+            "one of CLICK_EVENTS_SINK=stream, META_TAGS_ASYNC_IMAGE_VALIDATION, "
+            "or WEBHOOKS_ENABLED. Refusing to start so a misconfigured "
+            "deployment fails loudly instead of idling."
         )
 
     groups = enabled_groups(ce) if run_clicks else []
@@ -407,20 +520,34 @@ def create_worker_app(settings: AppSettings | None = None) -> AsgiFastStream:
             raise RuntimeError("worker runtime not initialised")
         return runtime.meta_validator
 
+    def domain_consumer_for() -> WebhookDomainConsumer:
+        runtime = runtime_holder.get("runtime")
+        if (
+            runtime is None or runtime.webhook_domain_consumer is None
+        ):  # pragma: no cover
+            raise RuntimeError("worker runtime not initialised")
+        return runtime.webhook_domain_consumer
+
     consumer_suffix = f"{socket.gethostname()}-{os.getpid()}"
     for group in groups:
         _register_group(broker, ce, group, consumer_suffix, consumer_for)
     if run_meta:
         _register_meta_image(broker, mt, consumer_suffix, validator_for)
+    if run_webhooks:
+        # link.clicked feed: the `webhooks` group is a sibling of stats/
+        # hotness on the click stream (only when clicks ride the stream).
+        if run_clicks:
+            _register_group(broker, ce, "webhooks", consumer_suffix, consumer_for)
+        _register_domain_webhooks(broker, ce, consumer_suffix, domain_consumer_for)
 
     async def _startup() -> None:
         runtime_holder["runtime"] = await _build_runtime(
-            settings, groups, run_meta=run_meta
+            settings, groups, run_meta=run_meta, run_webhooks=run_webhooks
         )
         log.info(
             "click_worker_started",
             stream=ce.stream,
-            groups=groups,
+            groups=groups + (["webhooks"] if run_webhooks else []),
             claim_idle_ms=ce.claim_idle_ms,
             max_deliveries=ce.max_deliveries,
         )


### PR DESCRIPTION
## What

Real-time event deliveries to subscriber URLs, following the [Standard Webhooks](https://www.standardwebhooks.com/) specification. When something happens to your links, spoo.me tells your other tools: your own server, a Zapier hook, anything that accepts an HTTPS POST.

Fully opt-in and dark by default: `WEBHOOKS_ENABLED=false` wires a null sink and mounts nothing, and access is additionally gated per user by the `webhooks` feature flag (default deny, 403 when not granted).

## Events

Five event types, one rule: events split by who caused them. Actor edits ride `link.updated` and its `changes` map (status included); system-discovered facts get named events.

| Event | Fires when |
|---|---|
| `link.created` | a link is created |
| `link.updated` | a link is edited; `changes` maps each field to old/new |
| `link.deleted` | a link is deleted |
| `link.clicked` | every tracked click, bots included (`is_bot` in payload) |
| `link.expired` | expiry is discovered (max clicks or time), once per link |

Payloads carry the full public link snapshot plus event context. `link.clicked` is flat and dimensional: country/city, browser/os/device, bounded raw user agent, referrer, UTM, `long_url`, running click total. Bulk operations emit per item, indistinguishable from a loop. Nothing password-shaped, IP-shaped, or internal ever rides the wire: password fields become presence booleans, meta tags reduce to their four public fields, and payload validation is pinned to the registry models by test.

`GET /api/v1/webhooks/event-types` is a public catalog with exact sample payloads; the same fixtures power test sends, so docs and behavior cannot drift.

## Delivery

- Standard Webhooks signing: `webhook-id` / `webhook-timestamp` / `webhook-signature` headers, HMAC-SHA256, `whsec_` secrets shown once and stored AES-GCM encrypted (the server signs at delivery time, so hash-only storage is not an option). Verified against the published reference test vector.
- At-least-once with retries: immediate, 5s, 5m, 30m, 2h, 5h, 10h. `webhook-id` is stable across retries and bodies are frozen after first render, so consumer dedup works on either.
- 410 Gone disables an endpoint immediately; ten consecutive exhausted deliveries disable it too.
- Per-endpoint pending cap (default 1000): beyond it deliveries are dropped and counted, and the next successful delivery carries `dropped_since_last` as a reconcile signal.
- Delivery log per endpoint: every attempt with status, latency, error, response snippet, and the exact body sent. 30-day TTL, coupled to the event store so a delivery can never outlive its event.

## Architecture

Two Redis Streams feed a dispatcher: the existing click stream gains a `webhooks` consumer group (reader plus claimer pair, DLQ guard, same machinery as the stats and hotness groups), and a new low-volume `events:domain` stream carries link lifecycle facts from `UrlService` and the bulk operations. The dispatcher matches subscriptions (owner-level Redis cache in front, so accounts without webhooks cost nothing on the click path) and records delivery intent in Mongo. A claim-loop executor owns delivery: atomic `findOneAndUpdate` claims with leases make N concurrent executors safe, and the loop needs only Mongo, so it runs in the click worker in production or embedded in the app process for self-hosts without a queue Redis. Deployments without any Redis still work: dispatch happens inline at emit time.

Events are stored once per fact; delivery rows are thin references. Rendering happens at first attempt, keeping dispatch insert-only on the consumer ack path.

## Security

- Endpoint URLs are SSRF-checked at registration and re-resolved before every delivery (public addresses only, connection pinned to the resolved IP, redirects refused), reusing the existing `safe_fetch` hardening.
- Registration requires a verified email plus the feature flag; `webhooks:manage` and `webhooks:read` API key scopes; five endpoints per user (config), 20KB payload cap, tight rate limits on create and test sends.

## Testing

Full suite green (2815). New coverage: signing vectors, registry/wildcard expansion, matcher scoping, dispatcher fan-out and cap, executor retry/disable paths, route integration with frozen wire shapes, bulk emission parity. Also verified end to end against live Mongo and Redis with a real signed HTTPS delivery to a public echo endpoint.

## Rollout

Merges dark. Enabling requires `WEBHOOKS_ENABLED=true` plus seeding the `webhooks` feature flag. Env reference is in `.env.example`; an Axiom dashboard for dispatch/delivery health ships in `axiom/dashboards/`. Follow-ups tracked separately: endpoint auto-disable email notification, Discord/Slack payload flavors, dashboard UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook endpoint management API (create/list/get/update/delete), event catalog, synchronous test sends, delivery log listing, and manual redelivery retries with scoped event subscriptions.
  * Added signed webhook deliveries with endpoint health tracking, retry/backoff handling, and auto-disable on repeated failures.
  * Added link lifecycle/click webhook payloads with wildcard subscriptions and new Discord/Slack rendering flavors.
  * Added dispatch/delivery execution for worker and embedded modes.
* **Documentation**
  * Updated the example environment file with optional Webhooks configuration (off by default), including timeouts, caps, and secret requirements.
* **Monitoring / Tests**
  * Added a webhooks performance dashboard and expanded webhook test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #271.
