### PR TITLE
feat: tighten anonymous and legacy rate limits

### DIFF
--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -17,6 +17,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from errors import AppError
 from infrastructure.logging import get_logger
 from infrastructure.templates import templates
+from middleware.rate_limiter import rate_limit_key
 
 log = get_logger(__name__)
 
@@ -146,13 +147,28 @@ def register_error_handlers(app: FastAPI) -> None:
             content=_validation_error_response(exc.errors()),
         )
 
+    def _rate_limit_hint(request: Request) -> str | None:
+        if request.url.path.startswith("/api/v1"):
+            if rate_limit_key(request).startswith(("apikey:", "jwt:")):
+                return None
+            return (
+                "Anonymous requests get the lowest limits. Authenticate with "
+                "a free account or an API key for 60 per minute and 5000 per day."
+            )
+        if request.method == "POST" and request.url.path in ("/", "/emoji"):
+            return (
+                "The legacy API is strictly rate limited. Use POST /api/v1/shorten "
+                "for higher limits: https://docs.spoo.me/rate-limits"
+            )
+        return None
+
     @app.exception_handler(RateLimitExceeded)
     async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> Response:
         if _wants_json(request):
-            return JSONResponse(
-                status_code=429,
-                content={"error": "Too many requests", "code": "rate_limit_exceeded"},
-            )
+            content = {"error": "Too many requests", "code": "rate_limit_exceeded"}
+            if hint := _rate_limit_hint(request):
+                content["hint"] = hint
+            return JSONResponse(status_code=429, content=content)
         return _error_html(request, 429, "TOO MANY REQUESTS", "rate_limit_exceeded")
 
     @app.exception_handler(StarletteHTTPException)

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -70,6 +70,24 @@ def _wants_json(request: Request) -> bool:
     )
 
 
+def _rate_limit_hint(request: Request) -> str | None:
+    # Mirrors rate_limit_key on purpose: the hint must match the tier the
+    # limiter actually applied, validated or not.
+    if request.url.path.startswith("/api/v1"):
+        if rate_limit_key(request).startswith(("apikey:", "jwt:")):
+            return None
+        return (
+            "Anonymous requests get the lowest limits. Authenticate with "
+            "a free account or an API key for 60 per minute and 5000 per day."
+        )
+    if request.method == "POST" and request.url.path in ("/", "/emoji"):
+        return (
+            "The legacy API is strictly rate limited. Use POST /api/v1/shorten "
+            "for higher limits: https://docs.spoo.me/rate-limits"
+        )
+    return None
+
+
 # Statuses that return EMPTY bodies under EDGE_COMPOSED_ERRORS — must stay
 # a subset of what Caddy's handle_response matcher composes, or visitors
 # get blank pages (verify at cutover; redirect ⊆ app-level is test-pinned).
@@ -147,29 +165,22 @@ def register_error_handlers(app: FastAPI) -> None:
             content=_validation_error_response(exc.errors()),
         )
 
-    def _rate_limit_hint(request: Request) -> str | None:
-        if request.url.path.startswith("/api/v1"):
-            if rate_limit_key(request).startswith(("apikey:", "jwt:")):
-                return None
-            return (
-                "Anonymous requests get the lowest limits. Authenticate with "
-                "a free account or an API key for 60 per minute and 5000 per day."
-            )
-        if request.method == "POST" and request.url.path in ("/", "/emoji"):
-            return (
-                "The legacy API is strictly rate limited. Use POST /api/v1/shorten "
-                "for higher limits: https://docs.spoo.me/rate-limits"
-            )
-        return None
-
     @app.exception_handler(RateLimitExceeded)
     async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> Response:
+        hint = _rate_limit_hint(request)
         if _wants_json(request):
             content = {"error": "Too many requests", "code": "rate_limit_exceeded"}
-            if hint := _rate_limit_hint(request):
+            if hint:
                 content["hint"] = hint
