### PR TITLE
fix(schemas): advertise epoch seconds in expire_after request schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9593,6 +9593,9 @@
                 "format": "date-time"
               },
               {
+                "type": "integer"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -10142,6 +10145,9 @@
               {
                 "type": "string",
                 "format": "date-time"
+              },
+              {
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -12825,6 +12831,9 @@
               {
                 "type": "string",
                 "format": "date-time"
+              },
+              {
+                "type": "integer"
               },
               {
                 "type": "null"

--- a/schemas/dto/requests/bulk.py
+++ b/schemas/dto/requests/bulk.py
@@ -90,7 +90,9 @@ class BulkUpdateExpiryRequest(BulkIdsRequest):
         examples=[1767225600],
     )
 
-    @field_validator("expire_after", mode="before")
+    @field_validator(
+        "expire_after", mode="before", json_schema_input_type=datetime | int | None
+    )
     @classmethod
     def _parse_expire_after(cls, v: str | int | None) -> datetime | None:
         # Same coercion as UpdateUrlRequest.expire_after — one parser for

--- a/schemas/dto/requests/url.py
+++ b/schemas/dto/requests/url.py
@@ -257,7 +257,9 @@ class CreateUrlRequest(RequestBase):
     def _alias_shape(cls, v: str | None) -> str | None:
         return _validate_alias_shape(v)
 
-    @field_validator("expire_after", mode="before")
+    @field_validator(
+        "expire_after", mode="before", json_schema_input_type=datetime | int | None
+    )
     @classmethod
     def _parse_expire_after(cls, v: str | int | None) -> datetime | None:
         if v is None:
@@ -368,7 +370,9 @@ class UpdateUrlRequest(RequestBase):
     def _alias_shape(cls, v: str | None) -> str | None:
         return _validate_alias_shape(v)
 
-    @field_validator("expire_after", mode="before")
+    @field_validator(
+        "expire_after", mode="before", json_schema_input_type=datetime | int | None
+    )
     @classmethod
     def _parse_expire_after(cls, v: str | int | None) -> datetime | None:
         if v is None:


### PR DESCRIPTION
The `expire_after` validator on `CreateUrlRequest`, `UpdateUrlRequest` and `BulkUpdateExpiryRequest` accepts Unix epoch seconds as well as ISO 8601 strings, and the field descriptions already say so. The generated OpenAPI schema only advertised `string date-time | null`, so SDKs that generate their request types from the spec had to widen the type by hand.

This sets `json_schema_input_type` on the three before-validators so the schema becomes `anyOf [string date-time, integer, null]`, and regenerates `openapi.json` via `make openapi`. Runtime parsing and validation are unchanged, the diff to `openapi.json` is exactly the three added `integer` variants.

The TypeScript, Python and Rust SDK repos vendor this spec and will refresh their copies once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * URL expiration values can now be provided as ISO 8601 date-time strings, Unix timestamps, or `null` when creating, updating, or bulk-updating URLs.
  * API documentation now accurately reflects the supported expiration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->