### PR TITLE
feat(webhooks): discord and slack delivery flavors

### DIFF
--- a/infrastructure/safe_fetch.py
+++ b/infrastructure/safe_fetch.py
@@ -248,6 +248,20 @@ class PostResult:
     status_code: int | None
     error: str | None
     body_snippet: str | None  # first 256 bytes, for the delivery log
+    # Parsed integer Retry-After, when the receiver sent one (429/503 flow
+    # control). HTTP-date form is not parsed — callers fall back to their
+    # own delay.
+    retry_after_seconds: float | None = None
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value.strip())
+    except ValueError:
+        return None
+    return seconds if seconds >= 0 else None
 
 
 async def post_public(
@@ -295,7 +309,12 @@ async def post_public(
                 except (asyncio.TimeoutError, TimeoutError):
                     buf = bytearray()
                 snippet = bytes(buf).decode("utf-8", errors="replace") if buf else None
-                return PostResult(resp.status_code, None, snippet)
+                return PostResult(
+                    resp.status_code,
+                    None,
+                    snippet,
+                    _parse_retry_after(resp.headers.get("retry-after")),
+                )
             finally:
                 await resp.aclose()
     except (httpx.TimeoutException, httpx.TransportError) as exc:

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -72,7 +72,7 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
                     "last_delivery_at": now,
                     "last_success_at": now,
                 },
-                "$inc": {"total_deliveries": 1, "total_successes": 1},
+                "$inc": {"total_successes": 1},
             },
             projection={"dropped_count": 1},
         )
@@ -87,11 +87,17 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
                     "last_delivery_at": datetime.now(timezone.utc),
                     "last_failure_reason": reason,
                 },
-                "$inc": {"total_deliveries": 1, "consecutive_failures": 1},
+                "$inc": {"consecutive_failures": 1},
             },
             return_document=True,
         )
         return int(doc.get("consecutive_failures", 0)) if doc else 0
+
+    async def increment_deliveries(self, endpoint_id: ObjectId, by: int = 1) -> None:
+        """Counted at ENQUEUE, not at terminal state — "0 of 2" while two
+        deliveries are mid-ladder beats a "0 of 0" that contradicts the
+        visible delivery log. Success keeps its own counter."""
+        await self._update({"_id": endpoint_id}, {"$inc": {"total_deliveries": by}})
 
     async def increment_dropped(self, endpoint_id: ObjectId) -> None:
         await self._update({"_id": endpoint_id}, {"$inc": {"dropped_count": 1}})

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -30,6 +30,7 @@ from dependencies.auth import (
     WEBHOOKS_MANAGE_SCOPES,
     WEBHOOKS_READ_SCOPES,
     CurrentUser,
+    JwtVerifiedUser,
     require_scopes_verified,
 )
 from errors import ValidationError
