### PR TITLE
fix(auth): send logged-out device-auth users to /login instead of the landing root

### DIFF
--- a/routes/auth/device.py
+++ b/routes/auth/device.py
@@ -131,7 +131,8 @@ async def device_login(
         if redirect_uri:
             params["redirect_uri"] = redirect_uri
         next_url = f"/auth/device/login?{urlencode(params)}"
-        return RedirectResponse(f"/?next={quote(next_url)}", status_code=302)
+        # /login is the only frontend surface that resumes ?next= after auth.
+        return RedirectResponse(f"/login?next={quote(next_url)}", status_code=302)
 
     # Check for existing active grant (auto-approve)
     grant = await grant_repo.find_active_grant(user.user_id, app_id)

--- a/tests/integration/test_device_auth.py
+++ b/tests/integration/test_device_auth.py
@@ -290,7 +290,7 @@ def test_device_login_unauthenticated_redirects(
     )
     assert resp.status_code == 302
     loc = resp.headers["location"]
-    assert "/?next=" in loc
+    assert loc.startswith("/login?next=")
     assert "spoo-snap" in loc
     assert "abc" in loc
     # The PKCE challenge must survive the login round-trip


### PR DESCRIPTION
## Problem

When a logged-out user opens a connected app's Sign in with Spoo link, `GET /auth/device/login` redirects to `/?next=<consent-url>`. Nothing on the landing root reads `next`, so the user is stranded on the homepage with no login prompt and the app never gets its grant. This hits every device-auth app (Snap, Raycast, the mobile app, the Discord bot) whenever the user is not already signed in.

## Fix

Redirect to `/login?next=<consent-url>` instead. The login page is the one surface that resumes `next` after sign-in. Signed-in users are unaffected: the redirect only fires in the no-session branch, so they still land straight on the consent page (or auto-approve on an existing grant).

## Testing

- `tests/integration/test_device_auth.py` pins the new location (38 passed)
- Verified against a local fullstack: the 302 targets `/login?next=...` and the consent page renders after sign-in

Pairs with spoo-me/frontend#52, which keeps `next` alive through the auth pane itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthenticated device login now redirects to the login page while preserving the requested destination.
  * Improved sign-in flow when accessing protected device authentication links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->