### PR TITLE
feat(telemetry): register sdk-rust and sdk-go client slugs

### DIFF
--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -29,6 +29,7 @@ FIRST_PARTY_CLIENTS = frozenset(
         "bot",
         "sdk-ts",
         "sdk-py",
+        "sdk-go",
         "sdk-rust",
     }
 )

--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -20,7 +20,17 @@ _CLIENT_TAG_RE = re.compile(r"^([a-z0-9_-]{1,32})(?:/([A-Za-z0-9._-]{1,16}))?$")
 # (created_via) accepts only members, so arbitrary header values can never
 # become permanent, unfilterable document history.
 FIRST_PARTY_CLIENTS = frozenset(
-    {"dashboard", "landing", "snap", "raycast", "cli", "bot", "sdk-ts", "sdk-py"}
+    {
+        "dashboard",
+        "landing",
+        "snap",
+        "raycast",
+        "cli",
+        "bot",
+        "sdk-ts",
+        "sdk-py",
+        "sdk-rust",
+    }
 )
 
 

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -45,6 +45,7 @@ def test_parse_invalid_is_absent(value):
         ("cli", "cli"),
         ("sdk-ts/1.0.0", "sdk-ts"),
         ("sdk-py/1.0.0", "sdk-py"),
+        ("sdk-rust/0.2.0", "sdk-rust"),
         # well-formed but not first-party: logged, never persisted
         ("whatever", None),
         ("curl/8.0", None),

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -45,6 +45,7 @@ def test_parse_invalid_is_absent(value):
         ("cli", "cli"),
         ("sdk-ts/1.0.0", "sdk-ts"),
         ("sdk-py/1.0.0", "sdk-py"),
+        ("sdk-go/0.5.2", "sdk-go"),
         ("sdk-rust/0.2.0", "sdk-rust"),
         # well-formed but not first-party: logged, never persisted
         ("whatever", None),


### PR DESCRIPTION
The Rust SDK ships with `X-Spoo-Client: sdk-rust/<version>` as its default tag. Adding `sdk-rust` to `FIRST_PARTY_CLIENTS` lets `created_via` persist it, so links created through the SDK attribute properly, the same way `sdk-ts` and `sdk-py` are registered.

`sdk-py` was already added in #307, so this only adds the Rust slug plus the matching test case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for the Rust SDK as a first-party client.

* **Bug Fixes**
  * Correctly identifies Rust SDK requests, including versioned client strings such as `sdk-rust/0.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Amended: sdk-go was also missing from the allowlist. The Go SDK has shipped since v0.1.0 with a default sdk-go/<version> tag, so its traffic was logged but never attributed as first-party. Added with the same shape as the other SDK entries.