-            return JSONResponse(status_code=429, content=content)
-        return _error_html(request, 429, "TOO MANY REQUESTS", "rate_limit_exceeded")
+            return JSONResponse(
+                status_code=429,
+                content=content,
+                headers={"X-Spoo-Hint": hint} if hint else None,
+            )
+        response = _error_html(request, 429, "TOO MANY REQUESTS", "rate_limit_exceeded")
+        if hint:
+            response.headers["X-Spoo-Hint"] = hint
+        return response
 
     @app.exception_handler(StarletteHTTPException)
     async def http_exception_handler(

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -32,7 +32,7 @@ class Limits:
 
     # API v1 — authenticated vs anonymous tiers
     API_AUTHED = "60 per minute; 5000 per day"
-    API_ANON = "20 per minute; 1000 per day"
+    API_ANON = "20 per minute; 200 per day"
 
     # Alias availability check — cheap read, UI debounces on each keystroke
     API_CHECK_AUTHED = "180 per minute; 10000 per day"
@@ -147,8 +147,8 @@ class Limits:
     WEBHOOK_RETRY = "30 per minute"
     WEBHOOK_EVENT_TYPES = "60 per minute"
 
-    # URL shortener (legacy endpoint)
-    SHORTEN_LEGACY = "100 per minute"
+    # URL shortener (legacy endpoints) — strict on purpose, pushes to v1
+    SHORTEN_LEGACY = "5 per minute; 50 per day"
 
     # Legacy stats / export pages
     STATS_LEGACY_PAGE = "20 per minute; 1000 per day"

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -33,6 +33,8 @@ class Limits:
     # API v1 — authenticated vs anonymous tiers
     API_AUTHED = "60 per minute; 5000 per day"
     API_ANON = "20 per minute; 200 per day"
+    # Anonymous public-stats reads keep the pre-tightening daily budget
+    API_ANON_READ = "20 per minute; 1000 per day"
 
     # Alias availability check — cheap read, UI debounces on each keystroke
     API_CHECK_AUTHED = "180 per minute; 10000 per day"

--- a/routes/api_v1/stats.py
+++ b/routes/api_v1/stats.py
@@ -24,7 +24,7 @@ from schemas.dto.responses.stats import StatsResponse
 
 router = APIRouter(tags=["Statistics"])
 
-_stats_limit, _stats_key = dynamic_limit(Limits.API_AUTHED, Limits.API_ANON)
+_stats_limit, _stats_key = dynamic_limit(Limits.API_AUTHED, Limits.API_ANON_READ)
 
 
 @router.get(

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -429,7 +429,7 @@ async def result(
 
 
 @router.get("/{short_code}+")
-@limiter.limit(Limits.SHORTEN_LEGACY)
+@limiter.limit(Limits.PUBLIC_PREVIEW)
 async def preview_url(
     short_code: str,
     request: Request,

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -162,6 +162,50 @@ def test_rate_limit_html_edge_composed_returns_empty_body(edge_composed_errors):
     assert resp.content == b""
 
 
+def test_rate_limit_hint_on_anonymous_api_route():
+    """Anonymous 429 on /api/v1/* carries the authenticate hint."""
+    _reset_limiter()
+    router = _make_api_limited_router("1/minute")
+    app = _build_test_app(extra_routers=[router])
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.get("/api/v1/test-limited")
+        resp = c.get("/api/v1/test-limited")
+    assert resp.status_code == 429
+    assert "free account" in resp.json()["hint"]
+
+
+def test_rate_limit_hint_absent_for_authenticated_api_route():
+    """Authenticated callers already have the top tier — no hint."""
+    _reset_limiter()
+    router = _make_api_limited_router("1/minute")
+    app = _build_test_app(extra_routers=[router])
+    headers = {"Authorization": "Bearer spoo_testkey123"}
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.get("/api/v1/test-limited", headers=headers)
+        resp = c.get("/api/v1/test-limited", headers=headers)
+    assert resp.status_code == 429
+    assert "hint" not in resp.json()
+
+
+def test_rate_limit_hint_on_legacy_shorten():
+    """429 on the legacy mint endpoints points at API v1."""
+    _reset_limiter()
+    r = APIRouter()
+
+    @r.post("/emoji")
+    @limiter.limit("1/minute")
+    async def _emoji(request: Request):
+        return {"ok": True}
+
+    app = _build_test_app(extra_routers=[r])
+    headers = {"Accept": "application/json"}
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.post("/emoji", headers=headers)
+        resp = c.post("/emoji", headers=headers)
+    assert resp.status_code == 429
+    assert "/api/v1/shorten" in resp.json()["hint"]
+
+
 def test_rate_limit_key_uses_ip_for_anonymous():
     """Anonymous requests (no auth header, no cookie) should be keyed by client IP."""
     _reset_limiter()

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -27,6 +27,7 @@ import pytest
 from config import AppSettings
 from middleware.error_handler import register_error_handlers
 from middleware.rate_limiter import (
+    Limits,
     RateLimitHeadersMiddleware,
     limiter,
     rate_limit_key,
@@ -204,6 +205,33 @@ def test_rate_limit_hint_on_legacy_shorten():
         resp = c.post("/emoji", headers=headers)
     assert resp.status_code == 429
     assert "/api/v1/shorten" in resp.json()["hint"]
+    assert "/api/v1/shorten" in resp.headers["X-Spoo-Hint"]
+
+
+def test_rate_limit_hint_header_on_legacy_form_post():
+    """A form post with curl's default Accept gets HTML, so the hint must
+    ride a header to reach the common legacy caller."""
+    _reset_limiter()
+    r = APIRouter()
+
+    @r.post("/emoji")
+    @limiter.limit("1/minute")
+    async def _emoji(request: Request):
+        return {"ok": True}
+
+    app = _build_test_app(extra_routers=[r])
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.post("/emoji", data={"url": "https://example.com"})
+        resp = c.post("/emoji", data={"url": "https://example.com"})
+    assert resp.status_code == 429
+    assert "text/html" in resp.headers["content-type"]
+    assert "/api/v1/shorten" in resp.headers["X-Spoo-Hint"]
+
+
+def test_hint_prose_matches_authed_tier():
+    """The anonymous hint hardcodes the authed numbers as prose; fail loudly
+    when the tier changes so the string can't silently lie."""
+    assert Limits.API_AUTHED == "60 per minute; 5000 per day"
 
 
 def test_rate_limit_key_uses_ip_for_anonymous():


### PR DESCRIPTION
## What

- v1 anonymous tier daily cap: 1000 to 200 (burst stays 20/min)
- Legacy v0 shorten endpoints (POST /, POST /emoji): 5/min + 50/day
- Legacy /{code}+ preview now shares the v1 public preview budget (30/min + 2000/day)
- Anonymous and legacy JSON 429s carry a `hint` field pointing at the authenticated v1 tiers

## Why

The legacy endpoints have run at 100/min with no daily cap since the FastAPI migration, while the docs promise 10/min + 100/hour + 500/day. That made v0 the loosest anonymous minting path on the service. Real traffic over the last week: legacy POST / has had no successful callers since the frontend cutover, POST /emoji serves about 20 requests a week, and 90% of anonymous v1 creator IPs never exceed 10 links a day. The new caps sit far above human usage while cutting per-IP campaign minting capacity, and the 429 hints give script authors the migration path instead of a bare error.

Test suite green apart from the pre-existing app-token-scopes and click-sink smoke failures on main.

A docs PR updating the published numbers follows and should merge once this deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate-limit responses now provide helpful guidance tailored to the affected API route and access method.
  * Legacy shortener rate-limit messages direct users toward the current shortening endpoint.

* **Changes**
  * Anonymous API usage is now limited to 200 requests per day.
  * Legacy URL shortening is limited to 5 requests per minute and 50 per day.
  * Preview requests use the standard preview limit instead of the legacy shortener limit.

* **Bug Fixes**
  * Improved consistency of rate-limit guidance for anonymous, authenticated, and legacy requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->