### PR TITLE
fix(oauth): set Secure on the OAuth state cookie

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from infrastructure.email.zeptomail import ZeptoMailProvider
 from infrastructure.geoip import GeoIPService
 from infrastructure.http_client import HttpClient
 from infrastructure.logging import get_logger
-from infrastructure.oauth_clients import init_oauth
+from infrastructure.oauth_clients import OAUTH_STATE_TTL_SECONDS, init_oauth
 from infrastructure.queue_redis import connect_queue_redis
 from infrastructure.templates import configure_template_globals, templates
 from middleware.error_handler import register_error_handlers
@@ -259,8 +259,37 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         )
 
     # ── Middleware (registered in reverse execution order) ────────────────
-    # 1. Session — outermost, needed by Authlib OAuth for state storage
-    app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
+    # 1. Session — needed by Authlib OAuth for state storage.
+    #    Authlib is the only reader/writer: authorize_redirect() stores
+    #    _state_{provider}_{state} in the session and the callback reads it
+    #    back, so this cookie is the whole OAuth flow's memory. Nothing else
+    #    in the app touches request.session.
+    #
+    #    Every option is spelled out rather than defaulted, because two of
+    #    the Starlette defaults are wrong for a cookie with that job:
+    #
+    #    https_only — defaults to False, which ships the cookie without the
+    #      Secure flag. On an HTTPS-only origin that is simply wrong: it
+    #      leaves the flow's CSRF state readable on any plain-http request to
+    #      spoo.me, and it makes the cookie eligible for the eviction rules
+    #      browsers reserve for insecure cookies during the cross-site
+    #      redirect out to the provider and back. Gated on is_production, the
+    #      same gate HSTS uses, so plain-http local development still works.
+    #    max_age — defaults to 14 days, and doubles as the signature lifetime.
+    #      A consent screen takes minutes; OAUTH_STATE_TTL_SECONDS is the
+    #      ceiling verify_oauth_state() already enforces on the state string,
+    #      so both halves of the flow now expire together instead of the
+    #      cookie outliving its own state by two weeks.
+    #    same_site — lax, matching the auth cookies. It has to stay lax: the
+    #      provider sends the user back with a top-level cross-site GET, and
+    #      strict would withhold the cookie on exactly that navigation.
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=settings.secret_key,
+        max_age=OAUTH_STATE_TTL_SECONDS,
+        same_site="lax",
+        https_only=settings.is_production,
+    )
     # 2. Security headers — must be outer so HSTS/CSP/nosniff apply to
     #    all responses including CORS preflights (204) and body-limit (413)
     app.add_middleware(SecurityHeadersMiddleware, hsts_enabled=settings.is_production)

--- a/app.py
+++ b/app.py
@@ -259,30 +259,14 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         )
 
     # ── Middleware (registered in reverse execution order) ────────────────
