### PR TITLE
fix(errors): set X-Error-Code header on JSON error responses

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -6,25 +6,29 @@ AppError is the base for all typed errors.
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import Any
 
-from typing_extensions import Required
+from typing_extensions import NotRequired, TypedDict
 
-
-class ErrorBody(TypedDict, total=False):
-    """Wire shape of a JSON error body.
-
-    ``code`` is the machine-readable slug that also feeds the
-    ``X-Error-Code`` response header, so a body without it is a type
-    error at the call site rather than a KeyError inside an exception
-    handler.
-    """
-
-    error: Required[str]
-    code: Required[str]
-    field: str
-    details: Any
-    message: str
+# Wire shape of a JSON error body. ``code`` is the machine-readable slug
+# that also feeds the ``X-Error-Code`` response header, so a body without
+# it is a type error at the call site rather than a KeyError inside an
+# exception handler.
+#
+# Functional syntax on purpose: under ``from __future__ import annotations``
+# the class form stringifies its annotations and the (Not)Required markers
+# are silently dropped at class creation — ``__required_keys__`` comes out
+# empty. Dict-literal values are real objects, so the markers survive.
+ErrorBody = TypedDict(  # noqa: UP013 — class syntax loses the markers here
+    "ErrorBody",
+    {
+        "error": str,
+        "code": str,
+        "field": NotRequired[str],
+        "details": NotRequired[Any],
+        "message": NotRequired[str],
+    },
+)
 
 
 class AppError(Exception):
