### PR TITLE
feat(stats): domain dimension on the stats API

### DIFF
--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -169,7 +169,7 @@ STATS_DOMAIN_DESC = (
     "Comma-separated domains the short links were served on (the system "
     "default domain or your custom domains). Alternative to using the "
     "`filters` JSON parameter.\n\n"
-    "**Important:** Use the exact lowercase fqdn (e.g. `links.example.com`). "
+    "**Important:** Values are case-insensitive (normalized to lowercase). "
     "`unknown` matches clicks recorded before domain tracking existed.\n\n"
     "**Note:** Both `filters` JSON and individual parameters can be combined."
 )

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -46,6 +46,8 @@ STATS_GROUP_BY_DESC = (
     "- `city` — group by city\n"
     "- `referrer` — group by referrer URL\n"
     "- `short_code` — group by URL alias (only with `scope=all`)\n"
+    "- `domain` — group by the domain the short link is served on "
+    "(clicks recorded before domain tracking appear as `unknown`)\n"
     "- `utm_source` — group by the `utm_source` tag on the short link "
     "(untagged clicks appear as `(none)`)\n"
     "- `utm_medium` — group by the `utm_medium` tag\n"
@@ -80,6 +82,9 @@ STATS_FILTERS_DESC = (
     "- `referrer` — Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n"
     "- `short_code` — Filter by URL alias (e.g., mylink, promo2024) — "
     "**not allowed** with `scope=anon`\n"
+    "- `domain` — Filter by the serving domain (e.g., spoo.me, "
+    "links.example.com); `unknown` matches clicks recorded before domain "
+    "tracking existed\n"
     "- `utm_source` / `utm_medium` / `utm_campaign` — Filter by campaign tags; "
     "`(none)` matches untagged clicks\n\n"
     "**Value format:** Array of strings for each dimension.\n\n"
@@ -156,6 +161,16 @@ STATS_UTM_DESC = (
     "JSON parameter.\n\n"
     "**Important:** Values are case-sensitive. `(none)` matches clicks with "
     "no tag.\n\n"
+    "**Note:** Both `filters` JSON and individual parameters can be combined."
+)
+
+STATS_DOMAIN_DESC = (
+    "**Method 2: Individual Filter Parameter**\n\n"
+    "Comma-separated domains the short links were served on (the system "
+    "default domain or your custom domains). Alternative to using the "
+    "`filters` JSON parameter.\n\n"
+    "**Important:** Use the exact lowercase fqdn (e.g. `links.example.com`). "
+    "`unknown` matches clicks recorded before domain tracking existed.\n\n"
     "**Note:** Both `filters` JSON and individual parameters can be combined."
 )
 

--- a/schemas/dto/requests/stats.py
+++ b/schemas/dto/requests/stats.py
@@ -254,6 +254,15 @@ class StatsQuery(RequestBase):
                     continue
                 parsed_filters[dim] = _parse_comma_separated(raw)
 
+        # Domains are case-insensitive by definition and stored lowercase
+        # (model normalizer), so fold caller casing — "Spoo.me" must not
+        # silently match nothing. The only normalized dimension; all others
+        # filter on case-sensitive stored values.
+        if StatsDimension.DOMAIN in parsed_filters:
+            parsed_filters[StatsDimension.DOMAIN] = [
+                v.lower() for v in parsed_filters[StatsDimension.DOMAIN]
+            ]
+
         self._parsed_filters = parsed_filters
 
         return self

--- a/schemas/dto/requests/stats.py
+++ b/schemas/dto/requests/stats.py
@@ -26,6 +26,7 @@ from schemas.dto.requests._descriptions import (
     STATS_CITY_DESC,
     STATS_COUNTRY_DESC,
     STATS_DEVICE_DESC,
+    STATS_DOMAIN_DESC,
     STATS_END_DATE_DESC,
     STATS_FILTERS_DESC,
     STATS_GROUP_BY_DESC,
@@ -154,6 +155,12 @@ class StatsQuery(RequestBase):
         description=STATS_REFERRER_DESC,
         examples=["https://google.com,https://twitter.com"],
     )
+    domain: str | None = Field(
+        default=None,
+        max_length=1000,
+        description=STATS_DOMAIN_DESC,
+        examples=["spoo.me,links.example.com"],
+    )
     utm_source: str | None = Field(
         default=None,
         max_length=1000,
@@ -234,6 +241,7 @@ class StatsQuery(RequestBase):
             "country",
             "city",
             "referrer",
+            "domain",
             "short_code",
             "utm_source",
             "utm_medium",

--- a/schemas/enums/stats.py
+++ b/schemas/enums/stats.py
@@ -29,6 +29,7 @@ class StatsDimension(str, Enum):
     CITY = "city"
     REFERRER = "referrer"
     SHORT_CODE = "short_code"
+    DOMAIN = "domain"
     UTM_SOURCE = "utm_source"
     UTM_MEDIUM = "utm_medium"
     UTM_CAMPAIGN = "utm_campaign"
@@ -62,6 +63,7 @@ ALLOWED_FILTERS = frozenset(
         StatsDimension.CITY,
         StatsDimension.REFERRER,
         StatsDimension.SHORT_CODE,
+        StatsDimension.DOMAIN,
         StatsDimension.UTM_SOURCE,
         StatsDimension.UTM_MEDIUM,
         StatsDimension.UTM_CAMPAIGN,

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -71,9 +71,17 @@ _KNOWN_TIMEZONES: frozenset[str] = frozenset(available_timezones())
 _NULL_SENTINEL_FILTERS: dict[StatsDimension, str] = {
     StatsDimension.REFERRER: "Direct",
     StatsDimension.DEVICE: "unknown",
+    StatsDimension.DOMAIN: "unknown",
     StatsDimension.UTM_SOURCE: "(none)",
     StatsDimension.UTM_MEDIUM: "(none)",
     StatsDimension.UTM_CAMPAIGN: "(none)",
+}
+
+# Dimensions whose clicks field lives under the time-series metaField rather
+# than at the top level. short_code is not listed — it has its own branch
+# (scope-bypass prevention).
+_FILTER_FIELD_PATHS: dict[StatsDimension, str] = {
+    StatsDimension.DOMAIN: "meta.domain",
 }
 
 
@@ -205,18 +213,19 @@ class StatsService:
                 and _NULL_SENTINEL_FILTERS[dimension] in values
             ):
                 # The stored-value $in keeps the sentinel: for device,
-                # "unknown" is also a real stored value; for referrer/utm
-                # the extra literal matches nothing (and if a visitor ever
-                # sends the literal, group-by merges it with null anyway).
+                # "unknown" is also a real stored value; for referrer/utm/
+                # domain the extra literal matches nothing (and if a stored
+                # value ever equalled it, group-by merges it with null anyway).
+                field = _FILTER_FIELD_PATHS.get(dimension, dimension)
                 or_groups.append(
                     [
-                        {dimension: {"$in": values}},
-                        {dimension: {"$in": [None, ""]}},
-                        {dimension: {"$exists": False}},
+                        {field: {"$in": values}},
+                        {field: {"$in": [None, ""]}},
+                        {field: {"$exists": False}},
                     ]
                 )
             else:
-                query[dimension] = {"$in": values}
+                query[_FILTER_FIELD_PATHS.get(dimension, dimension)] = {"$in": values}
 
         if len(or_groups) == 1:
             query["$or"] = or_groups[0]

--- a/shared/aggregation_strategies.py
+++ b/shared/aggregation_strategies.py
@@ -98,7 +98,22 @@ class FieldAggregationStrategy(AggregationStrategy):
 
     def build_pipeline(self, base_query: dict[str, Any]) -> list[dict[str, Any]]:
         if self._default is not None:
-            group_expr: Any = {"$ifNull": [self._mongo_field, self._default]}
+            # Sentinel dimensions: null, missing, AND empty string all mean
+            # the sentinel — the filter side's $or group folds "" the same
+            # way ($in: [None, ""]), so group-by and filter counts can never
+            # disagree on legacy document shapes.
+            group_expr: Any = {
+                "$ifNull": [
+                    {
+                        "$cond": [
+                            {"$eq": [self._mongo_field, ""]},
+                            None,
+                            self._mongo_field,
+                        ]
+                    },
+                    self._default,
+                ]
+            }
         else:
             group_expr = {"$ifNull": [self._mongo_field, "Unknown"]}
 

--- a/shared/aggregation_strategies.py
+++ b/shared/aggregation_strategies.py
@@ -274,6 +274,12 @@ class AggregationStrategyFactory:
         "short_code": lambda: FieldAggregationStrategy(
             "$meta.short_code", "short_code", 100
         ),
+        # "unknown" = clicks recorded before domain stamping existed
+        # (time-series buckets can't be backfilled). It can never collide
+        # with a real value: domains are always dotted fqdns.
+        "domain": lambda: FieldAggregationStrategy(
+            "$meta.domain", "domain", 50, default="unknown"
+        ),
         # "(none)" = untagged clicks (and clicks recorded before the utm
         # fields existed) — the campaign analogue of referrer's "Direct".
         "utm_source": lambda: FieldAggregationStrategy(

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -70,6 +70,18 @@ class TestStatsQuery:
         assert q.parsed_filters["device"] == ["mobile"]
         assert q.parsed_filters["utm_source"] == ["(none)"]
 
+    def test_domain_dimension_accepted_in_group_by(self):
+        q = StatsQuery.model_validate({"group_by": "domain"})
+        assert q.parsed_group_by == ["domain"]
+
+    def test_domain_filter_param_parsed(self):
+        q = StatsQuery.model_validate({"domain": "spoo.me,links.example.com"})
+        assert q.parsed_filters["domain"] == ["spoo.me", "links.example.com"]
+
+    def test_domain_accepted_in_filters_json(self):
+        q = StatsQuery.model_validate({"filters": json.dumps({"domain": ["unknown"]})})
+        assert q.parsed_filters["domain"] == ["unknown"]
+
     def test_comma_separated_metrics(self):
         assert StatsQuery.model_validate(
             {"metrics": "unique_clicks"}

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -82,6 +82,20 @@ class TestStatsQuery:
         q = StatsQuery.model_validate({"filters": json.dumps({"domain": ["unknown"]})})
         assert q.parsed_filters["domain"] == ["unknown"]
 
+    def test_domain_filter_values_case_folded(self):
+        """Domains are case-insensitive by definition and stored lowercase,
+        so caller casing must not silently match nothing. Both the param
+        and the filters JSON go through the fold; other dimensions stay
+        case-sensitive."""
+        q = StatsQuery.model_validate({"domain": "Spoo.Me,LINKS.example.com"})
+        assert q.parsed_filters["domain"] == ["spoo.me", "links.example.com"]
+
+        q = StatsQuery.model_validate(
+            {"filters": json.dumps({"domain": ["Spoo.me"], "browser": ["Chrome"]})}
+        )
+        assert q.parsed_filters["domain"] == ["spoo.me"]
+        assert q.parsed_filters["browser"] == ["Chrome"]
+
     def test_comma_separated_metrics(self):
         assert StatsQuery.model_validate(
             {"metrics": "unique_clicks"}

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -589,6 +589,43 @@ class TestClickQueryBuilding:
             {"device": {"$exists": False}},
         ]
 
+    def test_plain_domain_filter_targets_meta_field(self):
+        """Domain lives under the time-series metaField — a filter keyed
+        on bare "domain" would silently match nothing."""
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"domain": ["links.example.com"]}
+        )
+        assert q["meta.domain"] == {"$in": ["links.example.com"]}
+        assert "domain" not in q
+
+    def test_domain_unknown_sentinel_matches_missing_field(self):
+        """ "unknown" must match clicks recorded before domain stamping
+        existed (null/absent meta.domain), on the meta path."""
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            "all", OWNER_ID, None, START, NOW, {"domain": ["unknown", "spoo.me"]}
+        )
+        assert q["$or"] == [
+            {"meta.domain": {"$in": ["unknown", "spoo.me"]}},
+            {"meta.domain": {"$in": [None, ""]}},
+            {"meta.domain": {"$exists": False}},
+        ]
+
+    def test_domain_groupby_and_filter_agree_on_missing_docs(self):
+        """A click doc with no meta.domain lands in the same "unknown"
+        bucket for group-by ($ifNull default) and for filtering
+        (null-sentinel map)."""
+        from services.stats_service import _NULL_SENTINEL_FILTERS
+        from shared.aggregation_strategies import AggregationStrategyFactory
+
+        pipeline = AggregationStrategyFactory.get("domain").build_pipeline({})
+        group_expr = pipeline[1]["$group"]["_id"]
+        assert group_expr == {"$ifNull": ["$meta.domain", "unknown"]}
+        assert _NULL_SENTINEL_FILTERS["domain"] == "unknown"
+
     def test_device_groupby_and_filter_agree_on_missing_docs(self):
         """The invariant: a click doc with no device field lands in the
         same "unknown" bucket for group-by (aggregation $ifNull default),

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -623,8 +623,27 @@ class TestClickQueryBuilding:
 
         pipeline = AggregationStrategyFactory.get("domain").build_pipeline({})
         group_expr = pipeline[1]["$group"]["_id"]
-        assert group_expr == {"$ifNull": ["$meta.domain", "unknown"]}
+        assert group_expr["$ifNull"][1] == "unknown"
+        assert group_expr["$ifNull"][0]["$cond"][2] == "$meta.domain"
         assert _NULL_SENTINEL_FILTERS["domain"] == "unknown"
+
+    def test_filter_field_paths_agree_with_strategy_registry(self):
+        """Drift guard: _FILTER_FIELD_PATHS and the strategy registry are
+        two hand-kept copies of each dimension's mongo field. A new
+        meta-path dimension that updates the registry but not the map
+        reproduces the silent-empty-filter bug the map exists to prevent,
+        so pin them against each other. short_code is exempt: its filter
+        branch does scope-bypass prevention, not path mapping."""
+        from schemas.enums.stats import ALLOWED_FILTERS, StatsDimension
+        from services.stats_service import _FILTER_FIELD_PATHS
+        from shared.aggregation_strategies import AggregationStrategyFactory
+
+        for dim in ALLOWED_FILTERS:
+            if dim == StatsDimension.SHORT_CODE:
+                continue
+            strategy = AggregationStrategyFactory.get(dim)
+            registry_field = strategy._mongo_field.removeprefix("$")
+            assert registry_field == _FILTER_FIELD_PATHS.get(dim, dim), dim
 
     def test_device_groupby_and_filter_agree_on_missing_docs(self):
         """The invariant: a click doc with no device field lands in the
@@ -638,7 +657,8 @@ class TestClickQueryBuilding:
 
         pipeline = AggregationStrategyFactory.get("device").build_pipeline({})
         group_expr = pipeline[1]["$group"]["_id"]
-        assert group_expr == {"$ifNull": ["$device", "unknown"]}
+        assert group_expr["$ifNull"][1] == "unknown"
+        assert group_expr["$ifNull"][0]["$cond"][2] == "$device"
 
         from ua_parser import parse as ua_parse
 

--- a/tests/unit/shared/test_aggregation_strategies.py
+++ b/tests/unit/shared/test_aggregation_strategies.py
@@ -58,6 +58,7 @@ def test_factory_get_available_strategies():
         "utm_source",
         "utm_medium",
         "utm_campaign",
+        "domain",
     }
 
 
@@ -131,6 +132,13 @@ def test_short_code_pipeline_groups_by_nested_field():
     assert group_stage["_id"]["$ifNull"][0] == "$meta.short_code"
 
 
+def test_domain_pipeline_groups_by_nested_field():
+    """Domain must group by nested meta.domain, not a top-level field."""
+    pipeline = _strategy("domain").build_pipeline(_BASE_QUERY)
+    group_stage = next(s["$group"] for s in pipeline if "$group" in s)
+    assert group_stage["_id"]["$ifNull"][0] == "$meta.domain"
+
+
 def test_referrer_pipeline_uses_direct_as_null_fallback():
     """Referrer should fall back to 'Direct' (not 'Unknown') for null values."""
     pipeline = _strategy("referrer").build_pipeline(_BASE_QUERY)
@@ -151,6 +159,8 @@ def test_referrer_pipeline_uses_direct_as_null_fallback():
         ("utm_source", "(none)"),
         ("utm_medium", "(none)"),
         ("utm_campaign", "(none)"),
+        # clicks recorded before domain stamping existed
+        ("domain", "unknown"),
     ],
 )
 def test_pipeline_uses_unknown_as_null_fallback(strategy_name, expected_null_fallback):