-    # 1. Session — needed by Authlib OAuth for state storage.
-    #    Authlib is the only reader/writer: authorize_redirect() stores
-    #    _state_{provider}_{state} in the session and the callback reads it
-    #    back, so this cookie is the whole OAuth flow's memory. Nothing else
-    #    in the app touches request.session.
-    #
-    #    Every option is spelled out rather than defaulted, because two of
-    #    the Starlette defaults are wrong for a cookie with that job:
-    #
-    #    https_only — defaults to False, which ships the cookie without the
-    #      Secure flag. On an HTTPS-only origin that is simply wrong: it
-    #      leaves the flow's CSRF state readable on any plain-http request to
-    #      spoo.me, and it makes the cookie eligible for the eviction rules
-    #      browsers reserve for insecure cookies during the cross-site
-    #      redirect out to the provider and back. Gated on is_production, the
-    #      same gate HSTS uses, so plain-http local development still works.
-    #    max_age — defaults to 14 days, and doubles as the signature lifetime.
-    #      A consent screen takes minutes; OAUTH_STATE_TTL_SECONDS is the
-    #      ceiling verify_oauth_state() already enforces on the state string,
-    #      so both halves of the flow now expire together instead of the
-    #      cookie outliving its own state by two weeks.
-    #    same_site — lax, matching the auth cookies. It has to stay lax: the
-    #      provider sends the user back with a top-level cross-site GET, and
-    #      strict would withhold the cookie on exactly that navigation.
+    # 1. Session — Authlib OAuth state is the only reader/writer; nothing
+    #    else touches request.session. max_age doubles as the itsdangerous
+    #    signature lifetime, so it tracks OAUTH_STATE_TTL_SECONDS and both
+    #    halves of the flow expire together. same_site must stay lax: the
+    #    provider returns the user with a top-level cross-site GET, and
+    #    strict would drop the cookie on exactly that navigation. Secure is
+    #    gated on is_production, the same gate HSTS uses, so plain-http
+    #    local dev still works.
     app.add_middleware(
         SessionMiddleware,
         secret_key=settings.secret_key,

--- a/infrastructure/oauth_clients.py
+++ b/infrastructure/oauth_clients.py
@@ -147,6 +147,13 @@ def init_oauth(settings: Any) -> tuple[OAuth | None, dict[str, Any]]:
 
 # ── State utilities ───────────────────────────────────────────────────────────
 
+# How long a login/link flow may stay in flight. Long enough for a provider
+# consent screen (account picker, password, 2FA), short enough that the CSRF
+# state is not a durable credential. app.py reuses this as the lifetime of the
+# session cookie Authlib keeps its half of the state in, so the two halves of
+# the flow expire together.
+OAUTH_STATE_TTL_SECONDS = 600
+
 
 def generate_oauth_state(
     provider: str,
@@ -194,7 +201,7 @@ def verify_oauth_state(
 
         timestamp = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
         age = (datetime.now(timezone.utc) - timestamp).total_seconds()
-        if age > 600:
+        if age > OAUTH_STATE_TTL_SECONDS:
             return False, {}, "expired"
 
         return True, state_data, None

--- a/tests/smoke/test_middleware_stack.py
+++ b/tests/smoke/test_middleware_stack.py
@@ -7,6 +7,15 @@ import os
 os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 
 from fastapi.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.routing import Route
+
+from config import AppSettings
+from infrastructure.oauth_clients import OAUTH_STATE_TTL_SECONDS
 
 
 def test_x_request_id_header_present(smoke_client: TestClient) -> None:
@@ -75,6 +84,83 @@ def test_session_middleware_present(smoke_client: TestClient) -> None:
     # If SessionMiddleware were missing, OAuth state writes would crash.
     # A healthy response proves the middleware stack is functional.
     assert resp.status_code in (200, 503)
+
+
+# ── OAuth state cookie ────────────────────────────────────────────────────────
+#
+# The session cookie is where Authlib keeps its half of the OAuth state, so a
+# missing or dropped cookie fails every callback. Assert the flags the real
+# create_app() configures rather than the ones a test app happens to pass.
+
+
+def _oauth_state_cookie_attrs(*, production: bool) -> set[str]:
+    """Set-Cookie attributes create_app() emits for the session cookie.
+
+    Lifts the registered SessionMiddleware (class plus its keyword arguments)
+    out of the real application and replays it over a route that writes to the
+    session, so the assertions below read the header a browser would receive.
+    """
+    from app import create_app
+
+    settings = AppSettings()
+    settings.env = "production" if production else "development"
+    # A DSN in a developer's local .env would otherwise re-initialise Sentry
+    # with environment="production" as a side effect of this test.
+    settings.sentry.sentry_dsn = ""
+
+    entry = next(
+        mw for mw in create_app(settings).user_middleware if mw.cls is SessionMiddleware
+    )
+
+    async def write_state(request: Request) -> Response:
+        request.session["_state_google_test"] = {"data": {}}
+        return PlainTextResponse("ok")
+
+    probe = Starlette(
+        routes=[Route("/probe", write_state)],
+        middleware=[Middleware(entry.cls, *entry.args, **entry.kwargs)],
+    )
+    header = TestClient(probe).get("/probe").headers["set-cookie"]
+    # Attribute names only — the cookie value is base64 and could contain any
+    # substring we might otherwise search the raw header for.
+    return {part.strip().lower() for part in header.split(";")[1:]}
+
+
+def test_oauth_state_cookie_is_secure_in_production() -> None:
+    """The state cookie must carry Secure on an HTTPS-only origin.
+
+    Without it the cookie travels on plain-http requests to spoo.me and is
+    eligible for the eviction rules browsers apply to insecure cookies across
+    the redirect out to the provider and back, which loses the flow's state.
+    """
+    assert "secure" in _oauth_state_cookie_attrs(production=True)
+
+
+def test_oauth_state_cookie_is_not_secure_in_development() -> None:
+    """Secure is gated on production so plain-http local development works."""
+    assert "secure" not in _oauth_state_cookie_attrs(production=False)
+
+
+def test_oauth_state_cookie_is_httponly_and_lax() -> None:
+    """HttpOnly keeps the state out of scripts; lax survives the callback.
+
+    The provider returns the user with a top-level cross-site GET, which lax
+    allows and strict would not.
+    """
+    attrs = _oauth_state_cookie_attrs(production=True)
+    assert "httponly" in attrs
+    assert "samesite=lax" in attrs
+
+
+def test_oauth_state_cookie_expires_with_the_state_it_holds() -> None:
+    """Cookie lifetime matches the ceiling verify_oauth_state() enforces.
+
+    Starlette uses max_age for both the Max-Age attribute and the signature
+    lifetime, so the default of 14 days would leave the cookie valid long
+    after the state string inside it had expired.
+    """
+    attrs = _oauth_state_cookie_attrs(production=True)
+    assert f"max-age={OAUTH_STATE_TTL_SECONDS}" in attrs
 
 
 def test_middleware_ordering_correct(smoke_app) -> None:


### PR DESCRIPTION
## What is failing

`GET /oauth/{provider}/callback` raises `AppError: OAuth authentication failed`
(Sentry SPOO-PROD-110). Underneath it is Authlib's
`MismatchingStateError: CSRF Warning! State not equal in request and response`,
thrown from `client.authorize_access_token(request)`.

The OAuth flow keeps its state in two places. Our own signed `state` string
travels through the provider and is checked by `verify_oauth_state()`, and that
half always survives. Authlib keeps the other half server side, under
`_state_{provider}_{state}` in `request.session`, which Starlette serialises
into a single `session` cookie. If that cookie does not come back with the
callback, `get_state_data()` returns `None`, `_format_state_params()` raises,
and the user sees a failed login. The cookie is the entire memory of the flow.

## Evidence

330 occurrences since 2026-05-25, still firing. The affected user agents are
overwhelmingly mobile: Samsung Internet, Chrome Mobile, Android WebView. Desktop
browsers are close to absent from the sample. Every event arrives back from
`accounts.google.com`, so the provider round trip completed and the user really
did consent. The state query parameter is present and passes our own check,
which is why the failure only shows up one line later inside Authlib.

That shape points at the cookie rather than at the state string, and at
something browser side rather than server side.

## What was wrong

`SessionMiddleware` was registered with only `secret_key`, so every other option
was a Starlette default:

- `https_only=False`, so the cookie went out with no `Secure` attribute even
  though spoo.me is HTTPS only and sends HSTS.
- `max_age=14 days`, for what is a few minutes of CSRF state. Starlette uses
  `max_age` for both the `Max-Age` attribute and the itsdangerous signature
  lifetime, so a stale cookie stayed cryptographically valid for a fortnight
  after the state inside it had expired.
- `same_site` left implicit.

A cookie without `Secure` is treated as an insecure cookie by the browser
regardless of how it arrived. It is sent on plain http requests to the origin,
and it sits in the bucket browsers are most willing to evict, partition or
refuse to restore across a third party redirect chain. Mobile browsers are the
strictest here, which matches the user agent distribution exactly.

## The fix

Spell out every security relevant option so the intent is visible:

```python
app.add_middleware(
    SessionMiddleware,
    secret_key=settings.secret_key,
    max_age=OAUTH_STATE_TTL_SECONDS,
    same_site="lax",
    https_only=settings.is_production,
)
```

`same_site` stays `lax` deliberately. The provider returns the user with a
top level cross site GET, which lax permits and strict would not. Raising it
would break the callback outright.

`max_age` becomes `OAUTH_STATE_TTL_SECONDS` (600), which is the ceiling
`verify_oauth_state()` already applies to the state string. It is now a shared
constant instead of a literal in one file and a default in another. This cannot
turn a working login into a failing one: the cookie is signed a moment *after*
the state string is generated, so our own check reports "invalid state
parameter" fractionally before the cookie signature would expire. Anyone slow
enough to trip the new cookie lifetime was already being rejected.

## Why Secure is safe even though the app sees http

This is the part worth double checking, so stating it plainly.

Sentry logs the callback URL as `http://spoo.me/oauth/google/callback`. That is
real: uvicorn runs without `--forwarded-allow-ips`, so its proxy header handling
only trusts `127.0.0.1` while Caddy reaches it from `172.30.0.20` on the compose
network. Caddy does send `X-Forwarded-Proto: https`, uvicorn just declines to
believe it, and the ASGI scope keeps `scheme: http`.

That does not matter here, because nothing in the path consults the scheme:

1. Starlette's `SessionMiddleware` treats `https_only` as a string flag. It
   appends `"; secure"` to a precomputed `security_flags` at construction time
   and never looks at the request. There is no code path where an app that
   believes it is on http refuses to emit a `Secure` cookie.
2. `Secure` is enforced by the browser against the browser's own connection, not
   against whatever the origin server privately believes. The client speaks
   HTTPS to Cloudflare, Cloudflare speaks TLS to Caddy using the Origin CA
   certificate, and only the last hop inside the compose network is plaintext.
   The browser will send the cookie.

The existing auth cookies already prove this end to end. `set_auth_cookies()`
sets `secure=jwt_cfg.cookie_secure`, which defaults to `True`, and logged in
sessions work in production today under exactly the same scheme confusion. The
session cookie was the one auth related cookie that had been left out.

Gating on `settings.is_production` matches how `hsts_enabled` is already gated,
and keeps plain http local development working.

## Deliberately not in this PR

**`--forwarded-allow-ips`.** It is a real gap and it should be fixed, but it is
a deploy configuration change with a wider blast radius than a cookie flag, and
it is not required for this fix. Making uvicorn trust Caddy would flip
`request.url.scheme` and `request.base_url` app wide, which changes the
`host_url` baked into the rendered error page, the `is_https` field on every log
line, and the `short_url` returned by the legacy shortener at
`routes/legacy/url_shortener.py:379`. It would also change `request.client.host`,
which the legacy shortener records as `creation-ip-address` and which currently
stores Caddy's container IP on every row. Those are all worth fixing and all
worth verifying on their own, not as a rider on an auth fix.

Rate limiting is unaffected either way. `rate_limit_key()` falls through to
`get_client_ip()`, which reads `CF-Connecting-IP` from the headers directly and
never depends on uvicorn rewriting the scope.

When that change is made it should set the trust list explicitly rather than
widening it to `*`. Only Caddy can reach port 8000 on the compose network, port
8000 is not published to the host, and UFW restricts inbound 443 to Cloudflare
ranges, so the trusted set is one known container address.

## Residual causes

This removes the most likely cause and is correct on its own merits regardless
of how much of the 330 it accounts for. Other paths to the same exception remain
possible and are not addressed here. The clearest one: `set_state_data()` clears
any previous `_state_{provider}_*` entry before writing a new one, so a user who
double taps "Sign in with Google" invalidates the first attempt's state. Worth
watching the Sentry rate after this ships rather than assuming it goes to zero.

## Tests

Four new tests in `tests/smoke/test_middleware_stack.py`. They lift the
registered `SessionMiddleware` out of the real `create_app()` and replay it over
a route that writes to the session, so they assert the `Set-Cookie` header a
browser would actually receive rather than the arguments a test app happens to
pass. Two of them fail against the previous code.

`uv run pytest tests/ -q` passes, 3005 tests. Pre-commit (`ruff`, `ruff-format`)
is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved OAuth session-cookie protection with production-only secure transmission.
  * Applied consistent expiration timing for OAuth state data.
  * Configured cookies with `HttpOnly` and `SameSite=Lax` settings to reduce exposure and cross-site risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->