### PR TITLE
feat(stats)!: drop the scope param, stats and export require auth

### DIFF
--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -156,9 +156,8 @@ class Limits:
     STATS_LEGACY_PAGE = "20 per minute; 1000 per day"
     STATS_LEGACY_EXPORT = "10 per minute; 200 per day"
 
-    # Export stats (auth vs anon tiers)
+    # Export stats (auth required)
     API_EXPORT_AUTHED = "30 per minute; 1000 per day"
-    API_EXPORT_ANON = "10 per minute; 200 per day"
 
     # Password-protected URL check
     PASSWORD_CHECK = "10 per minute; 30 per hour"

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -33,8 +33,6 @@ class Limits:
     # API v1 — authenticated vs anonymous tiers
     API_AUTHED = "60 per minute; 5000 per day"
     API_ANON = "20 per minute; 200 per day"
-    # Anonymous public-stats reads keep the pre-tightening daily budget
-    API_ANON_READ = "20 per minute; 1000 per day"
 
     # Alias availability check — cheap read, UI debounces on each keystroke
     API_CHECK_AUTHED = "180 per minute; 10000 per day"

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -86,9 +86,9 @@ async def ensure_indexes(
 
     await clicks_col.create_index([("meta.url_id", 1), ("clicked_at", -1)])
     await clicks_col.create_index([("clicked_at", -1)])
-    # CRITICAL: for user-level analytics (scope=all queries)
+    # CRITICAL: for user-level analytics (account-scoped stats queries)
     await clicks_col.create_index([("meta.owner_id", 1), ("clicked_at", -1)])
-    # for anonymous stats (scope=anon, by short_code)
+    # for the short_code stats filter
     await clicks_col.create_index([("meta.short_code", 1), ("clicked_at", -1)])
     # sparse — older buckets have no meta.domain, index stays small
     await clicks_col.create_index([("meta.domain", 1), ("clicked_at", -1)], sparse=True)

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -9,7 +9,6 @@ shared CRUD helpers.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import TypedDict
 
 from bson import ObjectId
 from pymongo.errors import DuplicateKeyError, PyMongoError
@@ -20,14 +19,6 @@ from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.url import UrlStatus, UrlV2Doc
 
 log = get_logger(__name__)
-
-
-class StatsPrivacyInfo(TypedDict):
-    """Return type for check_stats_privacy."""
-
-    exists: bool
-    private: bool
-    owner_id: str | None
 
 
 class UrlRepository(BaseRepository[UrlV2Doc]):
@@ -382,21 +373,3 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
     async def count_by_query(self, query: dict) -> int:
         """Count documents matching query."""
         return await self._count(query)
-
-    async def check_stats_privacy(self, alias: str) -> StatsPrivacyInfo:
-        """Return privacy metadata for a URL alias.
-
-        Currently unscoped — stats route only operates on system-default
-        shorts. Scope by domain when stats becomes domain-aware.
-        """
-        doc = await self._find_one_raw(
-            {"alias": alias},
-            {"private_stats": 1, "owner_id": 1},
-        )
-        if not doc:
-            return {"exists": False, "private": False, "owner_id": None}
-        return {
-            "exists": True,
-            "private": bool(doc.get("private_stats", False)),
-            "owner_id": str(doc["owner_id"]) if doc.get("owner_id") else None,
-        }

--- a/routes/api_v1/exports.py
+++ b/routes/api_v1/exports.py
@@ -2,9 +2,8 @@
 GET /api/v1/export              — export URL stats as CSV, XLSX, JSON, or XML.
 GET /api/v1/export/links/{id}   — export twin of the per-link stats endpoint.
 
-Auth is optional for scope=anon (public stats); scope=all requires auth.
-The per-link endpoint always requires auth — you must own the URL.
-API key users require ``stats:read``, ``urls:read``, or ``admin:all``.
+Both require authentication — every export is scoped to the caller's own
+URLs. API key users require ``stats:read``, ``urls:read``, or ``admin:all``.
 """
 
 from __future__ import annotations
@@ -19,19 +18,14 @@ from dependencies import (
     CurrentUser,
     ExportSvc,
     UrlSvc,
-    optional_scopes,
     require_scopes,
 )
-from middleware.openapi import EXPORT_RESPONSES, OPTIONAL_AUTH_SECURITY
-from middleware.rate_limiter import Limits, dynamic_limit, limiter
+from middleware.openapi import EXPORT_RESPONSES
+from middleware.rate_limiter import Limits, limiter
 from routes.api_v1._helpers import parse_url_id
 from schemas.dto.requests.stats import ExportQuery, LinkExportQuery
 
 router = APIRouter(tags=["Statistics"])
-
-_export_limit, _export_key = dynamic_limit(
-    Limits.API_EXPORT_AUTHED, Limits.API_EXPORT_ANON
-)
 
 # Shared 200 documentation for both export routes — the download body is
 # format-dependent, never JSON-schema'd.
@@ -62,31 +56,26 @@ _EXPORT_200_RESPONSES = {
 @router.get(
     "/export",
     responses=_EXPORT_200_RESPONSES,
-    openapi_extra=OPTIONAL_AUTH_SECURITY,
     operation_id="exportStats",
     summary="Export Statistics",
 )
-@limiter.limit(_export_limit, key_func=_export_key)
+@limiter.limit(Limits.API_EXPORT_AUTHED)
 async def export_v1(
     request: Request,
     query: Annotated[ExportQuery, Query()],
     export_service: ExportSvc,
-    user: CurrentUser | None = Depends(optional_scopes(STATS_SCOPES)),  # noqa: B008
+    user: CurrentUser = Depends(require_scopes(STATS_SCOPES)),  # noqa: B008
 ) -> Response:
-    """Export URL click statistics as a downloadable file.
+    """Export click statistics across all URLs you own as a downloadable file.
 
     Generate a file export of click analytics data in the specified format.
     The response is a binary download with appropriate `Content-Disposition` header.
 
-    **Authentication**: Optional for `scope=anon` (public stats on a single URL);
-    required for `scope=all`.
+    **Authentication**: Required.
 
     **API Key Scope**: `stats:read`, `urls:read`, or `admin:all`
 
-    **Rate Limits**:
-
-    - Authenticated: 30/min, 1,000/day
-    - Anonymous: 10/min, 200/day
+    **Rate Limits**: 30/min, 1,000/day
 
     **Export Formats**:
 
@@ -102,8 +91,7 @@ async def export_v1(
     **Note**: Export generation is resource-intensive. Lower rate limits apply
     compared to other endpoints.
     """
-    owner_id = str(user.user_id) if user is not None else None
-    result = await export_service.export(query, owner_id)
+    result = await export_service.export(query, str(user.user_id))
     return Response(
         content=result.content,
         media_type=result.mimetype,

--- a/routes/api_v1/stats.py
+++ b/routes/api_v1/stats.py
@@ -2,8 +2,8 @@
 GET /api/v1/stats               — URL click statistics (account aggregate).
 GET /api/v1/stats/links/{id}    — click statistics for one owned URL.
 
-Auth is optional for scope=anon (public stats); scope=all requires auth.
-The per-link endpoint always requires auth — you must own the URL.
+Both require authentication — every stats read is scoped to the caller's
+own URLs. Public per-link stats live at GET /api/v1/public/stats/{code}.
 API key users require ``stats:read``, ``urls:read``, or ``admin:all``.
 
 Route-ordering note: the two paths differ in segment count, so neither can
@@ -23,67 +23,54 @@ from dependencies import (
     CurrentUser,
     StatsSvc,
     UrlSvc,
-    optional_scopes,
     require_scopes,
 )
-from middleware.openapi import ERROR_RESPONSES, OPTIONAL_AUTH_SECURITY
-from middleware.rate_limiter import Limits, dynamic_limit, limiter
+from middleware.openapi import ERROR_RESPONSES
+from middleware.rate_limiter import Limits, limiter
 from routes.api_v1._helpers import parse_url_id
 from schemas.dto.requests.stats import LinkStatsQuery, StatsQuery
 from schemas.dto.responses.stats import LinkStatsResponse, StatsResponse
 
 router = APIRouter(tags=["Statistics"])
 
-_stats_limit, _stats_key = dynamic_limit(Limits.API_AUTHED, Limits.API_ANON_READ)
-
 
 @router.get(
     "/stats",
     responses=ERROR_RESPONSES,
-    openapi_extra=OPTIONAL_AUTH_SECURITY,
     operation_id="getStats",
     summary="URL Statistics",
 )
-@limiter.limit(_stats_limit, key_func=_stats_key)
+@limiter.limit(Limits.API_AUTHED)
 async def stats_v1(
     request: Request,
     query: Annotated[StatsQuery, Query()],
     stats_service: StatsSvc,
-    user: CurrentUser | None = Depends(optional_scopes(STATS_SCOPES)),  # noqa: B008
+    user: CurrentUser = Depends(require_scopes(STATS_SCOPES)),  # noqa: B008
 ) -> StatsResponse:
-    """Get click statistics for URLs.
+    """Get aggregated click statistics across all URLs you own.
 
-    Retrieve aggregated click analytics with flexible grouping, filtering,
-    and time-range options.
+    Retrieve click analytics with flexible grouping, filtering, and
+    time-range options.
 
-    **Authentication**: Optional for `scope=anon` (public stats on a single URL);
-    required for `scope=all` (all URLs owned by the user).
+    **Authentication**: Required.
 
     **API Key Scope**: `stats:read`, `urls:read`, or `admin:all`
 
-    **Rate Limits**:
+    **Rate Limits**: 60/min, 5,000/day
 
-    - Authenticated: 60/min, 5,000/day
-    - Anonymous: 20/min, 1,000/day
-
-    **Scopes**:
-
-    - `scope=anon` + `short_code=<alias>` — public stats for one URL (if stats are not private)
-    - `scope=all` — aggregate stats across all URLs owned by the authenticated user
-
-    **Grouping Dimensions**: `time`, `browser`, `os`, `country`, `city`,
-    `referrer`, `short_code`
+    **Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,
+    `city`, `referrer`, `short_code`, `utm_source`, `utm_medium`,
+    `utm_campaign`
 
     **Metrics**: `clicks`, `unique_clicks`
 
-    **Filtering**: Filter by `browser`, `os`, `country`, `city`, `referrer`,
-    `short_code`, or `url_id` using query params or a JSON `filters` object.
-    Filters slice your own aggregate — `url_id` values you do not own simply
-    match nothing. For statistics on a single link, prefer
-    `GET /stats/links/{url_id}`.
+    **Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,
+    `referrer`, `short_code`, `url_id`, or the `utm_*` tags using query
+    params or a JSON `filters` object. Filters slice your own aggregate —
+    `url_id` values you do not own simply match nothing. For statistics on
+    a single link, prefer `GET /stats/links/{url_id}`.
     """
-    owner_id = str(user.user_id) if user is not None else None
-    result = await stats_service.query(query, owner_id)
+    result = await stats_service.query(query, str(user.user_id))
     return StatsResponse.model_validate(result)
 
 

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -9,17 +9,11 @@ OpenAPI spec.  Each constant is imported into the relevant model's
 
 # ── StatsQuery / ExportQuery ─────────────────────────────────────────────────
 
-STATS_SCOPE_DESC = (
-    "Statistics scope: `all` (authenticated only) or `anon` (public access).\n\n"
-    "- `all` — aggregate stats across all URLs owned by the authenticated user. "
-    "Requires authentication.\n"
-    "- `anon` — public stats for a single URL. Requires `short_code` parameter. "
-    "No authentication needed (unless stats are private)."
-)
-
 STATS_SHORT_CODE_DESC = (
-    "URL alias to query stats for. **Required** when `scope=anon`. "
-    "When `scope=all`, this is optional and filters stats to a specific URL."
+    "Comma-separated URL aliases to filter stats to specific URLs you own. "
+    "Slices your own aggregate — aliases you do not own simply match "
+    "nothing.\n\n"
+    "For statistics on a single link, prefer `GET /api/v1/stats/links/{url_id}`."
 )
 
 STATS_URL_ID_DESC = (
@@ -52,7 +46,7 @@ STATS_GROUP_BY_DESC = (
     "- `country` — group by country\n"
     "- `city` — group by city\n"
     "- `referrer` — group by referrer URL\n"
-    "- `short_code` — group by URL alias (only with `scope=all`)\n"
+    "- `short_code` — group by URL alias\n"
     "- `utm_source` — group by the `utm_source` tag on the short link "
     "(untagged clicks appear as `(none)`)\n"
     "- `utm_medium` — group by the `utm_medium` tag\n"
@@ -85,8 +79,7 @@ STATS_FILTERS_DESC = (
     "- `country` — Filter by country name (e.g., United States, Canada, Germany)\n"
     "- `city` — Filter by city name (e.g., New York, London, Mumbai)\n"
     "- `referrer` — Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n"
-    "- `short_code` — Filter by URL alias (e.g., mylink, promo2024) — "
-    "**not allowed** with `scope=anon`\n"
+    "- `short_code` — Filter by URL alias (e.g., mylink, promo2024)\n"
     "- `url_id` — Filter by URL id (MongoDB ObjectId); ids you do not own "
     "match nothing\n"
     "- `utm_source` / `utm_medium` / `utm_campaign` — Filter by campaign tags; "
@@ -98,8 +91,7 @@ STATS_FILTERS_DESC = (
     '- `{"browser": ["Chrome", "Firefox"]}` — Chrome OR Firefox clicks\n'
     '- `{"country": ["United States", "Canada"], "browser": ["Chrome"]}` — '
     "US/CA clicks from Chrome\n"
-    '- `{"short_code": ["link1", "link2"]}` — Stats for specific URLs '
-    "(`scope=all` only)\n\n"
+    '- `{"short_code": ["link1", "link2"]}` — Stats for specific URLs\n\n'
     "**Alternative:** You can also pass filters as individual query parameters "
     "(see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
 )

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -26,7 +26,7 @@ STATS_URL_ID_DESC = (
 STATS_START_DATE_DESC = (
     "Start of time range. Accepts ISO 8601 datetime string "
     "(e.g., `2025-01-01T00:00:00Z`) or Unix timestamp in seconds "
-    "(e.g., `1735689600`). If omitted, defaults to the URL creation date."
+    "(e.g., `1735689600`). If omitted, defaults to 7 days before `end_date`."
 )
 
 STATS_END_DATE_DESC = (

--- a/schemas/dto/requests/stats.py
+++ b/schemas/dto/requests/stats.py
@@ -8,9 +8,13 @@ LinkExportQuery  — GET /api/v1/export/links/{id}   (superset: adds ``format``)
 
 All models parse comma-separated strings for multi-value fields and validate
 IANA timezone names.  The JSON ``filters`` string is parsed into a typed dict.
-The per-link variants drop ``scope``/``short_code``/``url_id`` entirely —
-the path already names the link, so slicing or bucketing by link identity
-is meaningless there.
+The per-link variants drop ``short_code``/``url_id`` entirely — the path
+already names the link, so slicing or bucketing by link identity is
+meaningless there.
+
+There is no ``scope`` parameter: every endpoint in this family requires
+auth and reads the caller's own aggregate. A stray ``scope=`` from an old
+client is silently ignored (RequestBase drops unknown params).
 """
 
 from __future__ import annotations
@@ -40,7 +44,6 @@ from schemas.dto.requests._descriptions import (
     STATS_METRICS_DESC,
     STATS_OS_DESC,
     STATS_REFERRER_DESC,
-    STATS_SCOPE_DESC,
     STATS_SHORT_CODE_DESC,
     STATS_START_DATE_DESC,
     STATS_TIMEZONE_DESC,
@@ -56,7 +59,6 @@ from schemas.enums.stats import (
     LINK_ALLOWED_GROUP_BY,
     ExportFormat,
     StatsDimension,
-    StatsScope,
 )
 
 
@@ -260,9 +262,6 @@ class StatsQuery(_StatsQueryBase):
     The ``filters`` parameter accepts a JSON object string.
     """
 
-    scope: Literal[StatsScope.ALL, StatsScope.ANON] = Field(
-        default=StatsScope.ALL, description=STATS_SCOPE_DESC
-    )
     short_code: str | None = Field(
         default=None,
         max_length=50,
@@ -276,14 +275,8 @@ class StatsQuery(_StatsQueryBase):
         examples=["686cbf34cc37ed6bbcd82ab9"],
     )
 
-    @field_validator("scope", mode="before")
-    @classmethod
-    def _normalize_scope(cls, v: str) -> str:
-        return v.strip().lower() if isinstance(v, str) else v
-
     def _apply_identity_filters(self, parsed_filters: dict[str, list[str]]) -> None:
-        # short_code filter is blocked when scope=anon (bypass prevention)
-        if self.short_code and self.scope != StatsScope.ANON:
+        if self.short_code:
             parsed_filters["short_code"] = _parse_comma_separated(self.short_code)
         if self.url_id:
             parsed_filters["url_id"] = _parse_comma_separated(self.url_id)
@@ -307,8 +300,8 @@ class StatsQuery(_StatsQueryBase):
 class LinkStatsQuery(_StatsQueryBase):
     """Query parameters for GET /api/v1/stats/links/{url_id}.
 
-    StatsQuery minus link identity: no ``scope``, and no ``short_code`` or
-    ``url_id`` params or filters — the path already selects the link.
+    StatsQuery minus link identity: no ``short_code`` or ``url_id`` params
+    or filters — the path already selects the link.
     """
 
     _ALLOWED_GROUP_BY: ClassVar[frozenset] = LINK_ALLOWED_GROUP_BY

--- a/schemas/dto/requests/stats.py
+++ b/schemas/dto/requests/stats.py
@@ -264,7 +264,9 @@ class StatsQuery(_StatsQueryBase):
 
     short_code: str | None = Field(
         default=None,
-        max_length=50,
+        # Sized for the documented comma-separated LIST (aliases run up to
+        # 50 chars each), matching url_id and the other multi-value params.
+        max_length=1000,
         description=STATS_SHORT_CODE_DESC,
         examples=["mylink"],
     )
@@ -280,10 +282,6 @@ class StatsQuery(_StatsQueryBase):
             parsed_filters["short_code"] = _parse_comma_separated(self.short_code)
         if self.url_id:
             parsed_filters["url_id"] = _parse_comma_separated(self.url_id)
-        # anon queries have no owner arm — an id filter would re-scope the
-        # alias lock onto anyone's link, so reject (param and JSON paths).
-        if self.scope == StatsScope.ANON and parsed_filters.get(StatsDimension.URL_ID):
-            raise ValueError("url_id filters require scope=all")
         # Format-validate every url_id value (the JSON filters path too) so
         # the service can convert to ObjectId without a second check. No
         # ownership check — the owner stamp already scopes the $match, so

--- a/schemas/enums/stats.py
+++ b/schemas/enums/stats.py
@@ -12,7 +12,12 @@ from enum import Enum
 
 
 class StatsScope(str, Enum):
-    """Stats query scope."""
+    """Stats wire scope.
+
+    Response-only: the ``scope`` request parameter no longer exists (auth
+    is mandatory), but the response wire keeps its ``scope`` key and the
+    public stats endpoint's frozen contract still carries ``anon``.
+    """
 
     ALL = "all"
     ANON = "anon"
@@ -53,7 +58,6 @@ class ExportFormat(str, Enum):
     XML = "xml"
 
 
-ALLOWED_SCOPES = frozenset(StatsScope)
 ALLOWED_GROUP_BY = frozenset(StatsDimension) - {StatsDimension.URL_ID}
 ALLOWED_METRICS = frozenset(StatsMetric)
 ALLOWED_FILTERS = frozenset(

--- a/services/export/service.py
+++ b/services/export/service.py
@@ -20,7 +20,6 @@ import re
 from errors import ValidationError
 from infrastructure.logging import get_logger
 from schemas.dto.requests.stats import ExportQuery, LinkExportQuery
-from schemas.enums.stats import StatsScope
 from schemas.models.url import UrlV2Doc
 from schemas.results import ExportResult
 from services.export.protocol import ExportFormatter
@@ -60,7 +59,7 @@ class ExportService:
 
         Args:
             query:    Validated ExportQuery DTO with format and stats parameters.
-            owner_id: String user ID for scope=all, or None.
+            owner_id: String user ID of the authenticated caller.
 
         Raises:
             ValidationError: Unknown format.
@@ -75,8 +74,6 @@ class ExportService:
         log.info(
             "export_generated",
             format=query.format,
-            scope=query.scope,
-            short_code=query.short_code if query.scope == StatsScope.ANON else None,
             size_bytes=len(content),
         )
         return ExportResult(

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -11,8 +11,8 @@ The route layer is responsible for:
     - HTTP response construction
 
 This service receives already-parsed parameters and handles all business
-logic from there, including date defaults, privacy checks, and the single
-$facet MongoDB call.
+logic from there, including date defaults and the single $facet MongoDB
+call.
 """
 
 from __future__ import annotations
@@ -26,8 +26,6 @@ from bson import ObjectId
 
 from errors import (
     AuthenticationError,
-    ForbiddenError,
-    NotFoundError,
     ValidationError,
 )
 from infrastructure.logging import get_logger
@@ -83,7 +81,7 @@ class StatsService:
 
     Args:
         click_repo:         Repository for the ``clicks`` time-series collection.
-        url_repo:           Repository for the ``urlsV2`` collection (privacy checks).
+        url_repo:           Repository for the ``urlsV2`` collection (claimed ids).
         max_date_range_days: Maximum allowed date range in days (default 90).
     """
 
@@ -182,9 +180,7 @@ class StatsService:
 
     @staticmethod
     def _build_click_query(
-        scope: StatsScope,
-        owner_id: str | None,
-        short_code: str | None,
+        owner_id: str,
         start_date: datetime,
         end_date: datetime,
         filters: dict[str, list[str]],
@@ -192,38 +188,30 @@ class StatsService:
     ) -> dict[str, Any]:
         """Build the MongoDB $match query for the clicks collection.
 
-        Preserves the exact filtering logic from utils/query_builder.py
-        (ClickQueryBuilder + StatsQueryBuilderFactory), including:
-        - meta.owner_id scoping for scope=all
-        - meta.short_code scoping for scope=anon
-        - Time range on clicked_at
-        - Dimension filters with special handling for short_code and referrer/Direct
+        Always owner-scoped (``meta.owner_id``) — auth is mandatory on
+        every caller. Time range on ``clicked_at``, then dimension filters.
 
-        ``claimed_url_ids`` (scope=all only): claimed links' pre-claim
-        clicks are stamped with the anonymous owner, so they need a url_id
-        arm to carry their history. Empty set (almost every account) →
-        query byte-identical to the stamp-only one.
+        ``claimed_url_ids``: claimed links' pre-claim clicks are stamped
+        with the anonymous owner, so they need a url_id arm to carry their
+        history. Empty set (almost every account) → query byte-identical
+        to the stamp-only one.
         """
         query: dict[str, Any] = {}
 
-        # Ownership scope and null-sentinel filters both build $or groups;
+        # Ownership and null-sentinel filters both build $or groups;
         # multiple groups must nest under $and.
         or_groups: list[list[dict[str, Any]]] = []
 
-        # Scope filter
-        if scope == StatsScope.ALL and owner_id:
-            owner_oid = ObjectId(owner_id) if isinstance(owner_id, str) else owner_id
-            if claimed_url_ids:
-                or_groups.append(
-                    [
-                        {"meta.owner_id": owner_oid},
-                        {"meta.url_id": {"$in": claimed_url_ids}},
-                    ]
-                )
-            else:
-                query["meta.owner_id"] = owner_oid
-        elif scope == StatsScope.ANON and short_code:
-            query["meta.short_code"] = short_code
+        owner_oid = ObjectId(owner_id) if isinstance(owner_id, str) else owner_id
+        if claimed_url_ids:
+            or_groups.append(
+                [
+                    {"meta.owner_id": owner_oid},
+                    {"meta.url_id": {"$in": claimed_url_ids}},
+                ]
+            )
+        else:
+            query["meta.owner_id"] = owner_oid
 
         # Time range
         query["clicked_at"] = {"$gte": start_date, "$lte": end_date}
@@ -250,15 +238,6 @@ class StatsService:
                 continue
 
             if dimension == StatsDimension.SHORT_CODE:
-                # SECURITY: skip if scope already locks short_code (scope=anon)
-                if "meta.short_code" in query:
-                    log.warning(
-                        "query_builder_scope_bypass_prevented",
-                        dimension="short_code",
-                        locked_short_code=query.get("meta.short_code"),
-                        attempted_values=values,
-                    )
-                    continue
                 query["meta.short_code"] = {"$in": values}
             elif dimension == StatsDimension.URL_ID:
                 # SECURITY: skip if the query already locks url_id — on the
@@ -590,24 +569,21 @@ class StatsService:
         query: StatsQuery,
         owner_id: str | None,
     ) -> dict[str, Any]:
-        """Execute a stats query and return the formatted, enhanced response.
+        """Execute an account-scoped stats query and return the enhanced response.
 
         Args:
             query:    Validated StatsQuery DTO with all query parameters.
-            owner_id: String user ID for scope=all, or None.
+            owner_id: String user ID of the authenticated caller.
 
         Returns:
             Formatted stats dict ready for JSON serialisation.
 
         Raises:
-            ValidationError:      Invalid scope/target parameters.
-            NotFoundError:        short_code not found (scope=anon).
-            AuthenticationError:  Auth required for private stats or scope=all.
-            ForbiddenError:       Authenticated user does not own private URL.
+            ValidationError:      Invalid date parameters.
+            AuthenticationError:  No owner_id (defence in depth — the route
+                                  already requires auth).
             AppError:             DB failure.
         """
-        scope = query.scope
-        short_code = query.short_code
         filters = query.parsed_filters
         group_by = query.parsed_group_by
         metrics = query.parsed_metrics
@@ -617,56 +593,19 @@ class StatsService:
         start_date, end_date = self._resolve_window(query.start_date, query.end_date)
         tz_name = self.normalize_timezone(query.timezone)
 
-        # ── Scope/target validation ───────────────────────────────────────────
-        if scope == StatsScope.ANON:
-            if not short_code:
-                raise ValidationError("short_code is required when scope=anon")
-
-            privacy = await self._url_repo.check_stats_privacy(short_code)
-            if not privacy["exists"]:
-                raise NotFoundError("short_code not found")
-
-            if privacy["private"]:
-                if owner_id is None:
-                    log.info(
-                        "stats_access_denied",
-                        reason="unauthenticated_private_stats",
-                        short_code=short_code,
-                    )
-                    raise AuthenticationError(
-                        "this URL has private statistics - authentication required"
-                    )
-                if privacy["owner_id"] != str(owner_id):
-                    log.info(
-                        "stats_access_denied",
-                        reason="not_owner",
-                        short_code=short_code,
-                        requesting_user=str(owner_id),
-                        owner_user=privacy["owner_id"],
-                    )
-                    raise ForbiddenError("access denied - private statistics")
-
-        elif scope == StatsScope.ALL:
-            if owner_id is None:
-                log.info(
-                    "stats_access_denied",
-                    reason="unauthenticated_scope_all",
-                )
-                raise AuthenticationError("authentication required for scope=all")
+        if owner_id is None:
+            log.info("stats_access_denied", reason="unauthenticated")
+            raise AuthenticationError("authentication required")
 
         # ── Execute + format ──────────────────────────────────────────────────
         # Claimed links carry pre-claim history under the anonymous stamp;
         # sub-ms partial-index lookup, empty for almost every account.
-        claimed_url_ids: list[ObjectId] = []
-        if scope == StatsScope.ALL and owner_id:
-            claimed_url_ids = await self._url_repo.list_claimed_ids(
-                ObjectId(owner_id) if isinstance(owner_id, str) else owner_id
-            )
+        claimed_url_ids = await self._url_repo.list_claimed_ids(
+            ObjectId(owner_id) if isinstance(owner_id, str) else owner_id
+        )
 
         click_query = self._build_click_query(
-            scope,
             owner_id,
-            short_code,
             start_date,
             end_date,
             filters,
@@ -674,8 +613,8 @@ class StatsService:
         )
         response = await self.compute(
             click_query,
-            scope=scope,
-            short_code=short_code,
+            scope=StatsScope.ALL,
+            short_code=None,
             start_date=start_date,
             end_date=end_date,
             group_by=group_by,
@@ -688,8 +627,6 @@ class StatsService:
         duration_ms = int((time.perf_counter() - start_time) * 1000)
         log.info(
             "stats_query",
-            scope=scope,
-            short_code=short_code if scope == StatsScope.ANON else None,
             group_by=group_by,
             metrics=metrics,
             start_date=start_date.isoformat(),
@@ -762,7 +699,6 @@ class StatsService:
         duration_ms = int((time.perf_counter() - start_time) * 1000)
         log.info(
             "stats_query",
-            scope=StatsScope.ALL,
             url_id=str(url.id),
             group_by=group_by,
             metrics=metrics,

--- a/tests/integration/api_v1/test_export.py
+++ b/tests/integration/api_v1/test_export.py
@@ -16,6 +16,7 @@ from .conftest import _build_test_app, _make_api_key_doc, _make_url_doc, _make_u
 
 class TestExport:
     def test_export_json_returns_correct_content_type(self):
+        user = _make_user()
         mock_svc = AsyncMock()
         mock_svc.export = AsyncMock(
             return_value=ExportResult(
@@ -26,31 +27,66 @@ class TestExport:
         )
 
         application = _build_test_app(
-            {get_current_user: lambda: None, get_export_service: lambda: mock_svc}
+            {get_current_user: lambda: user, get_export_service: lambda: mock_svc}
         )
         with TestClient(application, raise_server_exceptions=True) as client:
-            resp = client.get("/api/v1/export?format=json&scope=anon&short_code=abc123")
+            resp = client.get("/api/v1/export?format=json")
 
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("application/json")
         assert "content-disposition" in resp.headers
 
-    def test_export_missing_format_returns_422(self):
+    def test_export_unauthenticated_returns_401(self):
         application = _build_test_app(
             {get_current_user: lambda: None, get_export_service: lambda: AsyncMock()}
         )
         with TestClient(application, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v1/export?scope=anon&short_code=abc123")
+            resp = client.get("/api/v1/export?format=json")
+
+        assert resp.status_code == 401
+
+    def test_export_stray_scope_param_silently_ignored(self):
+        user = _make_user()
+        mock_svc = AsyncMock()
+        mock_svc.export = AsyncMock(
+            return_value=ExportResult(
+                content=b'{"data": []}',
+                mimetype="application/json",
+                filename="stats.json",
+            )
+        )
+
+        application = _build_test_app(
+            {get_current_user: lambda: user, get_export_service: lambda: mock_svc}
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get("/api/v1/export?format=json&scope=anon")
+
+        assert resp.status_code == 200
+        assert not hasattr(mock_svc.export.call_args[0][0], "scope")
+
+    def test_export_missing_format_returns_422(self):
+        application = _build_test_app(
+            {
+                get_current_user: lambda: _make_user(),
+                get_export_service: lambda: AsyncMock(),
+            }
+        )
+        with TestClient(application, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/export")
 
         # Missing required `format` field → Pydantic validation → 422
         assert resp.status_code == 422
 
     def test_export_invalid_format_returns_422(self):
         application = _build_test_app(
-            {get_current_user: lambda: None, get_export_service: lambda: AsyncMock()}
+            {
+                get_current_user: lambda: _make_user(),
+                get_export_service: lambda: AsyncMock(),
+            }
         )
         with TestClient(application, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v1/export?format=pdf&scope=anon&short_code=abc123")
+            resp = client.get("/api/v1/export?format=pdf")
 
         assert resp.status_code == 422
 
@@ -62,7 +98,7 @@ class TestExport:
             {get_current_user: lambda: user, get_export_service: lambda: AsyncMock()}
         )
         with TestClient(application, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v1/export?format=json&scope=anon&short_code=abc123")
+            resp = client.get("/api/v1/export?format=json")
 
         assert resp.status_code == 403
 

--- a/tests/integration/api_v1/test_stats.py
+++ b/tests/integration/api_v1/test_stats.py
@@ -44,49 +44,56 @@ _BASE_STATS_RESULT = {
 class TestStats:
     _STATS_RESULT: ClassVar[dict] = {
         **_BASE_STATS_RESULT,
-        "scope": "anon",
-        "short_code": "abc123",
+        "scope": "all",
         "time_bucket_info": _TIME_BUCKET_INFO,
     }
 
-    def test_stats_anon_scope(self):
-        mock_svc = AsyncMock()
-        mock_svc.query = AsyncMock(return_value=self._STATS_RESULT)
-
-        application = _build_test_app(
-            {get_current_user: lambda: None, get_stats_service: lambda: mock_svc}
-        )
-        with TestClient(application, raise_server_exceptions=True) as client:
-            resp = client.get("/api/v1/stats?scope=anon&short_code=abc123")
-
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["scope"] == "anon"
-        assert body["summary"]["total_clicks"] == 42
-        assert "time_bucket_info" in body
-        assert body["time_bucket_info"]["strategy"] == "daily"
-
-    def test_stats_all_scope_with_auth(self):
+    def test_stats_with_auth(self):
         user = _make_user()
         mock_svc = AsyncMock()
-        mock_svc.query = AsyncMock(return_value={**_BASE_STATS_RESULT, "scope": "all"})
+        mock_svc.query = AsyncMock(return_value=self._STATS_RESULT)
 
         application = _build_test_app(
             {get_current_user: lambda: user, get_stats_service: lambda: mock_svc}
         )
         with TestClient(application, raise_server_exceptions=True) as client:
-            resp = client.get("/api/v1/stats?scope=all")
+            resp = client.get("/api/v1/stats")
 
         assert resp.status_code == 200
+        body = resp.json()
+        assert body["scope"] == "all"
+        assert body["summary"]["total_clicks"] == 42
+        assert "time_bucket_info" in body
+        assert body["time_bucket_info"]["strategy"] == "daily"
 
-    def test_stats_invalid_scope_returns_422(self):
+    def test_stats_unauthenticated_returns_401(self):
         application = _build_test_app(
             {get_current_user: lambda: None, get_stats_service: lambda: AsyncMock()}
         )
         with TestClient(application, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v1/stats?scope=invalid_value")
+            resp = client.get("/api/v1/stats")
 
-        assert resp.status_code == 422
+        assert resp.status_code == 401
+
+    def test_stats_stray_scope_param_silently_ignored(self):
+        """The scope param is gone; RequestBase drops unknown params, so an
+        old client sending scope=anon gets a normal authed response — the
+        wire never 422s on it."""
+        user = _make_user()
+        mock_svc = AsyncMock()
+        mock_svc.query = AsyncMock(return_value=self._STATS_RESULT)
+
+        application = _build_test_app(
+            {get_current_user: lambda: user, get_stats_service: lambda: mock_svc}
+        )
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get("/api/v1/stats?scope=anon&short_code=abc123")
+
+        assert resp.status_code == 200
+        query = mock_svc.query.call_args[0][0]
+        assert not hasattr(query, "scope")
+        # short_code survives as a plain filter under the owner stamp.
+        assert query.parsed_filters["short_code"] == ["abc123"]
 
     def test_stats_api_key_missing_scope_returns_403(self):
         key_doc = _make_api_key_doc(scopes=["shorten:create"])
@@ -96,7 +103,7 @@ class TestStats:
             {get_current_user: lambda: user, get_stats_service: lambda: AsyncMock()}
         )
         with TestClient(application, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v1/stats?scope=anon&short_code=abc123")
+            resp = client.get("/api/v1/stats")
 
         assert resp.status_code == 403
 

--- a/tests/integration/test_url_lifecycle.py
+++ b/tests/integration/test_url_lifecycle.py
@@ -164,14 +164,14 @@ def test_create_url_with_custom_alias_then_redirect():
 
 
 def test_create_url_then_check_stats():
-    """Create URL, then GET /api/v1/stats?short_code=xxx returns stats."""
+    """Create URL, then GET /api/v1/stats (authed) returns stats."""
     doc = _make_url_doc()
 
     url_svc = AsyncMock()
     url_svc.create.return_value = (doc, None)
 
     stats_result = {
-        "scope": "anon",
+        "scope": "all",
         "filters": {},
         "group_by": ["time"],
         "timezone": "UTC",
@@ -188,12 +188,15 @@ def test_create_url_then_check_stats():
     stats_svc = AsyncMock()
     stats_svc.query.return_value = stats_result
 
+    user = _mock_user()
+
     app = build_test_app(
         api_v1_router,
         redirect_router,
         overrides={
             get_url_service: lambda: url_svc,
             get_stats_service: lambda: stats_svc,
+            get_current_user: lambda: user,
         },
     )
     with TestClient(app, raise_server_exceptions=False) as client:
@@ -202,11 +205,11 @@ def test_create_url_then_check_stats():
         assert resp.status_code == 201
 
         # Step 2: Stats
-        resp = client.get(f"/api/v1/stats?short_code={_ALIAS}&scope=anon")
+        resp = client.get(f"/api/v1/stats?short_code={_ALIAS}")
         assert resp.status_code == 200
         data = resp.json()
         assert data["summary"]["total_clicks"] == 42
-        assert data["scope"] == "anon"
+        assert data["scope"] == "all"
 
 
 def test_create_url_then_update_long_url():
@@ -432,12 +435,15 @@ def test_create_url_then_export_stats():
         filename="stats.json",
     )
 
+    user = _mock_user()
+
     app = build_test_app(
         api_v1_router,
         redirect_router,
         overrides={
             get_url_service: lambda: url_svc,
             get_export_service: lambda: export_svc,
+            get_current_user: lambda: user,
         },
     )
     with TestClient(app, raise_server_exceptions=False) as client:
@@ -446,6 +452,6 @@ def test_create_url_then_export_stats():
         assert resp.status_code == 201
 
         # Step 2: Export
-        resp = client.get(f"/api/v1/export?short_code={_ALIAS}&scope=anon&format=json")
+        resp = client.get(f"/api/v1/export?short_code={_ALIAS}&format=json")
         assert resp.status_code == 200
         assert "attachment" in resp.headers.get("content-disposition", "")

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -131,22 +131,11 @@ class TestStatsQueryUrlIdFilter:
         with pytest.raises(ValidationError, match="invalid url_id"):
             StatsQuery.model_validate({"filters": json.dumps({"url_id": ["nope"]})})
 
-    def test_url_id_param_rejected_when_anon(self):
-        # anon has no owner arm — an id filter would re-scope the alias lock.
-        with pytest.raises(ValidationError, match="require scope=all"):
-            StatsQuery.model_validate(
-                {"scope": "anon", "short_code": "mylink", "url_id": "d" * 24}
-            )
-
-    def test_url_id_in_filters_json_rejected_when_anon(self):
-        with pytest.raises(ValidationError, match="require scope=all"):
-            StatsQuery.model_validate(
-                {
-                    "scope": "anon",
-                    "short_code": "mylink",
-                    "filters": json.dumps({"url_id": ["d" * 24]}),
-                }
-            )
+    def test_url_id_filter_survives_stray_anon_scope(self):
+        # The anon rejection died with the scope param: every query is
+        # owner-stamped now, so the filter is safe under any stray scope=.
+        q = StatsQuery.model_validate({"scope": "anon", "url_id": "d" * 24})
+        assert q.parsed_filters["url_id"] == ["d" * 24]
 
     def test_url_id_never_a_group_by_dimension(self):
         with pytest.raises(ValidationError, match="invalid group_by"):

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -25,14 +25,18 @@ from schemas.dto.responses.stats import (
 class TestStatsQuery:
     def test_defaults(self):
         q = StatsQuery.model_validate({})
-        assert q.scope == "all"
         assert q.parsed_group_by == ["time"]
         assert q.parsed_metrics == ["clicks", "unique_clicks"]
         assert q.timezone == "UTC"
 
-    def test_invalid_scope_rejected(self):
-        with pytest.raises(ValidationError):
-            StatsQuery.model_validate({"scope": "invalid"})
+    @pytest.mark.parametrize("value", ["anon", "all", "invalid"])
+    def test_stray_scope_param_silently_ignored(self, value):
+        """The scope field is gone; RequestBase is pydantic extra-ignore,
+        so an old client sending ANY scope value gets a normal response,
+        never a 422."""
+        q = StatsQuery.model_validate({"scope": value})
+        assert not hasattr(q, "scope")
+        assert q.parsed_group_by == ["time"]
 
     def test_comma_separated_group_by(self):
         q = StatsQuery.model_validate({"group_by": "time,browser,os"})
@@ -98,6 +102,10 @@ class TestStatsQuery:
         q = StatsQuery.model_validate({"browser": "Chrome", "country": "US,DE"})
         assert q.parsed_filters.get("browser") == ["Chrome"]
         assert "DE" in q.parsed_filters.get("country", [])
+
+    def test_short_code_param_is_a_plain_multi_value_filter(self):
+        q = StatsQuery.model_validate({"short_code": "link1,link2"})
+        assert q.parsed_filters["short_code"] == ["link1", "link2"]
 
 
 # ── StatsQuery — url_id filter ─────────────────────────────────────────────────
@@ -213,8 +221,8 @@ class TestExportQuery:
             ExportQuery.model_validate({"format": fmt})
 
     def test_inherits_stats_fields(self):
-        q = ExportQuery.model_validate({"format": "xlsx", "scope": "all"})
-        assert q.scope == "all"
+        q = ExportQuery.model_validate({"format": "xlsx", "short_code": "mylink"})
+        assert q.parsed_filters["short_code"] == ["mylink"]
 
     def test_url_id_filter_inherited(self):
         oid = "d" * 24

--- a/tests/unit/services/test_export_service.py
+++ b/tests/unit/services/test_export_service.py
@@ -32,8 +32,7 @@ NOW_ISO = NOW.isoformat()
 START_ISO = START.isoformat()
 
 SAMPLE_STATS = {
-    "scope": "anon",
-    "short_code": "abc",
+    "scope": "all",
     "filters": {},
     "group_by": ["browser"],
     "timezone": "UTC",
@@ -63,8 +62,6 @@ def _export_query(fmt="json"):
     """Build an ExportQuery with sensible defaults for tests."""
     return ExportQuery(
         format=fmt,
-        scope="anon",
-        short_code="abc",
         start_date=START_ISO,
         end_date=NOW_ISO,
         group_by="browser",

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from errors import AuthenticationError, ForbiddenError, NotFoundError, ValidationError
+from errors import AuthenticationError, ValidationError
 from schemas.dto.requests.stats import StatsQuery
 
 # ── Constants ────────────────────────────────────────────────────────────────
@@ -35,10 +35,6 @@ def make_service():
     return StatsService(click_repo=click_repo, url_repo=url_repo), click_repo, url_repo
 
 
-def privacy_info(exists=True, private=False, owner_id=OWNER_ID):
-    return {"exists": exists, "private": private, "owner_id": owner_id}
-
-
 def facet_response(
     total=10,
     unique=5,
@@ -64,8 +60,7 @@ def facet_response(
 
 
 def _q(
-    scope="anon",
-    short_code="abc",
+    short_code=None,
     start_date=None,
     end_date=None,
     group_by="time",
@@ -75,7 +70,6 @@ def _q(
 ):
     """Build a StatsQuery with sensible defaults for tests."""
     return StatsQuery(
-        scope=scope,
         short_code=short_code,
         start_date=start_date if start_date is not None else START_ISO,
         end_date=end_date if end_date is not None else NOW_ISO,
@@ -93,14 +87,11 @@ class TestDateHandling:
     @pytest.mark.asyncio
     async def test_default_date_range_applied_when_none(self):
         """When start/end are None, a 7-day window ending now is applied."""
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         result = await svc.query(
             query=StatsQuery(
-                scope="anon",
-                short_code="abc123",
                 group_by="time",
                 metrics="clicks",
                 timezone="UTC",
@@ -113,14 +104,12 @@ class TestDateHandling:
 
     @pytest.mark.asyncio
     async def test_start_date_after_end_date_raises(self):
-        svc, _, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, _, _ = make_service()
         future = NOW + timedelta(days=1)
 
         with pytest.raises(ValidationError, match="start_date must be before end_date"):
             await svc.query(
                 query=_q(
-                    short_code="abc",
                     start_date=future.isoformat(),
                     end_date=NOW_ISO,
                 ),
@@ -129,13 +118,11 @@ class TestDateHandling:
 
     @pytest.mark.asyncio
     async def test_date_range_exceeding_90_days_raises(self):
-        svc, _, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, _, _ = make_service()
 
         with pytest.raises(ValidationError, match="date range cannot exceed 90 days"):
             await svc.query(
                 query=_q(
-                    short_code="abc",
                     start_date=(NOW - timedelta(days=95)).isoformat(),
                     end_date=NOW_ISO,
                 ),
@@ -143,90 +130,24 @@ class TestDateHandling:
             )
 
 
-# ── Tests: scope / privacy ────────────────────────────────────────────────────
+# ── Tests: authentication ─────────────────────────────────────────────────────
 
 
-class TestScopeValidation:
+class TestAuthValidation:
     @pytest.mark.asyncio
-    async def test_anon_scope_requires_short_code(self):
-        svc, _, _ = make_service()
-
-        with pytest.raises(ValidationError, match="short_code is required"):
-            await svc.query(
-                query=_q(scope="anon", short_code=None),
-                owner_id=None,
-            )
-
-    @pytest.mark.asyncio
-    async def test_anon_scope_short_code_not_found_raises(self):
-        svc, _, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info(exists=False)
-
-        with pytest.raises(NotFoundError):
-            await svc.query(
-                query=_q(scope="anon", short_code="ghost"),
-                owner_id=None,
-            )
-
-    @pytest.mark.asyncio
-    async def test_anon_scope_private_stats_unauthenticated_raises(self):
-        svc, _, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info(
-            private=True, owner_id=OWNER_ID
-        )
-
-        with pytest.raises(AuthenticationError):
-            await svc.query(
-                query=_q(scope="anon", short_code="secret"),
-                owner_id=None,  # not logged in
-            )
-
-    @pytest.mark.asyncio
-    async def test_anon_scope_private_stats_wrong_owner_raises(self):
-        svc, _, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info(
-            private=True, owner_id="different_owner_id"
-        )
-
-        with pytest.raises(ForbiddenError):
-            await svc.query(
-                query=_q(scope="anon", short_code="secret"),
-                owner_id=OWNER_ID,  # authenticated but not the owner
-            )
-
-    @pytest.mark.asyncio
-    async def test_anon_scope_private_stats_correct_owner_succeeds(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info(
-            private=True, owner_id=OWNER_ID
-        )
-        click_repo.aggregate.return_value = facet_response()
-
-        result = await svc.query(
-            query=_q(scope="anon", short_code="secret"),
-            owner_id=OWNER_ID,
-        )
-        assert result["scope"] == "anon"
-
-    @pytest.mark.asyncio
-    async def test_all_scope_requires_auth(self):
+    async def test_unauthenticated_raises(self):
+        """Defence in depth — the route already requires auth."""
         svc, _, _ = make_service()
 
         with pytest.raises(AuthenticationError):
-            await svc.query(
-                query=_q(scope="all", short_code=None),
-                owner_id=None,
-            )
+            await svc.query(query=_q(), owner_id=None)
 
     @pytest.mark.asyncio
-    async def test_all_scope_with_auth_succeeds(self):
+    async def test_authenticated_succeeds(self):
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
-        result = await svc.query(
-            query=_q(scope="all", short_code=None),
-            owner_id=OWNER_ID,
-        )
+        result = await svc.query(query=_q(), owner_id=OWNER_ID)
         assert result["scope"] == "all"
 
 
@@ -237,8 +158,7 @@ class TestAggregationPipeline:
     @pytest.mark.asyncio
     async def test_single_facet_call_made(self):
         """Only one aggregate() call per query (the $facet pipeline)."""
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         await svc.query(
@@ -249,8 +169,7 @@ class TestAggregationPipeline:
 
     @pytest.mark.asyncio
     async def test_pipeline_starts_with_match(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         await svc.query(
@@ -262,8 +181,7 @@ class TestAggregationPipeline:
 
     @pytest.mark.asyncio
     async def test_pipeline_has_facet_stage(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         await svc.query(
@@ -275,8 +193,7 @@ class TestAggregationPipeline:
 
     @pytest.mark.asyncio
     async def test_facet_contains_summary_and_requested_dimensions(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         await svc.query(
@@ -289,31 +206,34 @@ class TestAggregationPipeline:
         assert "os" in facet
 
     @pytest.mark.asyncio
-    async def test_scope_all_adds_owner_id_to_match(self):
+    async def test_match_scopes_by_owner_id(self):
         from bson import ObjectId
 
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         await svc.query(
-            query=_q(scope="all", short_code=None),
+            query=_q(),
             owner_id=OWNER_ID,
         )
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.owner_id"] == ObjectId(OWNER_ID)
 
     @pytest.mark.asyncio
-    async def test_scope_anon_adds_short_code_to_match(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+    async def test_short_code_param_slices_the_owner_aggregate(self):
+        """short_code is a plain filter now — always inside the owner stamp."""
+        from bson import ObjectId
+
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         await svc.query(
-            query=_q(scope="anon", short_code="mycode"),
+            query=_q(short_code="mycode"),
             owner_id=OWNER_ID,
         )
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
-        assert match["meta.short_code"] == "mycode"
+        assert match["meta.owner_id"] == ObjectId(OWNER_ID)
+        assert match["meta.short_code"] == {"$in": ["mycode"]}
 
 
 # ── Tests: response structure ─────────────────────────────────────────────────
@@ -322,8 +242,7 @@ class TestAggregationPipeline:
 class TestResponseStructure:
     @pytest.mark.asyncio
     async def test_response_has_required_top_level_keys(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         result = await svc.query(
@@ -344,9 +263,18 @@ class TestResponseStructure:
             assert key in result, f"missing key: {key}"
 
     @pytest.mark.asyncio
+    async def test_response_scope_pinned_to_all(self):
+        """The wire keeps its scope key ("all") — the FE adapter reads it."""
+        svc, click_repo, _ = make_service()
+        click_repo.aggregate.return_value = facet_response()
+
+        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        assert result["scope"] == "all"
+        assert "short_code" not in result
+
+    @pytest.mark.asyncio
     async def test_summary_stats_populated(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response(total=50, unique=20)
 
         result = await svc.query(
@@ -358,8 +286,7 @@ class TestResponseStructure:
 
     @pytest.mark.asyncio
     async def test_computed_metrics_added_when_clicks_exist(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response(total=100, unique=40)
 
         result = await svc.query(
@@ -371,22 +298,9 @@ class TestResponseStructure:
         assert cm["repeat_click_rate"] == 60.0
 
     @pytest.mark.asyncio
-    async def test_anon_scope_includes_short_code_in_response(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
-        click_repo.aggregate.return_value = facet_response()
-
-        result = await svc.query(
-            query=_q(scope="anon", short_code="mycode"),
-            owner_id=OWNER_ID,
-        )
-        assert result["short_code"] == "mycode"
-
-    @pytest.mark.asyncio
     async def test_no_results_returns_empty_metrics(self):
         """When aggregate returns nothing, metrics lists are empty."""
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = []  # no data
 
         result = await svc.query(
@@ -398,8 +312,7 @@ class TestResponseStructure:
 
     @pytest.mark.asyncio
     async def test_avg_redirection_time_rounded_when_measured(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response(avg_redirect=120.456)
 
         result = await svc.query(query=_q(), owner_id=OWNER_ID)
@@ -408,8 +321,7 @@ class TestResponseStructure:
     @pytest.mark.asyncio
     async def test_avg_redirection_time_null_when_no_clicks_in_range(self):
         """Zero clicks in the window (empty _summary facet): null, never 0."""
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = [{"_summary": [], "time": []}]
 
         result = await svc.query(query=_q(), owner_id=OWNER_ID)
@@ -419,8 +331,7 @@ class TestResponseStructure:
     @pytest.mark.asyncio
     async def test_avg_redirection_time_null_when_clicks_carry_no_measurement(self):
         """Clicks exist but $avg found no redirect_ms values: null, never 0."""
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response(total=3, avg_redirect=None)
 
         result = await svc.query(query=_q(), owner_id=OWNER_ID)
@@ -434,8 +345,7 @@ class TestResponseStructure:
 class TestTimezone:
     @pytest.mark.asyncio
     async def test_invalid_timezone_falls_back_to_utc(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         result = await svc.query(
@@ -447,8 +357,7 @@ class TestTimezone:
     @pytest.mark.asyncio
     async def test_timezone_alias_is_normalised(self):
         """Legacy timezone aliases like Asia/Calcutta -> Asia/Kolkata."""
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
+        svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
         result = await svc.query(
@@ -462,24 +371,18 @@ class TestTimezone:
 
 
 class TestClickQueryBuilding:
-    def test_scope_all_produces_owner_id_filter(self):
+    def test_owner_id_filter_always_present(self):
         from bson import ObjectId
 
         from services.stats_service import StatsService
 
-        q = StatsService._build_click_query("all", OWNER_ID, None, START, NOW, {})
+        q = StatsService._build_click_query(OWNER_ID, START, NOW, {})
         assert q["meta.owner_id"] == ObjectId(OWNER_ID)
-
-    def test_scope_anon_produces_short_code_filter(self):
-        from services.stats_service import StatsService
-
-        q = StatsService._build_click_query("anon", None, "mycode", START, NOW, {})
-        assert q["meta.short_code"] == "mycode"
 
     def test_time_range_in_query(self):
         from services.stats_service import StatsService
 
-        q = StatsService._build_click_query("all", OWNER_ID, None, START, NOW, {})
+        q = StatsService._build_click_query(OWNER_ID, START, NOW, {})
         assert q["clicked_at"]["$gte"] == START
         assert q["clicked_at"]["$lte"] == NOW
 
@@ -487,7 +390,7 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"browser": ["Chrome", "Firefox"]}
+            OWNER_ID, START, NOW, {"browser": ["Chrome", "Firefox"]}
         )
         assert q["browser"] == {"$in": ["Chrome", "Firefox"]}
 
@@ -495,24 +398,19 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"referrer": ["Direct"]}
+            OWNER_ID, START, NOW, {"referrer": ["Direct"]}
         )
         assert "$or" in q
 
-    def test_short_code_filter_skipped_in_anon_scope(self):
-        """short_code filter cannot bypass the scope lock (security)."""
+    def test_short_code_filter_is_plain(self):
+        """No scope lock exists any more — short_code is a plain filter that
+        slices the owner-stamped aggregate."""
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "anon",
-            None,
-            "locked",
-            START,
-            NOW,
-            {"short_code": ["bypass_attempt"]},
+            OWNER_ID, START, NOW, {"short_code": ["link1", "link2"]}
         )
-        # meta.short_code must remain the locked value, not the filter value
-        assert q["meta.short_code"] == "locked"
+        assert q["meta.short_code"] == {"$in": ["link1", "link2"]}
 
     def test_url_id_filter_cannot_overwrite_locked_url_id(self):
         """url_id filter cannot bypass a per-link lock (security).
@@ -532,7 +430,7 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"utm_source": ["newsletter"]}
+            OWNER_ID, START, NOW, {"utm_source": ["newsletter"]}
         )
         assert q["utm_source"] == {"$in": ["newsletter"]}
 
@@ -542,7 +440,7 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"utm_source": ["(none)"]}
+            OWNER_ID, START, NOW, {"utm_source": ["(none)"]}
         )
         assert q["$or"] == [
             {"utm_source": {"$in": ["(none)"]}},
@@ -554,7 +452,7 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"utm_medium": ["(none)", "email"]}
+            OWNER_ID, START, NOW, {"utm_medium": ["(none)", "email"]}
         )
         assert q["$or"] == [
             {"utm_medium": {"$in": ["(none)", "email"]}},
@@ -568,9 +466,7 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all",
             OWNER_ID,
-            None,
             START,
             NOW,
             {"referrer": ["Direct"], "utm_source": ["(none)"]},
@@ -583,10 +479,9 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"device": ["mobile", "tablet"]}
+            OWNER_ID, START, NOW, {"device": ["mobile", "tablet"]}
         )
         assert q["device"] == {"$in": ["mobile", "tablet"]}
-        assert "$in" not in str(q.get("meta.short_code", ""))
 
     def test_device_unknown_matches_stored_and_missing(self):
         """ "unknown" is BOTH a stored value (classifier fallback) and the
@@ -595,7 +490,7 @@ class TestClickQueryBuilding:
         from services.stats_service import StatsService
 
         q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"device": ["unknown"]}
+            OWNER_ID, START, NOW, {"device": ["unknown"]}
         )
         assert q["$or"] == [
             {"device": {"$in": ["unknown"]}},
@@ -627,7 +522,8 @@ class TestClickQueryBuilding:
 
 
 class TestClaimedLinksArm:
-    """scope=ALL carries claimed links' pre-claim history via a url_id arm."""
+    """The account query carries claimed links' pre-claim history via a
+    url_id arm."""
 
     @pytest.mark.asyncio
     async def test_empty_claimed_set_keeps_pure_stamp_query(self):
@@ -637,7 +533,7 @@ class TestClaimedLinksArm:
         click_repo.aggregate.return_value = facet_response()
         url_repo.list_claimed_ids.return_value = []
 
-        await svc.query(query=_q(scope="all", short_code=None), owner_id=OWNER_ID)
+        await svc.query(query=_q(), owner_id=OWNER_ID)
 
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.owner_id"] == ObjectId(OWNER_ID)
@@ -652,7 +548,7 @@ class TestClaimedLinksArm:
         claimed = [ObjectId("f" * 24)]
         url_repo.list_claimed_ids.return_value = claimed
 
-        await svc.query(query=_q(scope="all", short_code=None), owner_id=OWNER_ID)
+        await svc.query(query=_q(), owner_id=OWNER_ID)
 
         url_repo.list_claimed_ids.assert_awaited_once_with(ObjectId(OWNER_ID))
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
@@ -666,16 +562,13 @@ class TestClaimedLinksArm:
     async def test_claimed_arm_nests_under_and_with_sentinel_filters(self):
         from bson import ObjectId
 
-        from schemas.dto.requests.stats import StatsScope
         from services.stats_service import StatsService
 
         claimed = [ObjectId("f" * 24)]
         start = datetime(2026, 1, 1, tzinfo=timezone.utc)
         end = datetime(2026, 2, 1, tzinfo=timezone.utc)
         query = StatsService._build_click_query(
-            StatsScope.ALL,
             OWNER_ID,
-            None,
             start,
             end,
             {"referrer": ["Direct"]},
@@ -685,16 +578,6 @@ class TestClaimedLinksArm:
         assert "$or" not in query
         assert len(query["$and"]) == 2
         assert query["$and"][0]["$or"][0] == {"meta.owner_id": ObjectId(OWNER_ID)}
-
-    @pytest.mark.asyncio
-    async def test_scope_anon_never_consults_claimed_set(self):
-        svc, click_repo, url_repo = make_service()
-        url_repo.check_stats_privacy.return_value = privacy_info()
-        click_repo.aggregate.return_value = facet_response()
-
-        await svc.query(query=_q(scope="anon", short_code="abc1234"), owner_id=None)
-
-        url_repo.list_claimed_ids.assert_not_awaited()
 
 
 # ── Tests: url_id filter (account scope) ──────────────────────────────────────
@@ -707,9 +590,7 @@ class TestUrlIdFilter:
         from services.stats_service import StatsService
 
         ids = ["a" * 24, "b" * 24]
-        q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"url_id": ids}
-        )
+        q = StatsService._build_click_query(OWNER_ID, START, NOW, {"url_id": ids})
         assert q["meta.url_id"] == {"$in": [ObjectId(v) for v in ids]}
 
     def test_url_id_filter_keeps_owner_stamp(self):
@@ -721,9 +602,7 @@ class TestUrlIdFilter:
         from services.stats_service import StatsService
 
         foreign = "f" * 24
-        q = StatsService._build_click_query(
-            "all", OWNER_ID, None, START, NOW, {"url_id": [foreign]}
-        )
+        q = StatsService._build_click_query(OWNER_ID, START, NOW, {"url_id": [foreign]})
         assert q["meta.owner_id"] == ObjectId(OWNER_ID)
         assert q["meta.url_id"] == {"$in": [ObjectId(foreign)]}
 
@@ -736,7 +615,7 @@ class TestUrlIdFilter:
         oid = "a" * 24
 
         await svc.query(
-            query=_q(scope="all", short_code=None, url_id=oid),
+            query=_q(url_id=oid),
             owner_id=OWNER_ID,
         )
         match = click_repo.aggregate.call_args[0][0][0]["$match"]


### PR DESCRIPTION
Breaking change, stacked on #291. Merge only after the frontend and client migrations ship.

`GET /api/v1/stats` and `GET /api/v1/export` now require authentication and are always scoped to the caller's own URLs. The `scope` parameter is removed; a stray `scope=` in the query string is silently ignored (pinned in tests). `short_code` remains available as a plain filter.

What replaces the old anonymous mode:

- Public per-link stats live at `GET /api/v1/public/stats/{code}`, which has the correct semantics the anonymous scope lacked: privacy answers as a plain 404, passwords travel in a POST body, clicks are matched by url id so same-alias links on other domains cannot bleed in, and utm dimensions stay private to the owner.
- Owner per-link stats live at `GET /api/v1/stats/links/{url_id}` from #291.

Also removed: the alias-based stats privacy check (`check_stats_privacy`), the anonymous export tier, and the anonymous read tier introduced in #289, whose only consumer was the anonymous stats read.

90 days of traffic were reviewed before removing this without a deprecation window: anonymous scope usage came from a single automated client, and the export endpoint had zero requests in any scope. Expect that client to start receiving 401s.

2983 tests pass.