### PR TITLE
feat: expose diagnostic headers on CORS responses

### DIFF
--- a/middleware/security.py
+++ b/middleware/security.py
@@ -19,6 +19,13 @@ _PUBLIC_PREFIXES = ("/api/v1", "/auth/device", "/stats", "/export", "/metric")
 
 _ALLOWED_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
 _ALLOWED_HEADERS = "Authorization, Content-Type, Accept, X-Request-ID, X-Spoo-Client"
+# Response headers cross-origin JS may read. Retry-After is included because
+# only the CORS-safelisted set (Cache-Control, Content-Language, Content-Length,
+# Content-Type, Expires, Last-Modified, Pragma) is readable without it.
+_EXPOSED_HEADERS = (
+    "X-Request-ID, X-Error-Code, X-Spoo-Hint, X-RateLimit-Limit, "
+    "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After"
+)
 
 
 def _classify_path(path: str) -> str:
@@ -83,9 +90,11 @@ class SplitCORSMiddleware(BaseHTTPMiddleware):
         """Set CORS headers based on route classification."""
         if classification == "public":
             response.headers["Access-Control-Allow-Origin"] = "*"
+            response.headers["Access-Control-Expose-Headers"] = _EXPOSED_HEADERS
         elif classification == "private" and origin in self._private_origins:
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Access-Control-Allow-Credentials"] = "true"
+            response.headers["Access-Control-Expose-Headers"] = _EXPOSED_HEADERS
             response.headers["Vary"] = "Origin"
 
 

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -245,6 +245,58 @@ def test_cors_private_route_disallowed_origin():
     assert "access-control-allow-origin" not in resp.headers
 
 
+def test_cors_public_route_exposes_headers():
+    app = _build_test_app(include_logging=False)
+    app.include_router(_test_router)
+    with TestClient(app) as c:
+        resp = c.get(
+            "/api/v1/test-404",
+            headers={"Origin": "https://example.com"},
+        )
+    assert resp.headers.get("access-control-expose-headers") == (
+        "X-Request-ID, X-Error-Code, X-Spoo-Hint, X-RateLimit-Limit, "
+        "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After"
+    )
+
+
+def test_cors_private_route_exposes_headers():
+    app = _build_test_app(include_logging=False)
+    from middleware.security import SplitCORSMiddleware
+
+    for mw in app.user_middleware:
+        if mw.cls is SplitCORSMiddleware:
+            mw.kwargs["private_origins"] = ["https://spoo.me"]
+    app.include_router(_test_router)
+    with TestClient(app, base_url="http://testserver") as c:
+        resp = c.get(
+            "/auth/test-401",
+            headers={"Origin": "https://spoo.me"},
+        )
+    assert resp.headers.get("access-control-expose-headers") == (
+        "X-Request-ID, X-Error-Code, X-Spoo-Hint, X-RateLimit-Limit, "
+        "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After"
+    )
+
+
+def test_cors_no_expose_headers_without_origin():
+    app = _build_test_app(include_logging=False)
+    app.include_router(_test_router)
+    with TestClient(app) as c:
+        resp = c.get("/api/v1/test-404")
+    assert "access-control-expose-headers" not in resp.headers
+
+
+def test_cors_no_expose_headers_for_disallowed_private_origin():
+    app = _build_test_app(include_logging=False)
+    app.include_router(_test_router)
+    with TestClient(app) as c:
+        resp = c.get(
+            "/auth/test-401",
+            headers={"Origin": "https://evil.com"},
+        )
+    assert "access-control-expose-headers" not in resp.headers
+
+
 def test_cors_unclassified_route_no_cors():
     app = _build_test_app(include_logging=False)
     app.include_router(_test_router)


### PR DESCRIPTION
`SplitCORSMiddleware` never sent `Access-Control-Expose-Headers`, so cross-origin JavaScript could not read any of our diagnostic response headers: `X-Request-ID`, `X-Error-Code`, `X-Spoo-Hint`, the `X-RateLimit-*` trio, or `Retry-After`. Browsers only let scripts read the CORS-safelisted set (Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma), and `Retry-After` is not on it, so it needs listing explicitly too.

The header is now set on both policies: public routes (wildcard origin) and private routes with an allowlisted origin. Non-CORS requests and disallowed private origins get no CORS headers, same as before.

New integration tests assert the exact exposed list on a public path and an allowlisted private path, and its absence without an Origin header and for a disallowed private origin.