@@ -204,7 +208,7 @@ class CloudflareAPIError(AppError):
     status_code = 502
     error_code = "cloudflare_api_error"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> ErrorBody:
         return {
             "error": (
                 "Upstream certificate service is temporarily unavailable. "

--- a/errors.py
+++ b/errors.py
@@ -6,7 +6,25 @@ AppError is the base for all typed errors.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypedDict
+
+from typing_extensions import Required
+
+
+class ErrorBody(TypedDict, total=False):
+    """Wire shape of a JSON error body.
+
+    ``code`` is the machine-readable slug that also feeds the
+    ``X-Error-Code`` response header, so a body without it is a type
+    error at the call site rather than a KeyError inside an exception
+    handler.
+    """
+
+    error: Required[str]
+    code: Required[str]
+    field: str
+    details: Any
+    message: str
 
 
 class AppError(Exception):
@@ -27,8 +45,8 @@ class AppError(Exception):
         self.field = field
         self.details = details
 
-    def to_dict(self) -> dict:
-        payload: dict = {"error": self.message, "code": self.error_code}
+    def to_dict(self) -> ErrorBody:
+        payload: ErrorBody = {"error": self.message, "code": self.error_code}
         if self.field is not None:
             payload["field"] = self.field
         if self.details is not None:
@@ -68,7 +86,7 @@ class EmailNotVerifiedError(ForbiddenError):
 
     error_code = "EMAIL_NOT_VERIFIED"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> ErrorBody:
         d = super().to_dict()
         d["message"] = (
             "You must verify your email address before creating resources. "

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -82,6 +82,22 @@ REDIRECT_EDGE_INTERCEPTED_STATUSES = {404, 410, 451}
 _HTTP_STATUS_SLUGS = {404: "not_found", 405: "method_not_allowed"}
 
 
+def _json_error(
+    status_code: int, content: dict, headers: dict | None = None
+) -> JSONResponse:
+    """Build a JSON error response that self-describes via ``X-Error-Code``.
+
+    The header always carries the exact slug from the body's ``code`` field,
+    so clients and the edge can route on the header without parsing the body
+    — same contract HTML errors already honour via ``_error_html``.
+    """
+    return JSONResponse(
+        status_code=status_code,
+        content=content,
+        headers={**(headers or {}), "X-Error-Code": content["code"]},
+    )
+
+
 def _error_html(
     request: Request, status_code: int, message: str, slug: str
 ) -> Response:
@@ -122,7 +138,7 @@ def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(AppError)
     async def app_error_handler(request: Request, exc: AppError) -> Response:
         if _wants_json(request):
-            return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
+            return _json_error(exc.status_code, exc.to_dict())
         return _error_html(
             request, exc.status_code, exc.message.upper(), exc.error_code
         )
@@ -132,26 +148,20 @@ def register_error_handlers(app: FastAPI) -> None:
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         # Validation errors only occur on typed API/auth routes — always JSON
-        return JSONResponse(
-            status_code=422,
-            content=_validation_error_response(exc.errors()),
-        )
+        return _json_error(422, _validation_error_response(exc.errors()))
 
     @app.exception_handler(PydanticValidationError)
     async def pydantic_validation_error_handler(
         request: Request, exc: PydanticValidationError
     ) -> JSONResponse:
-        return JSONResponse(
-            status_code=422,
-            content=_validation_error_response(exc.errors()),
-        )
+        return _json_error(422, _validation_error_response(exc.errors()))
 
     @app.exception_handler(RateLimitExceeded)
     async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> Response:
         if _wants_json(request):
-            return JSONResponse(
-                status_code=429,
-                content={"error": "Too many requests", "code": "rate_limit_exceeded"},
+            return _json_error(
+                429,
+                {"error": "Too many requests", "code": "rate_limit_exceeded"},
             )
         return _error_html(request, 429, "TOO MANY REQUESTS", "rate_limit_exceeded")
 
@@ -166,9 +176,9 @@ def register_error_handlers(app: FastAPI) -> None:
         slug = _HTTP_STATUS_SLUGS.get(exc.status_code, f"http_{exc.status_code}")
         message = str(exc.detail) if exc.detail else "Error"
         if _wants_json(request):
-            return JSONResponse(
-                status_code=exc.status_code,
-                content={"error": message, "code": slug},
+            return _json_error(
+                exc.status_code,
+                {"error": message, "code": slug},
                 headers=exc.headers,
             )
         return _error_html(request, exc.status_code, message.upper(), slug)
@@ -182,9 +192,9 @@ def register_error_handlers(app: FastAPI) -> None:
             path=request.url.path,
         )
         if _wants_json(request):
-            return JSONResponse(
-                status_code=500,
-                content={
+            return _json_error(
+                500,
+                {
                     "error": "An internal server error occurred.",
                     "code": "internal_error",
                 },

--- a/middleware/error_handler.py
+++ b/middleware/error_handler.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError as PydanticValidationError
 from slowapi.errors import RateLimitExceeded
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from errors import AppError
+from errors import AppError, ErrorBody
 from infrastructure.logging import get_logger
 from infrastructure.templates import templates
 
@@ -30,7 +30,7 @@ def _field_loc(err: dict) -> str:
     return ".".join(parts) if parts else "input"
 
 
-def _validation_error_response(errors: list[dict]) -> dict:
+def _validation_error_response(errors: list[dict]) -> ErrorBody:
     """Build a JSON-serialisable error dict from Pydantic validation errors.
 
     Follows the same ``{error, code, field?, details?}`` shape used by
@@ -83,7 +83,7 @@ _HTTP_STATUS_SLUGS = {404: "not_found", 405: "method_not_allowed"}
 
 
 def _json_error(
-    status_code: int, content: dict, headers: dict | None = None
+    status_code: int, content: ErrorBody, headers: dict | None = None
 ) -> JSONResponse:
     """Build a JSON error response that self-describes via ``X-Error-Code``.
 

--- a/middleware/security.py
+++ b/middleware/security.py
@@ -158,11 +158,14 @@ class MaxContentLengthMiddleware(BaseHTTPMiddleware):
         except ValueError:
             parsed = None
         if parsed is not None and parsed > self.max_content_length:
+            # Rejected before the exception handlers run, so the response
+            # must self-describe via X-Error-Code itself.
             return JSONResponse(
                 status_code=413,
                 content={
                     "error": "Request body too large",
                     "code": "payload_too_large",
                 },
+                headers={"X-Error-Code": "payload_too_large"},
             )
         return await call_next(request)

--- a/tests/integration/test_api_keys.py
+++ b/tests/integration/test_api_keys.py
@@ -148,6 +148,7 @@ def test_create_api_key_requires_verified_email():
     assert resp.status_code == 403
     body = resp.json()
     assert body["code"] == "EMAIL_NOT_VERIFIED"
+    assert resp.headers["X-Error-Code"] == "EMAIL_NOT_VERIFIED"
 
 
 def test_create_api_key_requires_auth():

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -26,6 +26,7 @@ from errors import (
     AuthenticationError,
     BlockedUrlError,
     ConflictError,
+    EmailNotVerifiedError,
     ForbiddenError,
     GoneError,
     NotFoundError,
@@ -75,6 +76,18 @@ async def api_validation(request: Request):
 @_api_router.get("/trigger-unhandled")
 async def api_unhandled(request: Request):
     raise RuntimeError("unexpected failure")
+
+
+@_api_router.get("/trigger-email-not-verified")
+async def api_email_not_verified(request: Request):
+    raise EmailNotVerifiedError("email not verified")
+
+
+@_api_router.get("/trigger-teapot")
+async def api_teapot(request: Request):
+    from starlette.exceptions import HTTPException
+
+    raise HTTPException(status_code=418, detail="teapot")
 
 
 @_api_router.get("/trigger-422")
@@ -174,6 +187,7 @@ def test_app_error_json_on_api_route():
     data = resp.json()
     assert data["error"] == "resource not found"
     assert data["code"] == "not_found"
+    assert resp.headers["X-Error-Code"] == "not_found"
     assert "application/json" in resp.headers["content-type"]
 
 
@@ -186,6 +200,7 @@ def test_app_error_json_on_auth_route():
     data = resp.json()
     assert data["error"] == "bad credentials"
     assert data["code"] == "authentication_error"
+    assert resp.headers["X-Error-Code"] == "authentication_error"
     assert "application/json" in resp.headers["content-type"]
 
 
@@ -250,6 +265,7 @@ def test_unmatched_route_json_when_accept_json():
     assert resp.status_code == 404
     data = resp.json()
     assert data["code"] == "not_found"
+    assert resp.headers["X-Error-Code"] == "not_found"
     assert "detail" not in data
 
 
@@ -271,6 +287,7 @@ def test_validation_error_returns_422_json():
     assert resp.status_code == 422
     data = resp.json()
     assert data["code"] == "validation_error"
+    assert resp.headers["X-Error-Code"] == "validation_error"
     assert data["field"] == "count"
     assert data["error"].startswith("count: ")
     assert "details" not in data
@@ -335,6 +352,7 @@ def test_unhandled_exception_returns_500_json():
     data = resp.json()
     assert data["error"] == "An internal server error occurred."
     assert data["code"] == "internal_error"
+    assert resp.headers["X-Error-Code"] == "internal_error"
 
 
 def test_unhandled_exception_returns_500_html():
@@ -426,6 +444,33 @@ def test_page_gone_returns_html():
     assert resp.headers["X-Error-Code"] == "gone"
 
 
+# ── X-Error-Code on JSON responses ───────────────────────────────────────────
+
+
+def test_email_not_verified_header_keeps_casing():
+    """The EMAIL_NOT_VERIFIED slug is upper-case in the body — the header
+    must carry it verbatim, not a normalised variant."""
+    app = _build_test_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/api/v1/trigger-email-not-verified")
+    assert resp.status_code == 403
+    data = resp.json()
+    assert data["code"] == "EMAIL_NOT_VERIFIED"
+    assert resp.headers["X-Error-Code"] == "EMAIL_NOT_VERIFIED"
+
+
+def test_http_exception_fallback_slug_in_header():
+    """Unmapped HTTPException statuses fall back to http_<status> — header
+    and body must agree."""
+    app = _build_test_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        resp = c.get("/api/v1/trigger-teapot")
+    assert resp.status_code == 418
+    data = resp.json()
+    assert data["code"] == "http_418"
+    assert resp.headers["X-Error-Code"] == "http_418"
+
+
 # ── Edge-composed errors (EDGE_COMPOSED_ERRORS) ──────────────────────────────
 
 
@@ -498,4 +543,4 @@ def test_edge_composed_json_path_unaffected(edge_composed_errors):
     data = resp.json()
     assert data["error"] == "resource not found"
     assert data["code"] == "not_found"
-    assert "X-Error-Code" not in resp.headers
+    assert resp.headers["X-Error-Code"] == "not_found"

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -266,6 +266,8 @@ def test_body_size_limit_rejects_large_payload():
             },
         )
     assert resp.status_code == 413
+    assert resp.json()["code"] == "payload_too_large"
+    assert resp.headers["X-Error-Code"] == "payload_too_large"
 
 
 def test_body_size_limit_allows_normal_payload():

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -133,6 +133,7 @@ def test_rate_limit_json_response_on_api_route():
     assert "error" in data
     assert "code" in data
     assert data["code"] == "rate_limit_exceeded"
+    assert resp.headers["X-Error-Code"] == "rate_limit_exceeded"
     assert "application/json" in resp.headers["content-type"]
 
 


### PR DESCRIPTION
Only HTML errors carried the X-Error-Code header. JSON clients had to parse the response body to get the machine-readable code, so the same error self-described differently depending on content negotiation.

Every negotiated error response now sends X-Error-Code with the exact slug that goes in the body's code field. A single _json_error() helper derives the header from the body, so the two cannot drift, including the EMAIL_NOT_VERIFIED casing and the http_<status> fallback slugs. The body shape is now a typed ErrorBody (TypedDict with required code), so a future call site that omits code fails where the body is built instead of raising KeyError inside an exception handler.

Covered branches:

- AppError handler
- RequestValidationError and PydanticValidationError (422)
- slowapi RateLimitExceeded (429)
- StarletteHTTPException fallback (merges with exc.headers)
- unhandled exception handler (500)
- the 413 body-size rejection in MaxContentLengthMiddleware, which short-circuits before the exception handlers run

Edge interaction, kept deliberately: with EDGE_COMPOSED_ERRORS on, Caddy's @err matcher keys on status plus the X-Error-Code header. JSON errors could never match before this PR; now they can. The inner @html gate still requires Accept: text/html on GET/HEAD, so real API clients (curl, SDKs, fetch) keep raw JSON. The only behavior change is a browser navigating directly to an API URL: an intercepted status (404, 410, 429, 451, 500) now renders the branded error page instead of raw JSON, which is the better outcome for a human at the address bar. Noted in the cutover checklist.

Not changed: response bodies, status codes, the HTML template path, and legacy route error shapes (no code field to mirror). One existing test pinned the header's absence on the JSON path; it now asserts the slug instead, and the body remains byte-identical.

Note: SplitCORSMiddleware has no Access-Control-Expose-Headers policy, so cross-origin browser JS still cannot read this header (same as X-Request-ID today). Until that lands, the header helps server-side clients and the edge; the dashboard still reads code from the body. Left out of this PR since it is a new mechanism rather than an addition to an existing set.