### PR TITLE
feat: register the sdk-py first-party client slug

### DIFF
--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -20,7 +20,7 @@ _CLIENT_TAG_RE = re.compile(r"^([a-z0-9_-]{1,32})(?:/([A-Za-z0-9._-]{1,16}))?$")
 # (created_via) accepts only members, so arbitrary header values can never
 # become permanent, unfilterable document history.
 FIRST_PARTY_CLIENTS = frozenset(
-    {"dashboard", "landing", "snap", "raycast", "cli", "bot", "sdk-ts"}
+    {"dashboard", "landing", "snap", "raycast", "cli", "bot", "sdk-ts", "sdk-py"}
 )
 
 

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -44,6 +44,7 @@ def test_parse_invalid_is_absent(value):
         ("snap/2.1.0", "snap"),
         ("cli", "cli"),
         ("sdk-ts/1.0.0", "sdk-ts"),
+        ("sdk-py/1.0.0", "sdk-py"),
         # well-formed but not first-party: logged, never persisted
         ("whatever", None),
         ("curl/8.0", None),


### PR DESCRIPTION
The official Python SDK is live on PyPI as [spoo 1.0.0](https://pypi.org/project/spoo/) ([spoo-me/spoo-py](https://github.com/spoo-me/spoo-py)) and tags every request with `X-Spoo-Client: sdk-py/{version}`.

This registers `sdk-py` in `FIRST_PARTY_CLIENTS` so links created through the SDK persist `created_via`, matching what #293 did for `sdk-ts`. Logging already picks the slug up shape-only; this only affects durable persistence.

One line plus a test case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing the Python SDK as a first-party client.
  * Python SDK activity can now be retained with the appropriate client attribution.

* **Tests**
  * Added coverage confirming Python SDK client tags are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->