@@ -184,11 +185,14 @@ async def get_endpoint(
 async def reveal_secret(
     request: Request,
     endpoint_id: Annotated[str, Path()],
-    user: ManageUser,
+    user: JwtVerifiedUser,
     webhook_service: WebhookSvc,
 ) -> WebhookSecretResponse:
     """The full signing secret, for the endpoint owner. Secrets are stored
-    encrypted and readable on demand; treat the response like a password."""
+    encrypted and readable on demand; treat the response like a password.
+
+    **Authentication**: Interactive session only — API keys are refused,
+    like every operation that exposes or mints credential material."""
     secret = await webhook_service.reveal_secret(
         _oid(endpoint_id, "endpoint"), user.user_id
     )

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -48,6 +48,7 @@ from schemas.dto.responses.webhook import (
     WebhookEndpointCreatedResponse,
     WebhookEndpointResponse,
     WebhookEndpointsListResponse,
+    WebhookSecretResponse,
 )
 from schemas.enums.webhook import DeliveryStatus
 from services.feature_flag_service import WEBHOOKS_FLAG
@@ -171,6 +172,27 @@ async def get_endpoint(
         _oid(endpoint_id, "endpoint"), user.user_id
     )
     return WebhookEndpointResponse.from_doc(doc)
+
+
+@router.get(
+    "/webhooks/{endpoint_id}/secret",
+    responses={**AUTH_RESPONSES, **ERROR_RESPONSES},
+    operation_id="revealWebhookSecret",
+    summary="Reveal Signing Secret",
+)
+@limiter.limit(Limits.WEBHOOK_READ)
+async def reveal_secret(
+    request: Request,
+    endpoint_id: Annotated[str, Path()],
+    user: ManageUser,
+    webhook_service: WebhookSvc,
+) -> WebhookSecretResponse:
+    """The full signing secret, for the endpoint owner. Secrets are stored
+    encrypted and readable on demand; treat the response like a password."""
+    secret = await webhook_service.reveal_secret(
+        _oid(endpoint_id, "endpoint"), user.user_id
+    )
+    return WebhookSecretResponse(signing_secret=secret)
 
 
 @router.patch(

--- a/schemas/dto/responses/webhook.py
+++ b/schemas/dto/responses/webhook.py
@@ -80,6 +80,12 @@ class WebhookEndpointCreatedResponse(WebhookEndpointResponse):
     )
 
 
+class WebhookSecretResponse(ResponseBase):
+    signing_secret: str = Field(
+        description="The full signing secret, revealed to the endpoint owner."
+    )
+
+
 class WebhookEndpointsListResponse(ResponseBase):
     endpoints: list[WebhookEndpointResponse]
 

--- a/schemas/enums/webhook.py
+++ b/schemas/enums/webhook.py
@@ -22,7 +22,8 @@ class WebhookFlavor(str, Enum):
     versioned contract; other flavors are lossy renderings of it."""
 
     RAW = "raw"
-    # Phase 2: DISCORD = "discord"; SLACK = "slack"
+    DISCORD = "discord"
+    SLACK = "slack"
 
 
 class EndpointDisabledReason(str, Enum):

--- a/services/webhooks/dispatcher.py
+++ b/services/webhooks/dispatcher.py
@@ -98,6 +98,8 @@ class WebhookDispatcher:
             rows.append(make_delivery_row(event_oid, event, endpoint))
 
         await self._delivery_repo.insert_many_rows(rows)
+        for row in rows:
+            await self._endpoint_repo.increment_deliveries(row["endpoint_id"])
         log.info(
             "webhook_dispatched",
             event_type=event.type,

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -44,6 +44,10 @@ USER_AGENT = "spoo.me-webhooks/1.0 (+https://spoo.me)"
 # Standard Webhooks retry convention: immediate, 5s, 5m, 30m, 2h, 5h, 10h.
 RETRY_SCHEDULE_SECONDS = (0, 5, 300, 1800, 7200, 18000, 36000)
 
+# 429 handling: honor Retry-After within a ceiling, else back off a minute.
+RATE_LIMIT_FALLBACK_SECONDS = 60
+RATE_LIMIT_MAX_DEFER_SECONDS = 900
+
 # Type of the on-disable hook — wiring plugs email notification in here so
 # the executor never grows an email dependency.
 OnDisabled = Callable[[WebhookEndpointDoc, str], Awaitable[None]]
@@ -180,6 +184,29 @@ class DeliveryExecutor:
                 is_test=row.is_test,
             )
             return
+
+        if result.status_code == 429 and not single_shot:
+            # Rate limiting is receiver flow control, not endpoint failure —
+            # normal operation for Discord/Slack receivers. Hold the row
+            # without burning a ladder attempt or touching the streak; the
+            # delivery-log TTL is the backstop for a receiver that
+            # rate-limits forever, and the pending cap bounds the queue.
+            delay = int(
+                min(
+                    result.retry_after_seconds or RATE_LIMIT_FALLBACK_SECONDS,
+                    RATE_LIMIT_MAX_DEFER_SECONDS,
+                )
+            )
+            await self._deliveries.defer(row.id, delay_seconds=delay)
+            log.info(
+                "webhook_delivery_rate_limited",
+                endpoint_id=str(endpoint.id),
+                event_type=row.event_type,
+                webhook_id=row.webhook_id,
+                delay_seconds=delay,
+            )
+            return
+
         log.warning(
             "webhook_delivery_attempt_failed",
             endpoint_id=str(endpoint.id),

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -14,6 +14,7 @@ import asyncio
 import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
 
 from infrastructure.crypto import decrypt_secret
 from infrastructure.logging import get_logger
@@ -152,7 +153,7 @@ class DeliveryExecutor:
 
         started = time.monotonic()
         result = await post_public(
-            endpoint.url,
+            self._delivery_url(endpoint),
             body,
             headers=headers,
             timeout=self._timeout,
@@ -255,6 +256,17 @@ class DeliveryExecutor:
         )
 
     # ── Internals ────────────────────────────────────────────────────────
+
+    def _delivery_url(self, endpoint: WebhookEndpointDoc) -> str:
+        """Endpoint URL plus any query params the flavor's renderer
+        declares (Discord's components-v2 bodies need
+        ``with_components=true``). The signature covers the body alone,
+        so delivery mechanics can ride the URL."""
+        renderer = self._renderers.get(endpoint.flavor.value)
+        query = getattr(renderer, "url_query", None)
+        if not query:
+            return endpoint.url
+        return endpoint.url + ("&" if "?" in endpoint.url else "?") + urlencode(query)
 
     async def _render(
         self, row: WebhookDeliveryDoc, endpoint: WebhookEndpointDoc

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -273,8 +273,14 @@ class DeliveryExecutor:
         payload = dict(event.payload)
         if row.dropped_since_last:
             payload["dropped_since_last"] = row.dropped_since_last
+        # Mongo returns naive datetimes; the wire timestamp must carry its
+        # UTC offset or consumers (and Discord's local-time rendering)
+        # can't place it.
         body = renderer.render(
-            event.event_id, event.type, event.occurred_at.isoformat(), payload
+            event.event_id,
+            event.type,
+            as_aware_utc(event.occurred_at).isoformat(),
+            payload,
         )
         if len(body.encode()) > self._max_bytes:
             await self._deliveries.mark_failed(row.id, "payload_over_cap")

--- a/services/webhooks/renderers/__init__.py
+++ b/services/webhooks/renderers/__init__.py
@@ -1,11 +1,23 @@
 """Flavor registry — adding a flavor is a new module + one entry here."""
 
+from services.webhooks.renderers.discord import DiscordRenderer
 from services.webhooks.renderers.protocol import Renderer
 from services.webhooks.renderers.raw import RawRenderer
+from services.webhooks.renderers.slack import SlackRenderer
 
 
 def default_renderers() -> dict[str, Renderer]:
-    return {RawRenderer.flavor: RawRenderer()}
+    return {
+        RawRenderer.flavor: RawRenderer(),
+        DiscordRenderer.flavor: DiscordRenderer(),
+        SlackRenderer.flavor: SlackRenderer(),
+    }
 
 
-__all__ = ["RawRenderer", "Renderer", "default_renderers"]
+__all__ = [
+    "DiscordRenderer",
+    "RawRenderer",
+    "Renderer",
+    "SlackRenderer",
+    "default_renderers",
+]

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -97,7 +97,7 @@ def _title(event_type: str, link: dict[str, Any]) -> str:
     label = EVENT_LABELS.get(event_type, event_type)
     alias, domain = link.get("alias"), link.get("domain")
     if _present(alias) and _present(domain):
-        return f"{label} · {domain}/{alias}"
+        return f"{label}: {domain}/{alias}"
     return label
 
 
@@ -128,29 +128,40 @@ def _age_days(created_at: Any, occurred_at: str) -> int | None:
         return None
 
 
+def _country_display(code: Any) -> str:
+    """ISO alpha-2 → flag emoji + code; anything else passes through."""
+    text = str(code)
+    if len(text) == 2 and text.isascii() and text.isalpha():
+        upper = text.upper()
+        flag = "".join(chr(0x1F1E6 + ord(c) - 65) for c in upper)
+        return f"{flag} {upper}"
+    return text
+
+
 def _clicked_pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
-    """A click always renders at least Device and From — absent analytics
-    dimensions are skipped, but a referrer-less click IS a direct visit
-    and renders as one, never as an empty card."""
+    """One field per dimension — the airy grid IS the point. Absent
+    analytics dimensions are skipped, but a referrer-less click IS a
+    direct visit and the running count is always stated, so a card is
+    never empty."""
     pairs: list[tuple[str, str]] = []
 
-    place = [
-        str(v) for v in (payload.get("city"), payload.get("country")) if _present(v)
-    ]
-    if place:
-        pairs.append(("Location", ", ".join(place)))
-
-    agent = " · ".join(
-        str(payload[k]) for k in ("browser", "os", "device") if _present(payload.get(k))
-    )
-    pairs.append(("Device", agent or "not detected"))
+    if _present(payload.get("country")):
+        pairs.append(("Country", _country_display(payload["country"])))
+    if _present(payload.get("city")):
+        pairs.append(("City", str(payload["city"])))
+    if _present(payload.get("browser")):
+        pairs.append(("Browser", str(payload["browser"])))
+    if _present(payload.get("os")):
+        pairs.append(("OS", str(payload["os"])))
+    if _present(payload.get("device")):
+        pairs.append(("Device", str(payload["device"])))
 
     referrer = payload.get("referrer")
     pairs.append(("From", _referrer_host(referrer) if _present(referrer) else "direct"))
 
     utm = payload.get("utm")
     if isinstance(utm, dict):
-        campaign = " · ".join(str(v) for v in utm.values() if _present(v))
+        campaign = " / ".join(str(v) for v in utm.values() if _present(v))
         if campaign:
             pairs.append(("UTM", campaign))
 
@@ -159,8 +170,9 @@ def _clicked_pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
         pairs.append(("Bot", str(bot) if _present(bot) else "detected"))
 
     total = payload.get("total_clicks")
-    if isinstance(total, int) and total > 0:
-        pairs.append(("Clicks", f"{total:,}"))
+    if isinstance(total, int):
+        # Count at click time — the payload snapshot precedes the increment.
+        pairs.append(("Clicks so far", f"{total:,}"))
 
     return [(name, clip(value, _VALUE_MAX)) for name, value in pairs]
 
@@ -202,10 +214,20 @@ def _lifecycle_pairs(
                 f"{max_clicks:,}" if isinstance(max_clicks, int) else "unlimited",
             )
         )
-        if link.get("password_protected"):
-            pairs.append(("Password", "protected"))
-        if link.get("block_bots"):
-            pairs.append(("Bots", "blocked"))
+        pairs.append(
+            ("Password", "protected" if link.get("password_protected") else "none")
+        )
+        pairs.append(("Bots", "blocked" if link.get("block_bots") else "allowed"))
+        pairs.append(("Meta tags", "custom" if link.get("meta_tags") else "default"))
+        geo = link.get("geo_rules")
+        pairs.append(
+            (
+                "Geo targeting",
+                f"{len(geo)} {'rule' if len(geo) == 1 else 'rules'}"
+                if isinstance(geo, dict) and geo
+                else "none",
+            )
+        )
 
     if event_type in ("link.deleted", "link.expired") and isinstance(total, int):
         pairs.append(("Lifetime clicks", f"{total:,}"))

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -77,9 +77,14 @@ class Copy:
     title_url: str | None
     # ``context`` is the full footer line (brand + time + notice) for flavors
     # without a native timestamp slot; ``notice`` alone is for flavors that
-    # render time themselves (Discord's embed timestamp).
+    # render time themselves.
     context: str
     notice: str | None = None
+    # Title split for flavors that compose their own heading markup, and
+    # the destination as a one-line subtitle for lifecycle events.
+    label: str = ""
+    display: str | None = None
+    subtitle: str | None = None
     lines: list[str] = field(default_factory=list)
     pairs: list[tuple[str, str]] = field(default_factory=list)
     changes: list[tuple[str, str, str]] = field(default_factory=list)
@@ -239,21 +244,88 @@ def _lifecycle_pairs(
     return pairs
 
 
+def clicked_summary(payload: dict[str, Any]) -> tuple[list[str], str | None]:
+    """Grouped one-per-topic lines for vertical layouts (Components V2),
+    plus the running count for the footer."""
+    lines: list[str] = []
+    if _present(payload.get("country")):
+        line = _country_display_bold(payload["country"])
+        if _present(payload.get("city")):
+            line += f"  {payload['city']}"
+        lines.append(line)
+    elif _present(payload.get("city")):
+        lines.append(str(payload["city"]))
+
+    device_bits = [
+        str(payload[k]) for k in ("browser", "os") if _present(payload.get(k))
+    ]
+    device = " on ".join(device_bits)
+    if _present(payload.get("device")):
+        device = f"{device}, {payload['device']}" if device else str(payload["device"])
+    if device:
+        lines.append(device)
+
+    referrer = payload.get("referrer")
+    source = (
+        f"from **{_referrer_host(referrer)}**" if _present(referrer) else "direct visit"
+    )
+    utm = payload.get("utm")
+    if isinstance(utm, dict):
+        campaign = " / ".join(str(v) for v in utm.values() if _present(v))
+        if campaign:
+            source += f"  ({campaign})"
+    lines.append(source)
+
+    if payload.get("is_bot"):
+        bot = payload.get("bot_name")
+        lines.append(f"bot  **{bot}**" if _present(bot) else "bot traffic")
+
+    total = payload.get("total_clicks")
+    count = f"{total:,}" if isinstance(total, int) else None
+    return [clip(line, _VALUE_MAX) for line in lines], count
+
+
+def _country_display_bold(code: Any) -> str:
+    text = str(code)
+    if len(text) == 2 and text.isascii() and text.isalpha():
+        upper = text.upper()
+        flag = "".join(chr(0x1F1E6 + ord(c) - 65) for c in upper)
+        return f"{flag} **{upper}**"
+    return str(code)
+
+
 def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy:
     link = _link_of(event_type, payload)
     title = _title(event_type, link)
     url = link.get("short_url") if _present(link.get("short_url")) else None
     notice = _notice(payload)
     context = f"spoo.me · {timestamp}" + (f" · {notice}" if notice else "")
+    label = EVENT_LABELS.get(event_type, event_type)
+    display = (
+        f"{link.get('domain')}/{link.get('alias')}"
+        if _present(link.get("alias")) and _present(link.get("domain"))
+        else None
+    )
+    subtitle = (
+        str(link.get("long_url"))
+        if event_type in ("link.created", "link.deleted", "link.expired")
+        and _present(link.get("long_url"))
+        else None
+    )
 
+    common = dict(label=label, display=display, subtitle=subtitle)
     if event_type == "link.clicked":
-        return Copy(title, url, context, notice, pairs=_clicked_pairs(payload))
+        return Copy(
+            title, url, context, notice, pairs=_clicked_pairs(payload), **common
+        )
     if event_type == "webhook.test":
         message = payload.get("message")
         lines = [clip(str(message), _VALUE_MAX)] if _present(message) else []
-        return Copy(title, url, context, notice, lines=lines)
+        return Copy(title, url, context, notice, lines=lines, **common)
     if event_type == "link.updated":
-        return Copy(title, url, context, notice, changes=_updated_changes(payload))
+        return Copy(
+            title, url, context, notice, changes=_updated_changes(payload), **common
+        )
     if event_type in ("link.created", "link.deleted", "link.expired"):
         return Copy(
             title,
@@ -261,8 +333,9 @@ def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy
             context,
             notice,
             pairs=_lifecycle_pairs(event_type, payload, timestamp),
+            **common,
         )
 
     shown = {k: v for k, v in payload.items() if k != "dropped_since_last"}
     code = clip(json.dumps(shown, separators=(",", ":"), default=str), _CODE_MAX)
-    return Copy(title, url, context, notice, code=code)
+    return Copy(title, url, context, notice, code=code, **common)

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -14,6 +14,7 @@ flavored endpoint.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -244,54 +245,66 @@ def _lifecycle_pairs(
     return pairs
 
 
-def clicked_summary(payload: dict[str, Any]) -> tuple[list[str], str | None]:
+def clicked_summary(
+    payload: dict[str, Any], escape: Callable[[str], str] | None = None
+) -> tuple[list[str], str | None]:
     """Grouped one-per-topic lines for vertical layouts (Components V2),
-    plus the running count for the footer."""
+    plus the running count for the footer.
+
+    ``escape`` runs on every payload-derived value BEFORE this function
+    adds its own markup. These values are visitor-controlled (the
+    referrer above all): a flavor whose text renders markup must
+    neutralize them, or a crafted Referer header plants live markdown in
+    the subscriber's channel."""
+    esc = escape or (lambda s: s)
     lines: list[str] = []
     if _present(payload.get("country")):
-        line = _country_display_bold(payload["country"])
+        line = _country_display_bold(payload["country"], esc)
         if _present(payload.get("city")):
-            line += f"  {payload['city']}"
+            line += f"  {esc(str(payload['city']))}"
         lines.append(line)
     elif _present(payload.get("city")):
-        lines.append(str(payload["city"]))
+        lines.append(esc(str(payload["city"])))
 
     device_bits = [
-        str(payload[k]) for k in ("browser", "os") if _present(payload.get(k))
+        esc(str(payload[k])) for k in ("browser", "os") if _present(payload.get(k))
     ]
     device = " on ".join(device_bits)
     if _present(payload.get("device")):
-        device = f"{device}, {payload['device']}" if device else str(payload["device"])
+        part = esc(str(payload["device"]))
+        device = f"{device}, {part}" if device else part
     if device:
         lines.append(device)
 
     referrer = payload.get("referrer")
     source = (
-        f"from **{_referrer_host(referrer)}**" if _present(referrer) else "direct visit"
+        f"from **{esc(_referrer_host(referrer))}**"
+        if _present(referrer)
+        else "direct visit"
     )
     utm = payload.get("utm")
     if isinstance(utm, dict):
-        campaign = " / ".join(str(v) for v in utm.values() if _present(v))
+        campaign = " / ".join(esc(str(v)) for v in utm.values() if _present(v))
         if campaign:
             source += f"  ({campaign})"
     lines.append(source)
 
     if payload.get("is_bot"):
         bot = payload.get("bot_name")
-        lines.append(f"bot  **{bot}**" if _present(bot) else "bot traffic")
+        lines.append(f"bot  **{esc(str(bot))}**" if _present(bot) else "bot traffic")
 
     total = payload.get("total_clicks")
     count = f"{total:,}" if isinstance(total, int) else None
     return [clip(line, _VALUE_MAX) for line in lines], count
 
 
-def _country_display_bold(code: Any) -> str:
+def _country_display_bold(code: Any, esc: Callable[[str], str]) -> str:
     text = str(code)
     if len(text) == 2 and text.isascii() and text.isalpha():
         upper = text.upper()
         flag = "".join(chr(0x1F1E6 + ord(c) - 65) for c in upper)
         return f"{flag} **{upper}**"
-    return str(code)
+    return esc(str(code))
 
 
 def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy:

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -1,9 +1,11 @@
 """Shared copy for the lossy flavors — one place decides wording and which
 fields earn space, so Discord and Slack never drift apart.
 
-Density is frequency-aware: ``link.clicked`` (high frequency) renders as a
-few compact lines that read well as a stream; lifecycle events (rare)
-render as label/value pairs. Event types this module does not know —
+Every event renders as label/value pairs with guaranteed substance: a
+click always carries Device and From (a referrer-less click is a
+"direct" visit, not a blank), and lifecycle cards state "never" and
+"unlimited" as the real answers they are. Event types this module does
+not know —
 including every future addition to the registry — fall back to the payload
 as a JSON code block, so adding an event can never terminal-fail a
 flavored endpoint.
@@ -13,6 +15,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
@@ -112,35 +115,54 @@ def _referrer_host(referrer: Any) -> str:
     return host or text
 
 
-def _clicked_lines(payload: dict[str, Any]) -> list[str]:
-    lines: list[str] = []
+def _date_part(value: Any) -> str:
+    return str(value)[:10] if _present(value) else "never"
+
+
+def _age_days(created_at: Any, occurred_at: str) -> int | None:
+    try:
+        created = datetime.fromisoformat(str(created_at))
+        occurred = datetime.fromisoformat(occurred_at)
+        return max(0, (occurred - created).days)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clicked_pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
+    """A click always renders at least Device and From — absent analytics
+    dimensions are skipped, but a referrer-less click IS a direct visit
+    and renders as one, never as an empty card."""
+    pairs: list[tuple[str, str]] = []
 
     place = [
         str(v) for v in (payload.get("city"), payload.get("country")) if _present(v)
     ]
-    agent = ""
-    if _present(payload.get("browser")) and _present(payload.get("os")):
-        agent = f"{payload['browser']} on {payload['os']}"
-    elif _present(payload.get("browser")):
-        agent = str(payload["browser"])
-    first = " · ".join(part for part in (", ".join(place), agent) if part)
-    if first:
-        lines.append(first)
+    if place:
+        pairs.append(("Location", ", ".join(place)))
 
-    second: list[str] = []
-    if _present(payload.get("referrer")):
-        second.append(f"from {_referrer_host(payload['referrer'])}")
-    total = payload.get("total_clicks")
-    if isinstance(total, int):
-        second.append(f"click #{total:,}")
-    if second:
-        lines.append(" · ".join(second))
+    agent = " · ".join(
+        str(payload[k]) for k in ("browser", "os", "device") if _present(payload.get(k))
+    )
+    pairs.append(("Device", agent or "not detected"))
+
+    referrer = payload.get("referrer")
+    pairs.append(("From", _referrer_host(referrer) if _present(referrer) else "direct"))
+
+    utm = payload.get("utm")
+    if isinstance(utm, dict):
+        campaign = " · ".join(str(v) for v in utm.values() if _present(v))
+        if campaign:
+            pairs.append(("UTM", campaign))
 
     if payload.get("is_bot"):
         bot = payload.get("bot_name")
-        lines.append(f"bot · {bot}" if _present(bot) else "bot traffic")
+        pairs.append(("Bot", str(bot) if _present(bot) else "detected"))
 
-    return [clip(line, _VALUE_MAX) for line in lines] or ["Tracked click recorded"]
+    total = payload.get("total_clicks")
+    if isinstance(total, int) and total > 0:
+        pairs.append(("Clicks", f"{total:,}"))
+
+    return [(name, clip(value, _VALUE_MAX)) for name, value in pairs]
 
 
 def _updated_changes(payload: dict[str, Any]) -> list[tuple[str, str, str]]:
@@ -155,9 +177,14 @@ def _updated_changes(payload: dict[str, Any]) -> list[tuple[str, str, str]]:
     return out
 
 
-def _lifecycle_pairs(event_type: str, payload: dict[str, Any]) -> list[tuple[str, str]]:
+def _lifecycle_pairs(
+    event_type: str, payload: dict[str, Any], occurred_at: str
+) -> list[tuple[str, str]]:
+    """Lifecycle cards lead with facts that always exist — an expiry of
+    "never" and a cap of "unlimited" are real answers, not blanks."""
     link = _link_of(event_type, payload)
     pairs: list[tuple[str, str]] = []
+    total = link.get("total_clicks")
 
     if event_type == "link.expired":
         reason = payload.get("reason")
@@ -165,17 +192,27 @@ def _lifecycle_pairs(event_type: str, payload: dict[str, Any]) -> list[tuple[str
 
     if _present(link.get("long_url")):
         pairs.append(("Destination", _fmt(link["long_url"])))
+
     if event_type == "link.created":
-        if _present(link.get("expires_at")):
-            pairs.append(("Expires", _fmt(link["expires_at"])))
-        if _present(link.get("max_clicks")):
-            pairs.append(("Max clicks", _fmt(link["max_clicks"])))
+        pairs.append(("Expires", _date_part(link.get("expires_at"))))
+        max_clicks = link.get("max_clicks")
+        pairs.append(
+            (
+                "Max clicks",
+                f"{max_clicks:,}" if isinstance(max_clicks, int) else "unlimited",
+            )
+        )
         if link.get("password_protected"):
-            pairs.append(("Password protected", "yes"))
-    if event_type in ("link.deleted", "link.expired") and isinstance(
-        link.get("total_clicks"), int
-    ):
-        pairs.append(("Total clicks", f"{link['total_clicks']:,}"))
+            pairs.append(("Password", "protected"))
+        if link.get("block_bots"):
+            pairs.append(("Bots", "blocked"))
+
+    if event_type in ("link.deleted", "link.expired") and isinstance(total, int):
+        pairs.append(("Lifetime clicks", f"{total:,}"))
+    if event_type == "link.deleted":
+        age = _age_days(link.get("created_at"), occurred_at)
+        if age is not None:
+            pairs.append(("Age", f"{age:,} days" if age != 1 else "1 day"))
 
     return pairs
 
@@ -188,7 +225,7 @@ def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy
     context = f"spoo.me · {timestamp}" + (f" · {notice}" if notice else "")
 
     if event_type == "link.clicked":
-        return Copy(title, url, context, notice, lines=_clicked_lines(payload))
+        return Copy(title, url, context, notice, pairs=_clicked_pairs(payload))
     if event_type == "webhook.test":
         message = payload.get("message")
         lines = [clip(str(message), _VALUE_MAX)] if _present(message) else []
@@ -197,7 +234,11 @@ def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy
         return Copy(title, url, context, notice, changes=_updated_changes(payload))
     if event_type in ("link.created", "link.deleted", "link.expired"):
         return Copy(
-            title, url, context, notice, pairs=_lifecycle_pairs(event_type, payload)
+            title,
+            url,
+            context,
+            notice,
+            pairs=_lifecycle_pairs(event_type, payload, timestamp),
         )
 
     shown = {k: v for k, v in payload.items() if k != "dropped_since_last"}

--- a/services/webhooks/renderers/copy.py
+++ b/services/webhooks/renderers/copy.py
@@ -1,0 +1,205 @@
+"""Shared copy for the lossy flavors — one place decides wording and which
+fields earn space, so Discord and Slack never drift apart.
+
+Density is frequency-aware: ``link.clicked`` (high frequency) renders as a
+few compact lines that read well as a stream; lifecycle events (rare)
+render as label/value pairs. Event types this module does not know —
+including every future addition to the registry — fall back to the payload
+as a JSON code block, so adding an event can never terminal-fail a
+flavored endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+EVENT_LABELS = {
+    "link.created": "Link created",
+    "link.updated": "Link updated",
+    "link.deleted": "Link deleted",
+    "link.expired": "Link expired",
+    "link.clicked": "Click",
+    "webhook.test": "Test delivery",
+}
+
+_EXPIRY_REASONS = {
+    "max_clicks_reached": "Max clicks reached",
+    "time_expired": "Expiry time passed",
+}
+
+# Analytics sentinels are for querying, not for humans — a dimension that
+# resolved to one renders as absent, same as None.
+_SENTINELS = {"", "unknown", "(none)"}
+
+_VALUE_MAX = 512  # per rendered value; receivers cap harder, this is copy-level
+_CODE_MAX = 1_500  # fallback JSON block
+
+
+def clip(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _present(value: Any) -> bool:
+    if value is None:
+        return False
+    return not (isinstance(value, str) and value.strip().lower() in _SENTINELS)
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (dict, list)):
+        return clip(json.dumps(value, separators=(",", ":"), default=str), _VALUE_MAX)
+    return clip(str(value), _VALUE_MAX)
+
+
+@dataclass(frozen=True)
+class Copy:
+    """Flavor-neutral content. Exactly one of ``lines`` / ``pairs`` /
+    ``changes`` / ``code`` is populated (compact, field grid, old/new
+    change set, or fallback code block).
+
+    ``changes`` stays structured — (field, old, new) — because flavors
+    disagree on the best rendering: Discord has colored diff blocks,
+    Slack only has plain pairs."""
+
+    title: str
+    title_url: str | None
+    # ``context`` is the full footer line (brand + time + notice) for flavors
+    # without a native timestamp slot; ``notice`` alone is for flavors that
+    # render time themselves (Discord's embed timestamp).
+    context: str
+    notice: str | None = None
+    lines: list[str] = field(default_factory=list)
+    pairs: list[tuple[str, str]] = field(default_factory=list)
+    changes: list[tuple[str, str, str]] = field(default_factory=list)
+    code: str | None = None
+
+
+def _link_of(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    if event_type == "link.clicked":
+        return payload
+    link = payload.get("link")
+    return link if isinstance(link, dict) else {}
+
+
+def _title(event_type: str, link: dict[str, Any]) -> str:
+    label = EVENT_LABELS.get(event_type, event_type)
+    alias, domain = link.get("alias"), link.get("domain")
+    if _present(alias) and _present(domain):
+        return f"{label} · {domain}/{alias}"
+    return label
+
+
+def _notice(payload: dict[str, Any]) -> str | None:
+    dropped = payload.get("dropped_since_last")
+    if isinstance(dropped, int) and dropped > 0:
+        plural = "delivery" if dropped == 1 else "deliveries"
+        return f"{dropped} earlier {plural} dropped"
+    return None
+
+
+def _referrer_host(referrer: Any) -> str:
+    text = str(referrer)
+    host = urlparse(text).netloc
+    return host or text
+
+
+def _clicked_lines(payload: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+
+    place = [
+        str(v) for v in (payload.get("city"), payload.get("country")) if _present(v)
+    ]
+    agent = ""
+    if _present(payload.get("browser")) and _present(payload.get("os")):
+        agent = f"{payload['browser']} on {payload['os']}"
+    elif _present(payload.get("browser")):
+        agent = str(payload["browser"])
+    first = " · ".join(part for part in (", ".join(place), agent) if part)
+    if first:
+        lines.append(first)
+
+    second: list[str] = []
+    if _present(payload.get("referrer")):
+        second.append(f"from {_referrer_host(payload['referrer'])}")
+    total = payload.get("total_clicks")
+    if isinstance(total, int):
+        second.append(f"click #{total:,}")
+    if second:
+        lines.append(" · ".join(second))
+
+    if payload.get("is_bot"):
+        bot = payload.get("bot_name")
+        lines.append(f"bot · {bot}" if _present(bot) else "bot traffic")
+
+    return [clip(line, _VALUE_MAX) for line in lines] or ["Tracked click recorded"]
+
+
+def _updated_changes(payload: dict[str, Any]) -> list[tuple[str, str, str]]:
+    changes = payload.get("changes")
+    if not isinstance(changes, dict):
+        return []
+    out: list[tuple[str, str, str]] = []
+    for name, change in changes.items():
+        old = _fmt(change.get("old")) if isinstance(change, dict) else _fmt(None)
+        new = _fmt(change.get("new")) if isinstance(change, dict) else _fmt(change)
+        out.append((str(name), old, new))
+    return out
+
+
+def _lifecycle_pairs(event_type: str, payload: dict[str, Any]) -> list[tuple[str, str]]:
+    link = _link_of(event_type, payload)
+    pairs: list[tuple[str, str]] = []
+
+    if event_type == "link.expired":
+        reason = payload.get("reason")
+        pairs.append(("Reason", _EXPIRY_REASONS.get(reason, _fmt(reason))))
+
+    if _present(link.get("long_url")):
+        pairs.append(("Destination", _fmt(link["long_url"])))
+    if event_type == "link.created":
+        if _present(link.get("expires_at")):
+            pairs.append(("Expires", _fmt(link["expires_at"])))
+        if _present(link.get("max_clicks")):
+            pairs.append(("Max clicks", _fmt(link["max_clicks"])))
+        if link.get("password_protected"):
+            pairs.append(("Password protected", "yes"))
+    if event_type in ("link.deleted", "link.expired") and isinstance(
+        link.get("total_clicks"), int
+    ):
+        pairs.append(("Total clicks", f"{link['total_clicks']:,}"))
+
+    return pairs
+
+
+def build_copy(event_type: str, timestamp: str, payload: dict[str, Any]) -> Copy:
+    link = _link_of(event_type, payload)
+    title = _title(event_type, link)
+    url = link.get("short_url") if _present(link.get("short_url")) else None
+    notice = _notice(payload)
+    context = f"spoo.me · {timestamp}" + (f" · {notice}" if notice else "")
+
+    if event_type == "link.clicked":
+        return Copy(title, url, context, notice, lines=_clicked_lines(payload))
+    if event_type == "webhook.test":
+        message = payload.get("message")
+        lines = [clip(str(message), _VALUE_MAX)] if _present(message) else []
+        return Copy(title, url, context, notice, lines=lines)
+    if event_type == "link.updated":
+        return Copy(title, url, context, notice, changes=_updated_changes(payload))
+    if event_type in ("link.created", "link.deleted", "link.expired"):
+        return Copy(
+            title, url, context, notice, pairs=_lifecycle_pairs(event_type, payload)
+        )
+
+    shown = {k: v for k, v in payload.items() if k != "dropped_since_last"}
+    code = clip(json.dumps(shown, separators=(",", ":"), default=str), _CODE_MAX)
+    return Copy(title, url, context, notice, code=code)

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -1,17 +1,23 @@
-"""Discord flavor — one embed per event, ready for a Discord webhook URL.
+"""Discord flavor — a Components V2 message, ready for a channel webhook.
 
-Receiver limits enforced locally (title 256, description 4096, field
-name 256 / value 1024, footer 2048, 6000 chars across the embed) so a
-rendered body is never rejected for size by Discord itself; the engine's
-max_payload_bytes cap still applies on top.
+The rendered body is a components-only message (flag 32768): one
+accent-colored container holding a heading, a divider, the event's
+substance, and a small-text footer with a timestamp Discord localizes
+per viewer (``<t:...>``). Delivery must carry ``with_components=true``
+on the webhook URL — declared here via ``url_query`` and appended by
+the executor, since the signature covers the body alone.
+
+Mentions are hard-disabled: text displays CAN ping (embeds never
+could), and payload values are user-controlled.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
+from datetime import datetime
+from typing import Any, ClassVar
 
-from services.webhooks.renderers.copy import build_copy, clip
+from services.webhooks.renderers.copy import build_copy, clicked_summary, clip
 
 _COLORS = {
     "link.created": 0x43B581,
@@ -25,12 +31,27 @@ _DEFAULT_COLOR = 0x99AAB5
 
 AVATAR_URL = "https://spoo.me/static/images/favicon.png"
 
-_TITLE_MAX = 256
-_DESCRIPTION_MAX = 4096
-_FIELD_NAME_MAX = 256
-_FIELD_VALUE_MAX = 1024
-_FOOTER_MAX = 2048
-_EMBED_TOTAL_MAX = 6000
+# Footer verb per event; ``f`` renders an absolute local time, ``R`` a
+# live relative one — moments for high-frequency events, dates for rare.
+_FOOTERS = {
+    "link.clicked": ("click", "R"),
+    "link.created": ("created", "f"),
+    "link.updated": ("updated", "R"),
+    "link.deleted": ("deleted", "f"),
+    "link.expired": ("expired", "R"),
+    "webhook.test": ("sent", "R"),
+}
+
+_TEXT_MAX = 3_500  # defensive budget across all text displays
+_SUBTITLE_MAX = 200
+
+
+def _td(content: str) -> dict[str, Any]:
+    return {"type": 10, "content": content}
+
+
+def _sep(spacing: int = 1, divider: bool = False) -> dict[str, Any]:
+    return {"type": 14, "spacing": spacing, "divider": divider}
 
 
 def _fence(text: str) -> str:
@@ -38,91 +59,98 @@ def _fence(text: str) -> str:
     return text.replace("```", "'''")
 
 
-def _embed_size(embed: dict[str, Any]) -> int:
-    total = len(embed.get("title", "")) + len(embed.get("description", ""))
-    total += len(embed.get("footer", {}).get("text", ""))
-    for field in embed.get("fields", []):
-        total += len(field["name"]) + len(field["value"])
-    return total
-
-
 class DiscordRenderer:
     flavor = "discord"
+    # Appended to the endpoint URL at delivery time; components-v2 bodies
+    # are rejected without it.
+    url_query: ClassVar[dict[str, str]] = {"with_components": "true"}
 
     def render(
         self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
     ) -> str:
         copy = build_copy(event_type, timestamp, payload)
+        try:
+            epoch = int(datetime.fromisoformat(timestamp).timestamp())
+        except ValueError:
+            epoch = None
 
-        # The webhook's own username and avatar carry the brand, and the
-        # embed timestamp renders natively in the viewer's timezone — the
-        # footer exists only for the drop notice.
-        embed: dict[str, Any] = {
-            "title": clip(copy.title, _TITLE_MAX),
-            "color": _COLORS.get(event_type, _DEFAULT_COLOR),
-            "timestamp": timestamp,
-        }
-        if copy.notice:
-            embed["footer"] = {"text": clip(copy.notice, _FOOTER_MAX)}
-        if copy.title_url:
-            embed["url"] = copy.title_url
+        label = copy.label or copy.title
+        components: list[dict[str, Any]] = []
 
-        if copy.changes:
-            # Discord colors diff blocks: removed lines red, added green —
-            # the old/new pair reads at a glance.
+        # Heading: linked short address, except a deleted link has no
+        # living address to point at.
+        if copy.display and copy.title_url and event_type != "link.deleted":
+            components.append(_td(f"### {label}  [{copy.display}]({copy.title_url})"))
+        elif copy.display:
+            components.append(_td(f"### {label}  {copy.display}"))
+        else:
+            components.append(_td(f"### {label}"))
+        if copy.subtitle:
+            components.append(_td(f"-# {clip(copy.subtitle, _SUBTITLE_MAX)}"))
+
+        lifecycle = event_type in ("link.created", "link.deleted", "link.expired")
+        components.append(_sep(2 if lifecycle else 1, divider=True))
+
+        count: str | None = None
+        if event_type == "link.clicked":
+            lines, count = clicked_summary(payload)
+            components.append(_td("\n".join(lines)))
+        elif copy.changes:
             diff_lines: list[str] = []
             for name, old, new in copy.changes:
                 diff_lines.append(f"- {name}: {_fence(old)}")
                 diff_lines.append(f"+ {name}: {_fence(new)}")
-            embed["description"] = clip(
-                "```diff\n" + "\n".join(diff_lines) + "\n```", _DESCRIPTION_MAX
+            components.append(_td("```diff\n" + "\n".join(diff_lines) + "\n```"))
+        elif copy.pairs:
+            components.append(
+                _td(
+                    "\n".join(
+                        f"**{name}**  {value}"
+                        for name, value in copy.pairs
+                        if name != "Destination"  # the subtitle already says it
+                    )
+                )
             )
         elif copy.code:
-            embed["description"] = clip(
-                "```json\n" + _fence(copy.code) + "\n```", _DESCRIPTION_MAX
-            )
+            components.append(_td("```json\n" + _fence(copy.code) + "\n```"))
         elif copy.lines:
-            embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
+            components.append(_td("\n".join(copy.lines)))
 
-        if copy.pairs:
-            # Two facts per row, never Discord's cramped three: a blank
-            # spacer field closes each pair so the grid stays airy. Long
-            # values like destination URLs take the full width up top.
-            fields: list[dict[str, Any]] = []
-            grid: list[tuple[str, str]] = []
-            for name, value in copy.pairs:
-                if name == "Destination" or len(value) > 32:
-                    fields.append(
-                        {
-                            "name": clip(name, _FIELD_NAME_MAX),
-                            "value": clip(value, _FIELD_VALUE_MAX),
-                            "inline": False,
-                        }
-                    )
-                else:
-                    grid.append((name, value))
-            for i, (name, value) in enumerate(grid):
-                fields.append(
-                    {
-                        "name": clip(name, _FIELD_NAME_MAX),
-                        "value": clip(value, _FIELD_VALUE_MAX),
-                        "inline": True,
-                    }
-                )
-                if i % 2 == 1 and i < len(grid) - 1:
-                    fields.append({"name": "\u200b", "value": "\u200b", "inline": True})
-            embed["fields"] = fields
+        components.append(_sep(2))
+        verb, style = _FOOTERS.get(event_type, ("received", "f"))
+        footer = f"-# {verb}"
+        if event_type == "link.clicked" and count is not None:
+            footer += f" {count}"
+        if epoch is not None:
+            footer += f"   <t:{epoch}:{style}>"
+        if copy.notice:
+            footer += f"\n-# {copy.notice}"
+        components.append(_td(footer))
 
-        while _embed_size(embed) > _EMBED_TOTAL_MAX and embed.get("fields"):
-            embed["fields"].pop()
-        if _embed_size(embed) > _EMBED_TOTAL_MAX and "description" in embed:
-            overflow = _embed_size(embed) - _EMBED_TOTAL_MAX
-            embed["description"] = clip(
-                embed["description"], max(1, len(embed["description"]) - overflow)
+        # Defensive budget: receivers reject oversize messages whole, so a
+        # pathological body gets its largest block clipped instead.
+        total = sum(len(c.get("content", "")) for c in components)
+        if total > _TEXT_MAX:
+            biggest = max(components, key=lambda c: len(c.get("content", "")))
+            overflow = total - _TEXT_MAX
+            biggest["content"] = clip(
+                biggest["content"], max(1, len(biggest["content"]) - overflow)
             )
 
         return json.dumps(
-            {"username": "spoo.me", "avatar_url": AVATAR_URL, "embeds": [embed]},
+            {
+                "username": "spoo.me",
+                "avatar_url": AVATAR_URL,
+                "flags": 32768,
+                "allowed_mentions": {"parse": []},
+                "components": [
+                    {
+                        "type": 17,
+                        "accent_color": _COLORS.get(event_type, _DEFAULT_COLOR),
+                        "components": components,
+                    }
+                ],
+            },
             separators=(",", ":"),
             default=str,
         )

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -54,6 +54,22 @@ def _sep(spacing: int = 1, divider: bool = False) -> dict[str, Any]:
     return {"type": 14, "spacing": spacing, "divider": divider}
 
 
+_MARKDOWN_CHARS = set("\\`*_~|>#[]()")
+
+
+def _md(text: str) -> str:
+    """Backslash-escape Discord markdown in user-derived text. Payload
+    values reach live text displays, and text displays render markup —
+    without this a crafted Referer header plants a clickable masked link
+    in the subscriber's channel."""
+    return "".join("\\" + ch if ch in _MARKDOWN_CHARS else ch for ch in text)
+
+
+def _link_target(url: str) -> str:
+    # Parentheses inside a masked-link target close the link early.
+    return url.replace("(", "%28").replace(")", "%29")
+
+
 def _fence(text: str) -> str:
     # A value containing ``` would break out of the block.
     return text.replace("```", "'''")
@@ -80,20 +96,25 @@ class DiscordRenderer:
         # Heading: linked short address, except a deleted link has no
         # living address to point at.
         if copy.display and copy.title_url and event_type != "link.deleted":
-            components.append(_td(f"### {label}  [{copy.display}]({copy.title_url})"))
+            components.append(
+                _td(
+                    f"### {_md(label)}  "
+                    f"[{_md(copy.display)}]({_link_target(copy.title_url)})"
+                )
+            )
         elif copy.display:
-            components.append(_td(f"### {label}  {copy.display}"))
+            components.append(_td(f"### {_md(label)}  {_md(copy.display)}"))
         else:
-            components.append(_td(f"### {label}"))
+            components.append(_td(f"### {_md(label)}"))
         if copy.subtitle:
-            components.append(_td(f"-# {clip(copy.subtitle, _SUBTITLE_MAX)}"))
+            components.append(_td(f"-# {_md(clip(copy.subtitle, _SUBTITLE_MAX))}"))
 
         lifecycle = event_type in ("link.created", "link.deleted", "link.expired")
         components.append(_sep(2 if lifecycle else 1, divider=True))
 
         count: str | None = None
         if event_type == "link.clicked":
-            lines, count = clicked_summary(payload)
+            lines, count = clicked_summary(payload, escape=_md)
             components.append(_td("\n".join(lines)))
         elif copy.changes:
             diff_lines: list[str] = []
@@ -105,7 +126,7 @@ class DiscordRenderer:
             components.append(
                 _td(
                     "\n".join(
-                        f"**{name}**  {value}"
+                        f"**{name}**  {_md(value)}"
                         for name, value in copy.pairs
                         if name != "Destination"  # the subtitle already says it
                     )
@@ -114,7 +135,7 @@ class DiscordRenderer:
         elif copy.code:
             components.append(_td("```json\n" + _fence(copy.code) + "\n```"))
         elif copy.lines:
-            components.append(_td("\n".join(copy.lines)))
+            components.append(_td("\n".join(_md(line) for line in copy.lines)))
 
         components.append(_sep(2))
         verb, style = _FOOTERS.get(event_type, ("received", "f"))

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -23,6 +23,8 @@ _COLORS = {
 }
 _DEFAULT_COLOR = 0x99AAB5
 
+AVATAR_URL = "https://spoo.me/static/images/favicon.png"
+
 _TITLE_MAX = 256
 _DESCRIPTION_MAX = 4096
 _FIELD_NAME_MAX = 256
@@ -52,15 +54,16 @@ class DiscordRenderer:
     ) -> str:
         copy = build_copy(event_type, timestamp, payload)
 
-        # Discord renders the embed timestamp natively, so the footer skips
-        # the time (unlike Slack's context line).
-        footer = "spoo.me" + (f" · {copy.notice}" if copy.notice else "")
+        # The webhook's own username and avatar carry the brand, and the
+        # embed timestamp renders natively in the viewer's timezone — the
+        # footer exists only for the drop notice.
         embed: dict[str, Any] = {
             "title": clip(copy.title, _TITLE_MAX),
             "color": _COLORS.get(event_type, _DEFAULT_COLOR),
             "timestamp": timestamp,
-            "footer": {"text": clip(footer, _FOOTER_MAX)},
         }
+        if copy.notice:
+            embed["footer"] = {"text": clip(copy.notice, _FOOTER_MAX)}
         if copy.title_url:
             embed["url"] = copy.title_url
 
@@ -82,16 +85,33 @@ class DiscordRenderer:
             embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
 
         if copy.pairs:
-            # Short facts sit side by side (Discord flows three per row);
-            # long values like destination URLs take the full width.
-            embed["fields"] = [
-                {
-                    "name": clip(name, _FIELD_NAME_MAX),
-                    "value": clip(value, _FIELD_VALUE_MAX),
-                    "inline": name != "Destination" and len(value) <= 32,
-                }
-                for name, value in copy.pairs
-            ]
+            # Two facts per row, never Discord's cramped three: a blank
+            # spacer field closes each pair so the grid stays airy. Long
+            # values like destination URLs take the full width up top.
+            fields: list[dict[str, Any]] = []
+            grid: list[tuple[str, str]] = []
+            for name, value in copy.pairs:
+                if name == "Destination" or len(value) > 32:
+                    fields.append(
+                        {
+                            "name": clip(name, _FIELD_NAME_MAX),
+                            "value": clip(value, _FIELD_VALUE_MAX),
+                            "inline": False,
+                        }
+                    )
+                else:
+                    grid.append((name, value))
+            for i, (name, value) in enumerate(grid):
+                fields.append(
+                    {
+                        "name": clip(name, _FIELD_NAME_MAX),
+                        "value": clip(value, _FIELD_VALUE_MAX),
+                        "inline": True,
+                    }
+                )
+                if i % 2 == 1 and i < len(grid) - 1:
+                    fields.append({"name": "\u200b", "value": "\u200b", "inline": True})
+            embed["fields"] = fields
 
         while _embed_size(embed) > _EMBED_TOTAL_MAX and embed.get("fields"):
             embed["fields"].pop()
@@ -102,7 +122,7 @@ class DiscordRenderer:
             )
 
         return json.dumps(
-            {"username": "spoo.me", "embeds": [embed]},
+            {"username": "spoo.me", "avatar_url": AVATAR_URL, "embeds": [embed]},
             separators=(",", ":"),
             default=str,
         )

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -1,0 +1,106 @@
+"""Discord flavor — one embed per event, ready for a Discord webhook URL.
+
+Receiver limits enforced locally (title 256, description 4096, field
+name 256 / value 1024, footer 2048, 6000 chars across the embed) so a
+rendered body is never rejected for size by Discord itself; the engine's
+max_payload_bytes cap still applies on top.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from services.webhooks.renderers.copy import build_copy, clip
+
+_COLORS = {
+    "link.created": 0x43B581,
+    "link.updated": 0x5865F2,
+    "link.deleted": 0xF04747,
+    "link.expired": 0xE67E22,
+    "link.clicked": 0x99AAB5,
+    "webhook.test": 0x99AAB5,
+}
+_DEFAULT_COLOR = 0x99AAB5
+
+_TITLE_MAX = 256
+_DESCRIPTION_MAX = 4096
+_FIELD_NAME_MAX = 256
+_FIELD_VALUE_MAX = 1024
+_FOOTER_MAX = 2048
+_EMBED_TOTAL_MAX = 6000
+
+
+def _fence(text: str) -> str:
+    # A value containing ``` would break out of the block.
+    return text.replace("```", "'''")
+
+
+def _embed_size(embed: dict[str, Any]) -> int:
+    total = len(embed.get("title", "")) + len(embed.get("description", ""))
+    total += len(embed.get("footer", {}).get("text", ""))
+    for field in embed.get("fields", []):
+        total += len(field["name"]) + len(field["value"])
+    return total
+
+
+class DiscordRenderer:
+    flavor = "discord"
+
+    def render(
+        self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
+    ) -> str:
+        copy = build_copy(event_type, timestamp, payload)
+
+        # Discord renders the embed timestamp natively, so the footer skips
+        # the time (unlike Slack's context line).
+        footer = "spoo.me" + (f" · {copy.notice}" if copy.notice else "")
+        embed: dict[str, Any] = {
+            "title": clip(copy.title, _TITLE_MAX),
+            "color": _COLORS.get(event_type, _DEFAULT_COLOR),
+            "timestamp": timestamp,
+            "footer": {"text": clip(footer, _FOOTER_MAX)},
+        }
+        if copy.title_url:
+            embed["url"] = copy.title_url
+
+        if copy.changes:
+            # Discord colors diff blocks: removed lines red, added green —
+            # the old/new pair reads at a glance.
+            diff_lines: list[str] = []
+            for name, old, new in copy.changes:
+                diff_lines.append(f"- {name}: {_fence(old)}")
+                diff_lines.append(f"+ {name}: {_fence(new)}")
+            embed["description"] = clip(
+                "```diff\n" + "\n".join(diff_lines) + "\n```", _DESCRIPTION_MAX
+            )
+        elif copy.code:
+            embed["description"] = clip(
+                "```json\n" + _fence(copy.code) + "\n```", _DESCRIPTION_MAX
+            )
+        elif copy.lines:
+            embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
+
+        if copy.pairs:
+            embed["fields"] = [
+                {
+                    "name": clip(name, _FIELD_NAME_MAX),
+                    "value": clip(value, _FIELD_VALUE_MAX),
+                    "inline": False,
+                }
+                for name, value in copy.pairs
+            ]
+
+        while _embed_size(embed) > _EMBED_TOTAL_MAX and embed.get("fields"):
+            embed["fields"].pop()
+        if _embed_size(embed) > _EMBED_TOTAL_MAX and "description" in embed:
+            overflow = _embed_size(embed) - _EMBED_TOTAL_MAX
+            embed["description"] = clip(
+                embed["description"], max(1, len(embed["description"]) - overflow)
+            )
+
+        return json.dumps(
+            {"username": "spoo.me", "embeds": [embed]},
+            separators=(",", ":"),
+            default=str,
+        )

--- a/services/webhooks/renderers/discord.py
+++ b/services/webhooks/renderers/discord.py
@@ -82,11 +82,13 @@ class DiscordRenderer:
             embed["description"] = clip("\n".join(copy.lines), _DESCRIPTION_MAX)
 
         if copy.pairs:
+            # Short facts sit side by side (Discord flows three per row);
+            # long values like destination URLs take the full width.
             embed["fields"] = [
                 {
                     "name": clip(name, _FIELD_NAME_MAX),
                     "value": clip(value, _FIELD_VALUE_MAX),
-                    "inline": False,
+                    "inline": name != "Destination" and len(value) <= 32,
                 }
                 for name, value in copy.pairs
             ]

--- a/services/webhooks/renderers/protocol.py
+++ b/services/webhooks/renderers/protocol.py
@@ -12,6 +12,10 @@ from typing import Any, Protocol
 
 
 class Renderer(Protocol):
+    # Optional: query params the executor appends to the endpoint URL at
+    # delivery time (e.g. Discord's ``with_components=true``). Absent or
+    # empty means the URL is used as stored.
+
     flavor: str
 
     def render(

--- a/services/webhooks/renderers/slack.py
+++ b/services/webhooks/renderers/slack.py
@@ -1,0 +1,96 @@
+"""Slack flavor — Block Kit body for a Slack incoming webhook URL.
+
+Top-level ``text`` is the notification fallback Slack shows in toasts and
+unexpanded previews. Receiver limits enforced locally (section text 3000,
+10 fields per section); Slack code blocks do not colorize, so link.updated
+renders old → new pairs instead of Discord's diff block.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from services.webhooks.renderers.copy import build_copy, clip
+
+_TEXT_MAX = 3000
+_FIELD_MAX = 2000
+_FIELDS_PER_SECTION = 10
+
+
+def _escape(text: str) -> str:
+    # Slack mrkdwn control characters.
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _mrkdwn(text: str) -> dict[str, str]:
+    return {"type": "mrkdwn", "text": clip(text, _TEXT_MAX)}
+
+
+def _title_text(title: str, url: str | None) -> str:
+    escaped = _escape(title)
+    return f"*<{url}|{escaped}>*" if url else f"*{escaped}*"
+
+
+def _field_sections(pairs: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    sections: list[dict[str, Any]] = []
+    for start in range(0, len(pairs), _FIELDS_PER_SECTION):
+        chunk = pairs[start : start + _FIELDS_PER_SECTION]
+        sections.append(
+            {
+                "type": "section",
+                "fields": [
+                    _mrkdwn(clip(f"*{_escape(name)}*\n{_escape(value)}", _FIELD_MAX))
+                    for name, value in chunk
+                ],
+            }
+        )
+    return sections
+
+
+class SlackRenderer:
+    flavor = "slack"
+
+    def render(
+        self, event_id: str, event_type: str, timestamp: str, payload: dict[str, Any]
+    ) -> str:
+        copy = build_copy(event_type, timestamp, payload)
+
+        blocks: list[dict[str, Any]] = []
+        if copy.lines:
+            body = "\n".join(_escape(line) for line in copy.lines)
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": _mrkdwn(
+                        f"{_title_text(copy.title, copy.title_url)}\n{body}"
+                    ),
+                }
+            )
+        else:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": _mrkdwn(_title_text(copy.title, copy.title_url)),
+                }
+            )
+            if copy.changes:
+                blocks.extend(
+                    _field_sections(
+                        [(name, f"{old} → {new}") for name, old, new in copy.changes]
+                    )
+                )
+            elif copy.pairs:
+                blocks.extend(_field_sections(copy.pairs))
+            elif copy.code:
+                blocks.append(
+                    {"type": "section", "text": _mrkdwn(f"```{_escape(copy.code)}```")}
+                )
+
+        blocks.append({"type": "context", "elements": [_mrkdwn(_escape(copy.context))]})
+
+        return json.dumps(
+            {"text": clip(copy.title, _TEXT_MAX), "blocks": blocks},
+            separators=(",", ":"),
+            default=str,
+        )

--- a/services/webhooks/service.py
+++ b/services/webhooks/service.py
@@ -14,7 +14,7 @@ from typing import Any
 from bson import ObjectId
 
 from errors import NotFoundError, ValidationError
-from infrastructure.crypto import encrypt_secret
+from infrastructure.crypto import decrypt_secret, encrypt_secret
 from infrastructure.logging import get_logger
 from infrastructure.safe_fetch import FetchHardError, validate_public_https_url
 from repositories.webhook_delivery_repository import WebhookDeliveryRepository
@@ -140,6 +140,27 @@ class WebhookService:
             await self._endpoints.update_fields(endpoint_id, updates)
             await self._cache.invalidate(str(user_id))
         return await self.get_endpoint(endpoint_id, user_id)
+
+    async def reveal_secret(self, endpoint_id: ObjectId, user_id: ObjectId) -> str:
+        """The stored secret is encrypted, never hashed (the executor must
+        read it back to sign), so revealing it to its owner is an ordinary
+        read. A secret the master key can no longer open is reported
+        instead of raising a bare crypto error."""
+        doc = await self.get_endpoint(endpoint_id, user_id)
+        try:
+            return decrypt_secret(
+                doc.signing_secret_enc, self._master_secret, domain=SECRET_ENC_DOMAIN
+            )
+        except Exception as exc:
+            log.error(
+                "webhook_secret_reveal_failed",
+                endpoint_id=str(endpoint_id),
+                error_type=type(exc).__name__,
+            )
+            raise ValidationError(
+                "The stored secret can no longer be read. Delete this "
+                "endpoint and create it again."
+            ) from exc
 
     async def delete_endpoint(self, endpoint_id: ObjectId, user_id: ObjectId) -> None:
         if not await self._endpoints.delete_endpoint(endpoint_id, user_id):

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -544,3 +544,19 @@ def test_create_rejects_unknown_flavor_422():
     with _NO_SSRF, TestClient(app) as c:
         resp = c.post(_URL, json=_create_body(flavor="teams"))
         assert resp.status_code == 422
+
+
+def test_reveal_secret_returns_the_created_secret():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+        revealed = c.get(f"{_URL}/{created['id']}/secret")
+        assert revealed.status_code == 200
+        assert revealed.json()["signing_secret"] == created["signing_secret"]
+
+
+def test_reveal_secret_unknown_endpoint_404():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        resp = c.get(f"{_URL}/{ObjectId()}/secret")
+        assert resp.status_code == 404

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -107,7 +107,6 @@ class _FakeEndpointRepo:
             {
                 "consecutive_failures": 0,
                 "dropped_count": 0,
-                "total_deliveries": doc.total_deliveries + 1,
                 "total_successes": doc.total_successes + 1,
                 "last_delivery_at": datetime.now(timezone.utc),
                 "last_success_at": datetime.now(timezone.utc),
@@ -122,11 +121,16 @@ class _FakeEndpointRepo:
             endpoint_id,
             {
                 "consecutive_failures": streak,
-                "total_deliveries": doc.total_deliveries + 1,
                 "last_failure_reason": reason,
             },
         )
         return streak
+
+    async def increment_deliveries(self, endpoint_id, by=1):
+        doc = self.docs[endpoint_id]
+        await self.update_fields(
+            endpoint_id, {"total_deliveries": doc.total_deliveries + by}
+        )
 
     async def increment_dropped(self, endpoint_id):
         doc = self.docs[endpoint_id]

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -11,6 +11,7 @@ the exact bodies asserted in this file.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -502,3 +503,44 @@ def test_scoped_endpoint_roundtrips_link_ids():
     with _NO_SSRF, TestClient(app) as c:
         created = c.post(_URL, json=_create_body(scope_links=[link_id])).json()
     assert created["scope_links"] == [link_id]
+
+
+def test_send_test_renders_discord_flavor_and_signature_covers_it():
+    """A discord-flavor endpoint delivers an embed body, and the signature
+    verifies over that rendered body (the raw envelope never leaves)."""
+    app, _, _, _ = _build()
+    post = AsyncMock(return_value=PostResult(204, None, None))
+    with (
+        _NO_SSRF,
+        patch("services.webhooks.executor.post_public", post),
+        TestClient(app) as c,
+    ):
+        created = c.post(_URL, json=_create_body(flavor="discord")).json()
+        assert created["flavor"] == "discord"
+        secret = created["signing_secret"]
+
+        resp = c.post(
+            f"{_URL}/{created['id']}/test", json={"event_type": "link.clicked"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+
+        _, body = post.await_args[0]
+        headers = post.await_args.kwargs["headers"]
+        sent = json.loads(body)
+        assert sent["username"] == "spoo.me"
+        assert sent["embeds"][0]["title"].startswith("Click")
+        assert verify(
+            headers["webhook-id"],
+            int(headers["webhook-timestamp"]),
+            body,
+            secret,
+            headers["webhook-signature"],
+        )
+
+
+def test_create_rejects_unknown_flavor_422():
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        resp = c.post(_URL, json=_create_body(flavor="teams"))
+        assert resp.status_code == 422

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -36,7 +36,7 @@ from services.webhooks.renderers import default_renderers
 from services.webhooks.signing import verify
 from tests.conftest import build_test_app
 
-from .conftest import _make_user
+from .conftest import _make_api_key_doc, _make_user
 
 _URL = "/api/v1/webhooks"
 _MASTER = "test-master-secret"
@@ -569,3 +569,16 @@ def test_reveal_secret_unknown_endpoint_404():
     with _NO_SSRF, TestClient(app) as c:
         resp = c.get(f"{_URL}/{ObjectId()}/secret")
         assert resp.status_code == 404
+
+
+def test_reveal_secret_refuses_api_key_auth():
+    """Secret reveal is credential material: interactive sessions only,
+    like key creation."""
+    app, _, _, _ = _build()
+    with _NO_SSRF, TestClient(app) as c:
+        created = c.post(_URL, json=_create_body()).json()
+    key_user = _make_user(api_key_doc=_make_api_key_doc(scopes=["webhooks:manage"]))
+    app.dependency_overrides[get_current_user] = lambda: key_user
+    with TestClient(app) as c:
+        resp = c.get(f"{_URL}/{created['id']}/secret")
+        assert resp.status_code == 403

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -529,11 +529,16 @@ def test_send_test_renders_discord_flavor_and_signature_covers_it():
         assert resp.status_code == 200
         assert resp.json()["status"] == "success"
 
-        _, body = post.await_args[0]
+        url, body = post.await_args[0]
         headers = post.await_args.kwargs["headers"]
+        assert url.endswith("?with_components=true")
         sent = json.loads(body)
         assert sent["username"] == "spoo.me"
-        assert sent["embeds"][0]["title"].startswith("Click")
+        assert sent["flags"] == 32768
+        texts = [
+            c["content"] for c in sent["components"][0]["components"] if c["type"] == 10
+        ]
+        assert texts[0].startswith("### Click")
         assert verify(
             headers["webhook-id"],
             int(headers["webhook-timestamp"]),

--- a/tests/unit/infrastructure/test_safe_fetch_post.py
+++ b/tests/unit/infrastructure/test_safe_fetch_post.py
@@ -11,7 +11,9 @@ import pytest
 from infrastructure.safe_fetch import (
     FetchHardError,
     FetchTransientError,
+    PostResult,
     _is_public,
+    _parse_retry_after,
     post_public,
 )
 
@@ -115,3 +117,25 @@ class TestPostPublic:
             result = await post_public("https://example.com/hook", "{}", headers={})
         assert result.status_code == 302
         assert "redirect" in result.error
+
+
+class TestRetryAfter:
+    @pytest.mark.parametrize(
+        ("header", "expected"),
+        [
+            ("5", 5.0),
+            ("0", 0.0),
+            (" 12 ", 12.0),
+            ("1.5", 1.5),
+            ("-3", None),  # negative is nonsense, ignore
+            ("Wed, 21 Oct 2026 07:28:00 GMT", None),  # HTTP-date form not parsed
+            ("soon", None),
+            (None, None),
+        ],
+    )
+    def test_parse_retry_after(self, header, expected):
+        assert _parse_retry_after(header) == expected
+
+    def test_post_result_defaults_to_no_retry_after(self):
+        # Three-arg construction (every non-header call site) stays valid.
+        assert PostResult(500, None, None).retry_after_seconds is None

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -24,6 +24,8 @@ from schemas.models.webhook import (
     WebhookEventDoc,
 )
 from services.webhooks.executor import (
+    RATE_LIMIT_FALLBACK_SECONDS,
+    RATE_LIMIT_MAX_DEFER_SECONDS,
     RETRY_SCHEDULE_SECONDS,
     SECRET_ENC_DOMAIN,
     DeliveryExecutor,
@@ -306,3 +308,54 @@ class TestFailurePaths:
         ts = int(headers[HEADER_TIMESTAMP])
         assert verify("msg_test", ts, body, _SECRET, headers[HEADER_SIGNATURE])
         assert verify("msg_test", ts, body, old_secret, headers[HEADER_SIGNATURE])
+
+
+class TestRateLimit:
+    """429 is receiver flow control: defer without burning the ladder."""
+
+    def _post_429(self, retry_after: float | None):
+        return AsyncMock(return_value=PostResult(429, None, None, retry_after))
+
+    @pytest.mark.asyncio
+    async def test_429_defers_without_ladder_or_streak(self):
+        executor, deliveries, endpoints, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(None)):
+            await executor.attempt(_delivery(attempt_count=1))
+        deliveries.defer.assert_awaited_once()
+        assert (
+            deliveries.defer.await_args.kwargs["delay_seconds"]
+            == RATE_LIMIT_FALLBACK_SECONDS
+        )
+        deliveries.record_attempt_and_reschedule.assert_not_awaited()
+        deliveries.record_attempt_and_finish.assert_not_awaited()
+        endpoints.record_exhausted.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_429_honors_retry_after(self):
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(5.0)):
+            await executor.attempt(_delivery())
+        assert deliveries.defer.await_args.kwargs["delay_seconds"] == 5
+
+    @pytest.mark.asyncio
+    async def test_429_retry_after_is_capped(self):
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(3600.0)):
+            await executor.attempt(_delivery())
+        assert (
+            deliveries.defer.await_args.kwargs["delay_seconds"]
+            == RATE_LIMIT_MAX_DEFER_SECONDS
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_shot_429_is_terminal_not_deferred(self):
+        # A rate-limited test send must report its outcome synchronously,
+        # not silently park the row.
+        executor, deliveries, _, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", self._post_429(5.0)):
+            await executor.attempt(_delivery(is_test=True, next_attempt_at=None))
+        deliveries.defer.assert_not_awaited()
+        assert (
+            deliveries.record_attempt_and_finish.await_args[0][2]
+            is DeliveryStatus.FAILED
+        )

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -359,3 +359,24 @@ class TestRateLimit:
             deliveries.record_attempt_and_finish.await_args[0][2]
             is DeliveryStatus.FAILED
         )
+
+
+class TestDeliveryUrl:
+    @pytest.mark.asyncio
+    async def test_discord_flavor_appends_components_param(self):
+        endpoint = _endpoint(flavor=WebhookFlavor.DISCORD)
+        executor, _, _, _ = _make(endpoint)
+        post = _post(204)
+        with patch("services.webhooks.executor.post_public", post):
+            await executor.attempt(_delivery())
+        url = post.await_args[0][0]
+        assert url == f"{endpoint.url}?with_components=true"
+
+    @pytest.mark.asyncio
+    async def test_raw_flavor_url_is_untouched(self):
+        endpoint = _endpoint()
+        executor, _, _, _ = _make(endpoint)
+        post = _post(204)
+        with patch("services.webhooks.executor.post_public", post):
+            await executor.attempt(_delivery())
+        assert post.await_args[0][0] == endpoint.url

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -45,26 +45,33 @@ class TestRegistry:
 
 
 class TestDiscord:
-    def test_clicked_renders_an_inline_field_grid(self):
+    def test_clicked_renders_a_two_column_grid(self):
         doc = _discord("link.clicked", _clicked_payload())
         assert doc["username"] == "spoo.me"
+        assert doc["avatar_url"].startswith("https://spoo.me/")
         (embed,) = doc["embeds"]
-        assert embed["title"] == "Click · spoo.me/summer-drop"
+        assert embed["title"] == "Click: spoo.me/summer-drop"
         assert embed["url"] == "https://spoo.me/summer-drop"
         assert embed["timestamp"] == _TS
         fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Location"] == "Mumbai, IN"
-        assert fields["Device"] == "Chrome · Android · mobile"
+        assert fields["Country"] == "🇮🇳 IN"
+        assert fields["City"] == "Mumbai"
+        assert fields["Browser"] == "Chrome"
+        assert fields["OS"] == "Android"
+        assert fields["Device"] == "mobile"
         assert fields["From"] == "x.com"
-        assert fields["UTM"] == "newsletter · email"
-        assert fields["Clicks"] == "4,102"
+        assert fields["UTM"] == "newsletter / email"
+        assert fields["Clicks so far"] == "4,102"
         assert all(f["inline"] for f in embed["fields"])
-        # Discord renders the embed timestamp itself; footer is brand only.
-        assert embed["footer"]["text"] == "spoo.me"
+        # Spacer fields close each pair so rows hold two facts, not three.
+        assert "\u200b" in fields
+        # The webhook identity carries the brand; no footer without a notice.
+        assert "footer" not in embed
+        assert "·" not in json.dumps(embed, ensure_ascii=False)
 
     def test_sparse_click_is_never_an_empty_card(self):
-        # A local/direct click has no geo and no referrer; it still carries
-        # Device and shows the truth: a direct visit.
+        # A local/direct click has no geo and no referrer; the truth still
+        # renders: a direct visit, count stated even at zero.
         doc = _discord(
             "link.clicked",
             _clicked_payload(
@@ -76,10 +83,11 @@ class TestDiscord:
             ),
         )
         fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
-        assert "Location" not in fields
-        assert "Clicks" not in fields
+        assert "Country" not in fields
+        assert "City" not in fields
         assert fields["From"] == "direct"
-        assert fields["Device"] == "Chrome · Android · mobile"
+        assert fields["Browser"] == "Chrome"
+        assert fields["Clicks so far"] == "0"
 
     def test_clicked_bot_field(self):
         doc = _discord(
@@ -90,9 +98,7 @@ class TestDiscord:
 
     def test_dropped_notice_rides_the_footer(self):
         doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
-        assert doc["embeds"][0]["footer"]["text"] == (
-            "spoo.me · 3 earlier deliveries dropped"
-        )
+        assert doc["embeds"][0]["footer"]["text"] == "3 earlier deliveries dropped"
 
     def test_updated_renders_a_diff_block(self):
         payload = EVENT_REGISTRY["link.updated"].sample()
@@ -117,9 +123,10 @@ class TestDiscord:
         (embed,) = _discord("link.expired", EVENT_REGISTRY["link.expired"].sample())[
             "embeds"
         ]
-        names = [f["name"] for f in embed["fields"]]
-        assert names == ["Reason", "Destination", "Lifetime clicks"]
-        assert embed["fields"][0]["value"] == "Max clicks reached"
+        fields = {f["name"]: f["value"] for f in embed["fields"]}
+        assert fields["Reason"] == "Max clicks reached"
+        assert "Destination" in fields
+        assert "Lifetime clicks" in fields
 
         (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
             "embeds"
@@ -129,7 +136,8 @@ class TestDiscord:
         assert "days" in fields["Age"]
 
     def test_bare_created_link_still_fills_the_card(self):
-        # No expiry and no cap are answers, not blanks.
+        # Every configuration fact renders with its real answer, absent
+        # settings included.
         payload = {"link": {**EVENT_REGISTRY["link.created"].sample()["link"]}}
         payload["link"]["expires_at"] = None
         payload["link"]["max_clicks"] = None
@@ -139,6 +147,10 @@ class TestDiscord:
         }
         assert fields["Expires"] == "never"
         assert fields["Max clicks"] == "unlimited"
+        assert fields["Password"] == "none"
+        assert fields["Bots"] == "allowed"
+        assert fields["Meta tags"] == "default"
+        assert fields["Geo targeting"] == "none"
 
     def test_destination_field_is_full_width(self):
         (embed,) = _discord("link.created", EVENT_REGISTRY["link.created"].sample())[
@@ -171,25 +183,21 @@ class TestDiscord:
         (embed,) = _discord("link.updated", payload)["embeds"]
         assert len(embed["title"]) <= 256
         assert len(embed["description"]) <= 4096
-        total = (
-            len(embed["title"])
-            + len(embed["description"])
-            + len(embed["footer"]["text"])
-        )
+        total = len(embed["title"]) + len(embed["description"])
         assert total <= _EMBED_TOTAL_MAX
 
 
 class TestSlack:
     def test_clicked_is_title_fields_context(self):
         doc = _slack("link.clicked", _clicked_payload())
-        assert doc["text"] == "Click · spoo.me/summer-drop"
+        assert doc["text"] == "Click: spoo.me/summer-drop"
         first, last = doc["blocks"][0], doc["blocks"][-1]
         assert first["type"] == "section"
         assert first["text"]["text"].startswith(
-            "*<https://spoo.me/summer-drop|Click · spoo.me/summer-drop>*"
+            "*<https://spoo.me/summer-drop|Click: spoo.me/summer-drop>*"
         )
         fields = [f["text"] for f in doc["blocks"][1]["fields"]]
-        assert "*Location*\nMumbai, IN" in fields
+        assert "*Country*\n🇮🇳 IN" in fields
         assert "*From*\nx.com" in fields
         assert last["type"] == "context"
         assert last["elements"][0]["text"] == f"spoo.me · {_TS}"

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -45,36 +45,48 @@ class TestRegistry:
 
 
 class TestDiscord:
-    def test_clicked_is_compact_description(self):
+    def test_clicked_renders_an_inline_field_grid(self):
         doc = _discord("link.clicked", _clicked_payload())
         assert doc["username"] == "spoo.me"
         (embed,) = doc["embeds"]
         assert embed["title"] == "Click · spoo.me/summer-drop"
         assert embed["url"] == "https://spoo.me/summer-drop"
         assert embed["timestamp"] == _TS
-        assert "Mumbai, IN · Chrome on Android" in embed["description"]
-        assert "from x.com · click #4,102" in embed["description"]
-        assert "fields" not in embed
+        fields = {f["name"]: f["value"] for f in embed["fields"]}
+        assert fields["Location"] == "Mumbai, IN"
+        assert fields["Device"] == "Chrome · Android · mobile"
+        assert fields["From"] == "x.com"
+        assert fields["UTM"] == "newsletter · email"
+        assert fields["Clicks"] == "4,102"
+        assert all(f["inline"] for f in embed["fields"])
         # Discord renders the embed timestamp itself; footer is brand only.
         assert embed["footer"]["text"] == "spoo.me"
 
-    def test_clicked_omits_absent_dimensions(self):
+    def test_sparse_click_is_never_an_empty_card(self):
+        # A local/direct click has no geo and no referrer; it still carries
+        # Device and shows the truth: a direct visit.
         doc = _discord(
             "link.clicked",
             _clicked_payload(
-                city=None, country="unknown", referrer="(none)", browser=None, os=None
+                city=None,
+                country="unknown",
+                referrer="(none)",
+                utm=None,
+                total_clicks=0,
             ),
         )
-        description = doc["embeds"][0]["description"]
-        assert "unknown" not in description
-        assert "none" not in description
-        assert "from" not in description
+        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
+        assert "Location" not in fields
+        assert "Clicks" not in fields
+        assert fields["From"] == "direct"
+        assert fields["Device"] == "Chrome · Android · mobile"
 
-    def test_clicked_bot_line(self):
+    def test_clicked_bot_field(self):
         doc = _discord(
             "link.clicked", _clicked_payload(is_bot=True, bot_name="GoogleBot")
         )
-        assert "bot · GoogleBot" in doc["embeds"][0]["description"]
+        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
+        assert fields["Bot"] == "GoogleBot"
 
     def test_dropped_notice_rides_the_footer(self):
         doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
@@ -106,13 +118,35 @@ class TestDiscord:
             "embeds"
         ]
         names = [f["name"] for f in embed["fields"]]
-        assert names == ["Reason", "Destination", "Total clicks"]
+        assert names == ["Reason", "Destination", "Lifetime clicks"]
         assert embed["fields"][0]["value"] == "Max clicks reached"
 
         (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
             "embeds"
         ]
-        assert [f["name"] for f in embed["fields"]] == ["Destination", "Total clicks"]
+        fields = {f["name"]: f["value"] for f in embed["fields"]}
+        assert fields["Lifetime clicks"] == "4,102"
+        assert "days" in fields["Age"]
+
+    def test_bare_created_link_still_fills_the_card(self):
+        # No expiry and no cap are answers, not blanks.
+        payload = {"link": {**EVENT_REGISTRY["link.created"].sample()["link"]}}
+        payload["link"]["expires_at"] = None
+        payload["link"]["max_clicks"] = None
+        fields = {
+            f["name"]: f["value"]
+            for f in _discord("link.created", payload)["embeds"][0]["fields"]
+        }
+        assert fields["Expires"] == "never"
+        assert fields["Max clicks"] == "unlimited"
+
+    def test_destination_field_is_full_width(self):
+        (embed,) = _discord("link.created", EVENT_REGISTRY["link.created"].sample())[
+            "embeds"
+        ]
+        by_name = {f["name"]: f for f in embed["fields"]}
+        assert by_name["Destination"]["inline"] is False
+        assert by_name["Expires"]["inline"] is True
 
     def test_test_event_renders_its_message(self):
         (embed,) = _discord("webhook.test", TEST_EVENT_SPEC.sample())["embeds"]
@@ -146,7 +180,7 @@ class TestDiscord:
 
 
 class TestSlack:
-    def test_clicked_is_one_section_plus_context(self):
+    def test_clicked_is_title_fields_context(self):
         doc = _slack("link.clicked", _clicked_payload())
         assert doc["text"] == "Click · spoo.me/summer-drop"
         first, last = doc["blocks"][0], doc["blocks"][-1]
@@ -154,7 +188,9 @@ class TestSlack:
         assert first["text"]["text"].startswith(
             "*<https://spoo.me/summer-drop|Click · spoo.me/summer-drop>*"
         )
-        assert "Mumbai, IN · Chrome on Android" in first["text"]["text"]
+        fields = [f["text"] for f in doc["blocks"][1]["fields"]]
+        assert "*Location*\nMumbai, IN" in fields
+        assert "*From*\nx.com" in fields
         assert last["type"] == "context"
         assert last["elements"][0]["text"] == f"spoo.me · {_TS}"
 
@@ -176,9 +212,10 @@ class TestSlack:
 
     def test_mrkdwn_control_characters_escaped(self):
         payload = _clicked_payload(city="<Berlin & Brandenburg>")
-        text = _slack("link.clicked", payload)["blocks"][0]["text"]["text"]
-        assert "&lt;Berlin &amp; Brandenburg&gt;" in text
-        assert "<Berlin" not in text
+        doc = _slack("link.clicked", payload)
+        fields = " ".join(f["text"] for f in doc["blocks"][1]["fields"])
+        assert "&lt;Berlin &amp; Brandenburg&gt;" in fields
+        assert "<Berlin" not in fields
 
     def test_dropped_notice_rides_the_context_line(self):
         doc = _slack("link.clicked", _clicked_payload(dropped_since_last=1))

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -1,0 +1,217 @@
+"""Discord and Slack flavors — full-shape pins per event type, receiver
+size limits, escaping, and the fallback that keeps future event types from
+terminal-failing flavored endpoints. Raw stays pinned via the executor
+tests; these cover the lossy renderings."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from schemas.enums.webhook import WebhookFlavor
+from services.webhooks.registry import EVENT_REGISTRY, TEST_EVENT_SPEC
+from services.webhooks.renderers import default_renderers
+from services.webhooks.renderers.discord import _EMBED_TOTAL_MAX, DiscordRenderer
+from services.webhooks.renderers.slack import SlackRenderer
+
+_TS = "2026-07-24T14:32:00+00:00"
+
+
+def _discord(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    body = DiscordRenderer().render("evt_x", event_type, _TS, payload)
+    return json.loads(body)
+
+
+def _slack(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    body = SlackRenderer().render("evt_x", event_type, _TS, payload)
+    return json.loads(body)
+
+
+def _clicked_payload(**overrides: Any) -> dict[str, Any]:
+    payload = EVENT_REGISTRY["link.clicked"].sample()
+    payload.update(overrides)
+    return payload
+
+
+class TestRegistry:
+    def test_every_flavor_has_a_renderer(self):
+        # Enum and registry must never drift: a flavor an endpoint can be
+        # created with must be renderable, or deliveries terminal-fail.
+        assert set(default_renderers()) == {f.value for f in WebhookFlavor}
+
+    def test_renderers_expose_matching_flavor_attribute(self):
+        for key, renderer in default_renderers().items():
+            assert renderer.flavor == key
+
+
+class TestDiscord:
+    def test_clicked_is_compact_description(self):
+        doc = _discord("link.clicked", _clicked_payload())
+        assert doc["username"] == "spoo.me"
+        (embed,) = doc["embeds"]
+        assert embed["title"] == "Click · spoo.me/summer-drop"
+        assert embed["url"] == "https://spoo.me/summer-drop"
+        assert embed["timestamp"] == _TS
+        assert "Mumbai, IN · Chrome on Android" in embed["description"]
+        assert "from x.com · click #4,102" in embed["description"]
+        assert "fields" not in embed
+        # Discord renders the embed timestamp itself; footer is brand only.
+        assert embed["footer"]["text"] == "spoo.me"
+
+    def test_clicked_omits_absent_dimensions(self):
+        doc = _discord(
+            "link.clicked",
+            _clicked_payload(
+                city=None, country="unknown", referrer="(none)", browser=None, os=None
+            ),
+        )
+        description = doc["embeds"][0]["description"]
+        assert "unknown" not in description
+        assert "none" not in description
+        assert "from" not in description
+
+    def test_clicked_bot_line(self):
+        doc = _discord(
+            "link.clicked", _clicked_payload(is_bot=True, bot_name="GoogleBot")
+        )
+        assert "bot · GoogleBot" in doc["embeds"][0]["description"]
+
+    def test_dropped_notice_rides_the_footer(self):
+        doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
+        assert doc["embeds"][0]["footer"]["text"] == (
+            "spoo.me · 3 earlier deliveries dropped"
+        )
+
+    def test_updated_renders_a_diff_block(self):
+        payload = EVENT_REGISTRY["link.updated"].sample()
+        payload["changes"]["max_clicks"] = {"old": 5000, "new": 10000}
+        description = _discord("link.updated", payload)["embeds"][0]["description"]
+        assert description.startswith("```diff\n")
+        assert description.endswith("\n```")
+        assert "- long_url: https://example.com/old" in description
+        assert "+ long_url: https://example.com/campaign" in description
+        assert "- max_clicks: 5000" in description
+        assert "+ max_clicks: 10000" in description
+
+    def test_diff_values_cannot_break_out_of_the_block(self):
+        payload = {
+            "link": {"alias": "a", "domain": "spoo.me"},
+            "changes": {"long_url": {"old": "x", "new": "```@everyone"}},
+        }
+        description = _discord("link.updated", payload)["embeds"][0]["description"]
+        assert description.count("```") == 2  # only the fence itself
+
+    def test_lifecycle_field_grids(self):
+        (embed,) = _discord("link.expired", EVENT_REGISTRY["link.expired"].sample())[
+            "embeds"
+        ]
+        names = [f["name"] for f in embed["fields"]]
+        assert names == ["Reason", "Destination", "Total clicks"]
+        assert embed["fields"][0]["value"] == "Max clicks reached"
+
+        (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
+            "embeds"
+        ]
+        assert [f["name"] for f in embed["fields"]] == ["Destination", "Total clicks"]
+
+    def test_test_event_renders_its_message(self):
+        (embed,) = _discord("webhook.test", TEST_EVENT_SPEC.sample())["embeds"]
+        assert embed["description"] == "If you can read this, your endpoint works."
+
+    def test_unknown_event_type_falls_back_to_json(self):
+        # A future registry addition must degrade, never terminal-fail.
+        (embed,) = _discord("link.blocked", {"link_id": "x", "reason": "phishing"})[
+            "embeds"
+        ]
+        assert embed["title"] == "link.blocked"
+        assert embed["description"].startswith("```json\n")
+        assert '"reason":"phishing"' in embed["description"]
+
+    def test_receiver_limits_hold_under_pathological_changes(self):
+        payload = {
+            "link": {"alias": "a" * 500, "domain": "spoo.me"},
+            "changes": {
+                f"field_{i}": {"old": "x" * 900, "new": "y" * 900} for i in range(10)
+            },
+        }
+        (embed,) = _discord("link.updated", payload)["embeds"]
+        assert len(embed["title"]) <= 256
+        assert len(embed["description"]) <= 4096
+        total = (
+            len(embed["title"])
+            + len(embed["description"])
+            + len(embed["footer"]["text"])
+        )
+        assert total <= _EMBED_TOTAL_MAX
+
+
+class TestSlack:
+    def test_clicked_is_one_section_plus_context(self):
+        doc = _slack("link.clicked", _clicked_payload())
+        assert doc["text"] == "Click · spoo.me/summer-drop"
+        first, last = doc["blocks"][0], doc["blocks"][-1]
+        assert first["type"] == "section"
+        assert first["text"]["text"].startswith(
+            "*<https://spoo.me/summer-drop|Click · spoo.me/summer-drop>*"
+        )
+        assert "Mumbai, IN · Chrome on Android" in first["text"]["text"]
+        assert last["type"] == "context"
+        assert last["elements"][0]["text"] == f"spoo.me · {_TS}"
+
+    def test_updated_renders_old_to_new_pairs(self):
+        doc = _slack("link.updated", EVENT_REGISTRY["link.updated"].sample())
+        fields = doc["blocks"][1]["fields"]
+        assert fields[0]["text"] == (
+            "*long_url*\nhttps://example.com/old → https://example.com/campaign"
+        )
+
+    def test_field_sections_chunk_at_ten(self):
+        payload = {
+            "link": {"alias": "a", "domain": "spoo.me"},
+            "changes": {f"f{i}": {"old": i, "new": i + 1} for i in range(12)},
+        }
+        doc = _slack("link.updated", payload)
+        field_sections = [b for b in doc["blocks"] if "fields" in b]
+        assert [len(s["fields"]) for s in field_sections] == [10, 2]
+
+    def test_mrkdwn_control_characters_escaped(self):
+        payload = _clicked_payload(city="<Berlin & Brandenburg>")
+        text = _slack("link.clicked", payload)["blocks"][0]["text"]["text"]
+        assert "&lt;Berlin &amp; Brandenburg&gt;" in text
+        assert "<Berlin" not in text
+
+    def test_dropped_notice_rides_the_context_line(self):
+        doc = _slack("link.clicked", _clicked_payload(dropped_since_last=1))
+        assert doc["blocks"][-1]["elements"][0]["text"] == (
+            f"spoo.me · {_TS} · 1 earlier delivery dropped"
+        )
+
+    def test_unknown_event_type_falls_back_to_json(self):
+        doc = _slack("link.blocked", {"link_id": "x", "reason": "phishing"})
+        assert doc["text"] == "link.blocked"
+        code = doc["blocks"][1]["text"]["text"]
+        assert code.startswith("```")
+        assert "phishing" in code
+
+    def test_output_stays_under_the_engine_payload_cap(self):
+        payload = {
+            "link": {"alias": "a" * 500, "domain": "spoo.me"},
+            "changes": {
+                f"field_{i}": {"old": "x" * 900, "new": "y" * 900} for i in range(10)
+            },
+        }
+        body = SlackRenderer().render("evt_x", "link.updated", _TS, payload)
+        assert len(body.encode()) < 20_480
+        assert len(json.loads(body)["blocks"]) <= 50
+
+
+class TestAllEventsBothFlavors:
+    def test_every_registered_sample_renders_valid_json(self):
+        renderers = default_renderers()
+        specs = [*EVENT_REGISTRY.values(), TEST_EVENT_SPEC]
+        for spec in specs:
+            for flavor in ("discord", "slack"):
+                body = renderers[flavor].render("evt_x", spec.name, _TS, spec.sample())
+                parsed = json.loads(body)
+                assert parsed  # non-empty, valid JSON
+                assert len(body.encode()) < 20_480

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -11,7 +11,7 @@ from typing import Any
 from schemas.enums.webhook import WebhookFlavor
 from services.webhooks.registry import EVENT_REGISTRY, TEST_EVENT_SPEC
 from services.webhooks.renderers import default_renderers
-from services.webhooks.renderers.discord import _EMBED_TOTAL_MAX, DiscordRenderer
+from services.webhooks.renderers.discord import DiscordRenderer
 from services.webhooks.renderers.slack import SlackRenderer
 
 _TS = "2026-07-24T14:32:00+00:00"
@@ -45,33 +45,41 @@ class TestRegistry:
 
 
 class TestDiscord:
-    def test_clicked_renders_a_two_column_grid(self):
+    """Components V2: one accent container, heading, divider, substance,
+    small-text localized footer. Never embeds, never pings."""
+
+    def _container(self, doc):
+        assert doc["flags"] == 32768
+        assert doc["allowed_mentions"] == {"parse": []}
+        assert "embeds" not in doc and "content" not in doc
+        (container,) = doc["components"]
+        assert container["type"] == 17
+        return container
+
+    def _texts(self, container):
+        return [c["content"] for c in container["components"] if c["type"] == 10]
+
+    def test_clicked_message_shape(self):
         doc = _discord("link.clicked", _clicked_payload())
         assert doc["username"] == "spoo.me"
         assert doc["avatar_url"].startswith("https://spoo.me/")
-        (embed,) = doc["embeds"]
-        assert embed["title"] == "Click: spoo.me/summer-drop"
-        assert embed["url"] == "https://spoo.me/summer-drop"
-        assert embed["timestamp"] == _TS
-        fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Country"] == "🇮🇳 IN"
-        assert fields["City"] == "Mumbai"
-        assert fields["Browser"] == "Chrome"
-        assert fields["OS"] == "Android"
-        assert fields["Device"] == "mobile"
-        assert fields["From"] == "x.com"
-        assert fields["UTM"] == "newsletter / email"
-        assert fields["Clicks so far"] == "4,102"
-        assert all(f["inline"] for f in embed["fields"])
-        # Spacer fields close each pair so rows hold two facts, not three.
-        assert "\u200b" in fields
-        # The webhook identity carries the brand; no footer without a notice.
-        assert "footer" not in embed
-        assert "·" not in json.dumps(embed, ensure_ascii=False)
+        container = self._container(doc)
+        texts = self._texts(container)
+        assert texts[0] == (
+            "### Click  [spoo.me/summer-drop](https://spoo.me/summer-drop)"
+        )
+        body = texts[1]
+        assert "🇮🇳 **IN**  Mumbai" in body
+        assert "Chrome on Android, mobile" in body
+        assert "from **x.com**  (newsletter / email)" in body
+        footer = texts[-1]
+        assert footer.startswith("-# click 4,102")
+        assert "<t:" in footer and footer.rstrip().endswith(":R>")
+        # A divider separates the heading from the substance.
+        assert any(c["type"] == 14 and c["divider"] for c in container["components"])
+        assert "·" not in json.dumps(doc, ensure_ascii=False)
 
     def test_sparse_click_is_never_an_empty_card(self):
-        # A local/direct click has no geo and no referrer; the truth still
-        # renders: a direct visit, count stated even at zero.
         doc = _discord(
             "link.clicked",
             _clicked_payload(
@@ -82,109 +90,100 @@ class TestDiscord:
                 total_clicks=0,
             ),
         )
-        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
-        assert "Country" not in fields
-        assert "City" not in fields
-        assert fields["From"] == "direct"
-        assert fields["Browser"] == "Chrome"
-        assert fields["Clicks so far"] == "0"
+        texts = self._texts(self._container(doc))
+        assert "Chrome on Android, mobile" in texts[1]
+        assert "direct visit" in texts[1]
+        assert texts[-1].startswith("-# click 0")
 
-    def test_clicked_bot_field(self):
+    def test_clicked_bot_line(self):
         doc = _discord(
             "link.clicked", _clicked_payload(is_bot=True, bot_name="GoogleBot")
         )
-        fields = {f["name"]: f["value"] for f in doc["embeds"][0]["fields"]}
-        assert fields["Bot"] == "GoogleBot"
+        texts = self._texts(self._container(doc))
+        assert "bot  **GoogleBot**" in texts[1]
 
     def test_dropped_notice_rides_the_footer(self):
         doc = _discord("link.clicked", _clicked_payload(dropped_since_last=3))
-        assert doc["embeds"][0]["footer"]["text"] == "3 earlier deliveries dropped"
+        footer = self._texts(self._container(doc))[-1]
+        assert "-# 3 earlier deliveries dropped" in footer
 
     def test_updated_renders_a_diff_block(self):
         payload = EVENT_REGISTRY["link.updated"].sample()
         payload["changes"]["max_clicks"] = {"old": 5000, "new": 10000}
-        description = _discord("link.updated", payload)["embeds"][0]["description"]
-        assert description.startswith("```diff\n")
-        assert description.endswith("\n```")
-        assert "- long_url: https://example.com/old" in description
-        assert "+ long_url: https://example.com/campaign" in description
-        assert "- max_clicks: 5000" in description
-        assert "+ max_clicks: 10000" in description
+        texts = self._texts(self._container(_discord("link.updated", payload)))
+        diff = next(t for t in texts if t.startswith("```diff"))
+        assert "- long_url: https://example.com/old" in diff
+        assert "+ long_url: https://example.com/campaign" in diff
+        assert "- max_clicks: 5000" in diff
+        assert "+ max_clicks: 10000" in diff
 
     def test_diff_values_cannot_break_out_of_the_block(self):
         payload = {
             "link": {"alias": "a", "domain": "spoo.me"},
             "changes": {"long_url": {"old": "x", "new": "```@everyone"}},
         }
-        description = _discord("link.updated", payload)["embeds"][0]["description"]
-        assert description.count("```") == 2  # only the fence itself
+        texts = self._texts(self._container(_discord("link.updated", payload)))
+        diff = next(t for t in texts if t.startswith("```diff"))
+        assert diff.count("```") == 2  # only the fence itself
 
-    def test_lifecycle_field_grids(self):
-        (embed,) = _discord("link.expired", EVENT_REGISTRY["link.expired"].sample())[
-            "embeds"
-        ]
-        fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Reason"] == "Max clicks reached"
-        assert "Destination" in fields
-        assert "Lifetime clicks" in fields
-
-        (embed,) = _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())[
-            "embeds"
-        ]
-        fields = {f["name"]: f["value"] for f in embed["fields"]}
-        assert fields["Lifetime clicks"] == "4,102"
-        assert "days" in fields["Age"]
-
-    def test_bare_created_link_still_fills_the_card(self):
-        # Every configuration fact renders with its real answer, absent
-        # settings included.
+    def test_created_states_the_full_configuration(self):
         payload = {"link": {**EVENT_REGISTRY["link.created"].sample()["link"]}}
         payload["link"]["expires_at"] = None
         payload["link"]["max_clicks"] = None
-        fields = {
-            f["name"]: f["value"]
-            for f in _discord("link.created", payload)["embeds"][0]["fields"]
-        }
-        assert fields["Expires"] == "never"
-        assert fields["Max clicks"] == "unlimited"
-        assert fields["Password"] == "none"
-        assert fields["Bots"] == "allowed"
-        assert fields["Meta tags"] == "default"
-        assert fields["Geo targeting"] == "none"
+        container = self._container(_discord("link.created", payload))
+        texts = self._texts(container)
+        # Destination rides as a small subtitle under the heading.
+        assert texts[1] == "-# https://example.com/campaign"
+        facts = texts[2]
+        assert "**Expires**  never" in facts
+        assert "**Max clicks**  unlimited" in facts
+        assert "**Password**  none" in facts
+        assert "**Bots**  allowed" in facts
+        assert "**Meta tags**  default" in facts
+        assert "**Geo targeting**  none" in facts
+        assert container["accent_color"] == 0x43B581
 
-    def test_destination_field_is_full_width(self):
-        (embed,) = _discord("link.created", EVENT_REGISTRY["link.created"].sample())[
-            "embeds"
-        ]
-        by_name = {f["name"]: f for f in embed["fields"]}
-        assert by_name["Destination"]["inline"] is False
-        assert by_name["Expires"]["inline"] is True
+    def test_deleted_heading_is_not_a_link(self):
+        texts = self._texts(
+            self._container(
+                _discord("link.deleted", EVENT_REGISTRY["link.deleted"].sample())
+            )
+        )
+        assert texts[0] == "### Link deleted  spoo.me/summer-drop"
+        assert "**Lifetime clicks**  4,102" in texts[2]
+        assert "**Age**" in texts[2]
 
     def test_test_event_renders_its_message(self):
-        (embed,) = _discord("webhook.test", TEST_EVENT_SPEC.sample())["embeds"]
-        assert embed["description"] == "If you can read this, your endpoint works."
+        texts = self._texts(
+            self._container(_discord("webhook.test", TEST_EVENT_SPEC.sample()))
+        )
+        assert "If you can read this, your endpoint works." in texts
 
     def test_unknown_event_type_falls_back_to_json(self):
         # A future registry addition must degrade, never terminal-fail.
-        (embed,) = _discord("link.blocked", {"link_id": "x", "reason": "phishing"})[
-            "embeds"
-        ]
-        assert embed["title"] == "link.blocked"
-        assert embed["description"].startswith("```json\n")
-        assert '"reason":"phishing"' in embed["description"]
+        texts = self._texts(
+            self._container(
+                _discord("link.blocked", {"link_id": "x", "reason": "phishing"})
+            )
+        )
+        assert texts[0] == "### link.blocked"
+        code = next(t for t in texts if t.startswith("```json"))
+        assert '"reason":"phishing"' in code
 
-    def test_receiver_limits_hold_under_pathological_changes(self):
+    def test_text_budget_holds_under_pathological_changes(self):
         payload = {
             "link": {"alias": "a" * 500, "domain": "spoo.me"},
             "changes": {
                 f"field_{i}": {"old": "x" * 900, "new": "y" * 900} for i in range(10)
             },
         }
-        (embed,) = _discord("link.updated", payload)["embeds"]
-        assert len(embed["title"]) <= 256
-        assert len(embed["description"]) <= 4096
-        total = len(embed["title"]) + len(embed["description"])
-        assert total <= _EMBED_TOTAL_MAX
+        container = self._container(_discord("link.updated", payload))
+        total = sum(len(t) for t in self._texts(container))
+        assert total <= 3_500
+        assert len(container["components"]) <= 40
+
+    def test_delivery_url_query_declared(self):
+        assert DiscordRenderer.url_query == {"with_components": "true"}
 
 
 class TestSlack:

--- a/tests/unit/services/webhooks/test_renderers.py
+++ b/tests/unit/services/webhooks/test_renderers.py
@@ -259,3 +259,51 @@ class TestAllEventsBothFlavors:
                 parsed = json.loads(body)
                 assert parsed  # non-empty, valid JSON
                 assert len(body.encode()) < 20_480
+
+
+class TestDiscordInjection:
+    """Visitor-controlled payload values must never render as live
+    Discord markdown in the subscriber's channel."""
+
+    def _body_text(self, doc):
+        return "\n".join(
+            c["content"] for c in doc["components"][0]["components"] if c["type"] == 10
+        )
+
+    def test_masked_link_in_referrer_is_neutralized(self):
+        doc = _discord(
+            "link.clicked", _clicked_payload(referrer="[x](https://evil.phish)")
+        )
+        text = self._body_text(doc)
+        assert "[x](https://evil.phish)" not in text
+        assert "\\[x\\]" in text
+
+    def test_markdown_in_dimensions_is_neutralized(self):
+        doc = _discord(
+            "link.clicked",
+            _clicked_payload(browser="**bold**", city="`code`", os="||spoiler||"),
+        )
+        text = self._body_text(doc)
+        assert "**bold**" not in text
+        assert "`code`" not in text
+        assert "||spoiler||" not in text
+
+    def test_lifecycle_values_are_neutralized(self):
+        payload = {
+            "link": {
+                "alias": "a",
+                "domain": "spoo.me",
+                "long_url": "https://example.com/a(b)[c]",
+                "short_url": "https://spoo.me/a",
+            }
+        }
+        doc = _discord("link.created", payload)
+        text = self._body_text(doc)
+        assert "(b)[c]" not in text  # subtitle rides escaped
+
+    def test_link_target_parens_cannot_close_the_masked_link(self):
+        payload = _clicked_payload()
+        payload["short_url"] = "https://spoo.me/a)b"
+        doc = _discord("link.clicked", payload)
+        heading = doc["components"][0]["components"][0]["content"]
+        assert "](https://spoo.me/a%29b)" in heading


### PR DESCRIPTION
Stacked on #270. Adds the two prebuilt flavors so an endpoint can point straight at a Discord or Slack incoming webhook, no middleware in between.

## What's in here

**Flavors**
- `WebhookFlavor` gains `discord` and `slack`; endpoint create/update accepts them and the signature keeps covering the rendered body, so verification works the same for every flavor.
- A shared copy layer (`renderers/copy.py`) decides wording and which fields earn space, so the two flavors never drift apart. Density follows event frequency: `link.clicked` renders as a few compact lines that read well as a stream, while the rare lifecycle events get field grids.
- `link.updated` on Discord renders the change set as a `diff` code block, so old/new values come out red/green. Slack code blocks don't colorize, so it gets `old → new` pairs instead.
- Receiver limits are enforced locally (Discord: title 256, description 4096, 6000 across the embed; Slack: 3000 per section, fields chunked at 10) with values fenced so they can't break out of code blocks.
- Unknown event types degrade to a JSON code block instead of failing, so adding a new event later can never break a flavored endpoint. `webhook.test` renders its message in both flavors.

**429 handling**
- `post_public` now surfaces an integer `Retry-After` when the receiver sends one.
- On 429 the executor defers the row (Retry-After honored, capped at 15 minutes, 60s fallback) instead of burning retry-ladder attempts or counting toward the auto-disable streak. Discord rate limiting is flow control, not endpoint failure, and popularity should never get an endpoint disabled.
- Test sends and manual retries still report a terminal outcome synchronously.

## Tests

35 new: full-shape pins per flavor per event, receiver size limits under pathological inputs, code-block escape safety, Slack mrkdwn escaping, the unknown-type fallback, a registry/enum drift guard (every flavor an endpoint can be created with must have a renderer), Retry-After parsing, and the 429 defer semantics including the single-shot exception. Full suite: 2879 green.