### PR TITLE
fix(metadata): gate the destination fetcher on the meta tags flag

### DIFF
--- a/routes/api_v1/metadata.py
+++ b/routes/api_v1/metadata.py
@@ -3,7 +3,8 @@
 The prefill companion to custom meta-tags (Dub precedent: api.dub.co/
 metatags): clients call this to pre-populate title/description/image from
 the destination before customizing. Auth-required — an anonymous version
-would be a free fetch-proxy for the whole internet — with its own tight
+would be a free fetch-proxy for the whole internet — and gated on the same
+``custom_meta_tags`` flag as the write paths it feeds, with its own tight
 rate limit, SSRF-guarded fetching, and Redis caching (1h / 5m negative).
 """
 
@@ -14,7 +15,13 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Request
 
-from dependencies import URL_READ_SCOPES, CurrentUser, Settings, require_scopes
+from dependencies import (
+    URL_READ_SCOPES,
+    CurrentUser,
+    FeatureFlagSvc,
+    Settings,
+    require_scopes,
+)
 from errors import AppError, ValidationError
 from infrastructure.logging import get_logger
 from infrastructure.safe_fetch import (
@@ -25,6 +32,7 @@ from infrastructure.safe_fetch import (
 from middleware.openapi import AUTH_RESPONSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.dto.responses.metadata import MetadataResponse
+from services.feature_flag_service import META_TAGS_FLAG
 from services.meta_tags.parse_html import parse_meta_tags
 
 log = get_logger(__name__)
@@ -65,6 +73,7 @@ async def get_metadata(
         ),
     ],
     settings: Settings,
+    flag_svc: FeatureFlagSvc,
     user: CurrentUser = Depends(require_scopes(URL_READ_SCOPES)),  # noqa: B008
 ) -> MetadataResponse:
     """Fetch a destination page and return its existing meta tags.
@@ -76,9 +85,18 @@ async def get_metadata(
     **Authentication**: Required. **API Key Scope**: `urls:read`,
     `urls:manage`, or `admin:all`.
 
+    **Feature gate**: `custom_meta_tags` must be enabled for the calling
+    account — this endpoint only exists to feed that feature.
+
     **Rate Limits**: 20/min, 500/day — results are cached ~1h server-side,
     so repeat calls for the same URL are cheap and don't refetch.
     """
+    # Same gate as the write paths that consume this prefill (POST /shorten,
+    # PATCH /urls/{id}). 403 rather than a hiding 404: those siblings already
+    # answer 403 for the same flag and the endpoint is in the public OpenAPI
+    # spec, so there is no existence left to conceal.
+    await flag_svc.require(META_TAGS_FLAG, user)
+
     if not url.startswith("https://"):
         raise ValidationError("url must be https", field="url")
 

--- a/tests/integration/api_v1/test_metadata.py
+++ b/tests/integration/api_v1/test_metadata.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
-from dependencies import get_current_user
+from dependencies import get_current_user, get_feature_flag_service
+from errors import ForbiddenError
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
 from infrastructure.safe_fetch import FetchedBody, FetchHardError, FetchTransientError
 
@@ -18,8 +19,27 @@ HTML = b"""<html><head>
 </head><body></body></html>"""
 
 
-def _app(user=None):
-    app = _build_test_app({get_current_user: lambda: user or _make_user()})
+def _flag_svc(enabled: bool) -> AsyncMock:
+    svc = AsyncMock()
+    svc.is_enabled = AsyncMock(return_value=enabled)
+
+    async def _require(name: str, user, **_kw) -> None:
+        # Mirrors FeatureFlagService.require: raise 403 when disabled.
+        if not enabled:
+            feature = name.replace("_", " ").capitalize()
+            raise ForbiddenError(f"{feature} is not enabled for this account")
+
+    svc.require = AsyncMock(side_effect=_require)
+    return svc
+
+
+def _app(user=None, flag_enabled: bool = True):
+    app = _build_test_app(
+        {
+            get_current_user: lambda: user or _make_user(),
+            get_feature_flag_service: lambda: _flag_svc(flag_enabled),
+        }
+    )
     app.state.meta_fetch_cache = MetaFetchCache(None)  # no-op cache
     return app
 
@@ -30,6 +50,18 @@ def test_metadata_requires_auth():
     with TestClient(app, raise_server_exceptions=False) as client:
         resp = client.get("/api/v1/metadata", params={"url": "https://dest.example"})
     assert resp.status_code == 401
+
+
+def test_metadata_requires_flag():
+    # Same gate as the write paths this prefill feeds: no flag, no fetch.
+    fetch = AsyncMock()
+    with (
+        patch("routes.api_v1.metadata.fetch_public", new=fetch),
+        TestClient(_app(flag_enabled=False), raise_server_exceptions=False) as client,
+    ):
+        resp = client.get("/api/v1/metadata", params={"url": "https://dest.example"})
+    assert resp.status_code == 403
+    fetch.assert_not_called()
 
 
 def test_metadata_parses_destination():


### PR DESCRIPTION
## The inconsistency

`GET /api/v1/metadata` fetches a destination page and returns its parsed meta tags. It is the prefill companion to custom meta tags: the client calls it, then sends the result back through `POST /api/v1/shorten` or `PATCH /api/v1/urls/{id}`.

Both of those write paths call `flag_svc.require(META_TAGS_FLAG, user)`. The fetcher did not. It only required auth and `urls:read`, so writing meta tags was gated while the endpoint that exists to support that writing was open to every authenticated caller, whether or not the feature was enabled for their account.

The consequence is a wider surface than intended. This endpoint makes server side requests to arbitrary third party URLs. It is SSRF guarded, rate limited (20/min, 500/day) and cached, so the exposure is bounded, but an ungated authed fetch proxy is available to far more accounts than the feature it serves.

## The fix

Adds `await flag_svc.require(META_TAGS_FLAG, user)` as the first statement of the handler, through the same `FeatureFlagSvc` dependency alias the sibling routes use.

403, not a hiding 404. The custom domains routes hide behind 404 because the existence of that feature is itself concealed. `custom_meta_tags` is not concealed: the write paths already answer 403 for it, `GET /api/v1/me/features` reports its state, and this endpoint is published in the OpenAPI spec. A 404 here would conceal nothing and would disagree with its own siblings. 403 is already in the endpoint's declared responses, so the documented contract does not change shape.

## Audit of the other routes

Checked every route under `routes/api_v1/` against the five registered flags. No other gaps:

- `custom_domains`: create is gated (404); reads, verify and delete stay open on purpose so a de-allowlisted owner can still see and remove domains.
- `webhooks`: create, test send and retry are gated, which are the paths that make outbound calls. Passive management of existing endpoints is intentionally not gated.
- `geo_targeting`: gated on both write paths. The redirect path applies already stored rules and is not an authoring path.
- `ab_testing`: registered as a flag, no endpoints yet.

## Tests

`test_metadata_requires_flag` asserts 403 when the flag is off and that no fetch is attempted, using the same `_flag_svc` mock shape as the existing meta tags and custom domain route tests. The rest of the metadata tests now build their app with the flag on explicitly rather than leaning on the default mock.

Full suite: 3002 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata access is now controlled by the `custom_meta_tags` feature flag.
  * Requests without access receive a forbidden response before any metadata processing occurs.

* **Bug Fixes**
  * Prevented unauthorized metadata requests from triggering URL validation, caching, fetching, or parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->