### PR TITLE
feat: register sdk-ts as a first-party client slug

### DIFF
--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -20,7 +20,7 @@ _CLIENT_TAG_RE = re.compile(r"^([a-z0-9_-]{1,32})(?:/([A-Za-z0-9._-]{1,16}))?$")
 # (created_via) accepts only members, so arbitrary header values can never
 # become permanent, unfilterable document history.
 FIRST_PARTY_CLIENTS = frozenset(
-    {"dashboard", "landing", "snap", "raycast", "cli", "bot"}
+    {"dashboard", "landing", "snap", "raycast", "cli", "bot", "sdk-ts"}
 )
 
 

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -43,6 +43,7 @@ def test_parse_invalid_is_absent(value):
         ("dashboard", "dashboard"),
         ("snap/2.1.0", "snap"),
         ("cli", "cli"),
+        ("sdk-ts/1.0.0", "sdk-ts"),
         # well-formed but not first-party: logged, never persisted
         ("whatever", None),
         ("curl/8.0", None),


### PR DESCRIPTION
The upcoming official TypeScript SDK will identify itself with `X-Spoo-Client: sdk-ts/<version>`.

This adds `sdk-ts` to `FIRST_PARTY_CLIENTS` so links created through the SDK persist `created_via`. Without it the slug still shows up in logs (any shape-valid slug does) but gets dropped at persistence time as an unknown client.

Also adds a `first_party_client` test case covering the new slug, which doubles as coverage for hyphenated slugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing the TypeScript SDK as a first-party client in persisted client tags.

* **Tests**
  * Added coverage confirming TypeScript SDK client tags are identified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->