### PR TITLE
feat(telemetry): register sdk-kotlin and app-android client slugs

### DIFF
--- a/shared/client_tag.py
+++ b/shared/client_tag.py
@@ -31,6 +31,8 @@ FIRST_PARTY_CLIENTS = frozenset(
         "sdk-py",
         "sdk-go",
         "sdk-rust",
+        "sdk-kotlin",
+        "app-android",
     }
 )
 

--- a/tests/unit/shared/test_client_tag.py
+++ b/tests/unit/shared/test_client_tag.py
@@ -46,6 +46,8 @@ def test_parse_invalid_is_absent(value):
         ("sdk-ts/1.0.0", "sdk-ts"),
         ("sdk-py/1.0.0", "sdk-py"),
         ("sdk-go/0.5.2", "sdk-go"),
+        ("sdk-kotlin/0.1.0", "sdk-kotlin"),
+        ("app-android/1.0.0", "app-android"),
         ("sdk-rust/0.2.0", "sdk-rust"),
         # well-formed but not first-party: logged, never persisted
         ("whatever", None),


### PR DESCRIPTION
Adds the two upcoming first-party client tags to the allowlist so their traffic attributes from the first request: sdk-kotlin (the Kotlin SDK's default tag) and app-android (the Android app's own tag, following the pattern where apps override the SDK default). Test rows mirror the existing SDK entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for Kotlin SDK and Android app clients as first-party clients.

* **Tests**
  * Added coverage for identifying Kotlin SDK and Android app client versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->