### PR TITLE
perf: pack clicks time-series buckets properly

### DIFF
--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -72,7 +72,11 @@ async def ensure_indexes(
             timeseries={
                 "timeField": "clicked_at",
                 "metaField": "meta",
-                "granularity": "seconds",
+                # "hours" spans buckets over 30 days. Most links get sparse
+                # clicks, so finer granularity degenerates into one bucket
+                # per click. Existing deploys need a one-time collMod to
+                # match (the transition is one-way, coarser only).
+                "granularity": "hours",
             },
         )
     except (CollectionInvalid, OperationFailure) as e:

--- a/schemas/models/click.py
+++ b/schemas/models/click.py
@@ -60,3 +60,14 @@ class ClickDoc(MongoBaseModel):
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None
+
+    def to_mongo(self) -> dict:
+        """Serialise for insertion, omitting None fields entirely.
+
+        Time-series buckets track one BSON type per field. An explicit
+        null following a string value (or vice versa) is a type conflict
+        that closes the bucket early, while an absent field packs fine.
+        Queries are unaffected: MongoDB treats missing and null the same
+        in $eq/$group, and the stats sentinels already map both.
+        """
+        return self.model_dump(by_alias=True, exclude_none=True)

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -145,7 +145,7 @@ class TestEnsureIndexes:
             timeseries={
                 "timeField": "clicked_at",
                 "metaField": "meta",
-                "granularity": "seconds",
+                "granularity": "hours",
             },
         )
 

--- a/tests/unit/schemas/models/test_click.py
+++ b/tests/unit/schemas/models/test_click.py
@@ -50,3 +50,19 @@ class TestClickDoc:
         restored = ClickDoc.from_mongo(doc.to_mongo())
         assert restored.referrer == "google.com"
         assert restored.redirect_ms == doc.redirect_ms
+
+    def test_to_mongo_omits_none_fields(self):
+        # Explicit nulls flip the per-field BSON type and close time-series
+        # buckets; None fields must be absent from the insert document.
+        data = self._make(referrer=None, bot_name=None).to_mongo()
+        assert "referrer" not in data
+        assert "bot_name" not in data
+        assert "device" not in data
+        assert "utm_source" not in data
+        assert "domain" not in data["meta"]
+
+    def test_to_mongo_keeps_set_fields(self):
+        data = self._make(referrer="google.com", device="mobile").to_mongo()
+        assert data["referrer"] == "google.com"
+        assert data["device"] == "mobile"
+        assert data["country"] == "Unknown"

--- a/tests/unit/services/test_click_service.py
+++ b/tests/unit/services/test_click_service.py
@@ -303,10 +303,11 @@ class TestV2ClickHandler:
 
         await handler.handle(make_context(url_data))
 
+        # Absent, not null: explicit nulls close time-series buckets.
         doc = d.click_repo.insert.call_args[0][0]
-        assert doc["utm_source"] is None
-        assert doc["utm_medium"] is None
-        assert doc["utm_campaign"] is None
+        assert "utm_source" not in doc
+        assert "utm_medium" not in doc
+        assert "utm_campaign" not in doc
 
     @pytest.mark.asyncio
     async def test_meta_carries_domain_from_cache(self):
@@ -320,9 +321,10 @@ class TestV2ClickHandler:
         assert doc["meta"]["domain"] == "links.acme.com"
 
     @pytest.mark.asyncio
-    async def test_meta_domain_none_when_cache_empty_string(self):
-        # Older cached entries pre-PR1 have domain="". Coerce to None so
-        # per-domain queries can distinguish "unknown" from a real value.
+    async def test_meta_domain_omitted_when_cache_empty_string(self):
+        # Older cached entries pre-PR1 have domain="". Coerced to None and
+        # then omitted from the insert doc ($eq: null matches missing, so
+        # per-domain queries still distinguish "unknown" from a real value).
         d = make_deps()
         handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
         url_data = make_v2_cache(domain="")
@@ -330,7 +332,7 @@ class TestV2ClickHandler:
         await handler.handle(make_context(url_data))
 
         doc = d.click_repo.insert.call_args[0][0]
-        assert doc["meta"]["domain"] is None
+        assert "domain" not in doc["meta"]
 
     @pytest.mark.asyncio
     async def test_blocked_bot_skips_analytics_no_error(self):


### PR DESCRIPTION
## What

Two write-path fixes for the clicks time-series collection. Together they stop most bucket churn: buckets that close after a handful of measurements instead of filling toward the 1000 cap, which bloats storage and slows every range scan.

## The fixes

**Omit None fields from click inserts.** A time-series bucket tracks one BSON type per field. A click carrying `referrer: null` after one carrying a string is a type conflict, and the bucket closes on the spot; with nullable fields on every click (`referrer`, `bot_name`), busy links close buckets every few measurements. An absent field causes no conflict, so `ClickDoc.to_mongo()` now drops None fields entirely. Reproduced in a test: 200 same-minute clicks alternating string/null produced 200 buckets; the same workload with the field omitted packs into one.

Queries are unaffected: MongoDB treats missing like null in `$eq` and `$group`, and the stats sentinel filters already match both (they carry explicit `$exists: false` arms).

**Default new clicks collections to hours granularity.** Seconds granularity caps a bucket at one hour of wall time, but a typical short link gets single clicks hours or days apart, one bucket per click. Hours granularity spans buckets across 30 days, so a sparse link produces roughly one bucket a month. Only affects collection creation (fresh and self-hosted deploys); existing collections keep their setting and need a one-time online migration, since Mongo only allows coarsening:

```
db.runCommand({collMod: "clicks", timeseries: {granularity: "hours"}})
```

The trade is coarser per-bucket time pruning, which is irrelevant here: every stats query filters on the meta field (link, owner) before any time range.

## Blast radius

- Write path only; no query changes anywhere.
- Old clicks written with explicit nulls stay valid; readers already treat missing and null alike.
- Self-hosters get the right granularity on first boot; the README-level migration note for existing deploys can ride the release notes.

## Testing

Unit suites for the click model, click service, and index bootstrap updated and passing (2,156 total). Bucket behavior verified against a real MongoDB: the string/null alternation repro, the absent-field packing, and the granularity change applied online to a live collection with results confirmed on both sides.