@@ -174,6 +184,7 @@ def test_pipeline_uses_unknown_as_null_fallback(strategy_name, expected_null_fal
         ("city", 50),
         ("referrer", 30),
         ("short_code", 100),
+        ("domain", 50),
     ],
 )
 def test_pipeline_limit_values(strategy_name, expected_limit):
@@ -297,6 +308,7 @@ _RAW = [{"_id": "Chrome", "total_clicks": 10, "unique_clicks": 7}]
         ("city", "city"),
         ("referrer", "referrer"),
         ("short_code", "short_code"),
+        ("domain", "domain"),
     ],
 )
 def test_format_results_renames_id_to_dimension_key(strategy_name, key):

--- a/tests/unit/shared/test_aggregation_strategies.py
+++ b/tests/unit/shared/test_aggregation_strategies.py
@@ -104,6 +104,18 @@ def _strategy(name: str) -> FieldAggregationStrategy:
 _BASE_QUERY = {"meta.owner_id": "user123"}
 
 
+def _group_field(group_id: dict) -> str:
+    """Extract the grouped mongo field from either group-expr shape.
+
+    Sentinel dimensions wrap the field in a $cond that folds "" into null
+    before the $ifNull; plain dimensions pass the field straight through.
+    """
+    inner = group_id["$ifNull"][0]
+    if isinstance(inner, dict):
+        return inner["$cond"][2]
+    return inner
+
+
 @pytest.mark.parametrize(
     "strategy_name, expected_field",
     [
@@ -120,23 +132,43 @@ def test_pipeline_groups_by_correct_field(strategy_name, expected_field):
     strategy = _strategy(strategy_name)
     pipeline = strategy.build_pipeline(_BASE_QUERY)
     group_stage = next(s["$group"] for s in pipeline if "$group" in s)
-    group_id = group_stage["_id"]
-    # _id is {"$ifNull": [<field>, <default>]}
-    assert group_id["$ifNull"][0] == expected_field
+    assert _group_field(group_stage["_id"]) == expected_field
 
 
 def test_short_code_pipeline_groups_by_nested_field():
     """ShortCode must group by nested meta.short_code, not a top-level field."""
     pipeline = _strategy("short_code").build_pipeline(_BASE_QUERY)
     group_stage = next(s["$group"] for s in pipeline if "$group" in s)
-    assert group_stage["_id"]["$ifNull"][0] == "$meta.short_code"
+    assert _group_field(group_stage["_id"]) == "$meta.short_code"
 
 
 def test_domain_pipeline_groups_by_nested_field():
     """Domain must group by nested meta.domain, not a top-level field."""
     pipeline = _strategy("domain").build_pipeline(_BASE_QUERY)
     group_stage = next(s["$group"] for s in pipeline if "$group" in s)
-    assert group_stage["_id"]["$ifNull"][0] == "$meta.domain"
+    assert _group_field(group_stage["_id"]) == "$meta.domain"
+
+
+def test_sentinel_dimension_group_expr_folds_empty_string():
+    """Sentinel dims must bucket "" with null/missing: the filter side's
+    $or group already matches "" as the sentinel ($in: [None, ""]), so a
+    group-by that preserved "" as its own bucket would make widget counts
+    and filter counts disagree on legacy document shapes."""
+    pipeline = _strategy("domain").build_pipeline(_BASE_QUERY)
+    group_stage = next(s["$group"] for s in pipeline if "$group" in s)
+    assert group_stage["_id"] == {
+        "$ifNull": [
+            {"$cond": [{"$eq": ["$meta.domain", ""]}, None, "$meta.domain"]},
+            "unknown",
+        ]
+    }
+
+
+def test_non_sentinel_dimension_keeps_plain_ifnull():
+    """Dimensions without a sentinel default keep the flat expression."""
+    pipeline = _strategy("browser").build_pipeline(_BASE_QUERY)
+    group_stage = next(s["$group"] for s in pipeline if "$group" in s)
+    assert group_stage["_id"] == {"$ifNull": ["$browser", "Unknown"]}
 
 
 def test_referrer_pipeline_uses_direct_as_null_fallback():


### PR DESCRIPTION
Adds **domain** as a stats dimension: per-domain breakdowns and filtering on `/api/v1/stats` and `/api/v1/export`, completing the analytics side of custom domains.

## What changed

**Stats API:** `domain` is now a valid `group_by` dimension and filter (both the `filters` JSON and a dedicated query param). Grouping runs on `meta.domain`, which every click already carries, and the sparse `(meta.domain, clicked_at)` index already exists, so this is read-side only: no hot-path, schema, or migration work.

**Unknown bucket:** clicks recorded before domain stamping existed have a null or absent `meta.domain` (old time-series buckets keep their shape forever). Those aggregate under `unknown`, and filtering by `unknown` matches the same null/missing documents via the existing null-sentinel machinery, so filter counts always agree with group-by. `unknown` can never collide with a real value since domains are always dotted fqdns.

**Field path mapping:** domain is the first filterable dimension living under the time-series metaField (`short_code` also does, but it has its own branch for scope-bypass prevention). The query builder now maps dimensions to their Mongo field paths instead of assuming top-level names; a filter keyed on bare `domain` would have silently matched nothing.

Exports pick the dimension up automatically. The public per-link stats payload is deliberately unchanged: a single link lives on exactly one domain, so a domain breakdown there is meaningless.

## Tests

- DTO tests: `group_by=domain`, the dedicated param, and the `filters` JSON form
- Query builder tests: meta path targeting, the `unknown` sentinel matching null/missing, and the group-by/filter agreement invariant
- Aggregation strategy tests: nested field grouping, sentinel fallback, limit (50)
- Full suite green: 3016 passed
- Live smoke on a real Mongo 8 time-series collection: seeded clicks with a real domain, an explicit null, and an absent key; verified bucket counts, both filter shapes, and group-by/filter agreement end to end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added domain-based grouping and filtering to statistics.
  * Supports comma-separated domain filters and JSON filter input.
  * Domain values use lowercase FQDN format.
  * Missing, empty, or unavailable domain data is grouped and filterable as `unknown`.
  * Domain groupings return up to 50 results.

* **Tests**
  * Added coverage for domain filters, grouping, fallback handling, and result formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->