### PR TITLE
Register the Android app's redirect URI and scopes

### DIFF
--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -58,6 +58,15 @@ apps:
     verified: true
     status: coming_soon
     type: device_auth
+    redirect_uris:
+      - spoo://oauth/callback
+    links:
+      github: https://github.com/spoo-me/spoo-android
+    scopes:
+      - shorten:create
+      - urls:read
+      - urls:manage
+      - stats:read
 
   spoo-telegram:
     name: Telegram Bot


### PR DESCRIPTION
Registers the native Android app (spoo-mobile) for Sign in with Spoo.

- `spoo://oauth/callback` as the redirect URI. The redirect validator does exact string matching, so the deep link the app actually sends has to be enumerated here. Custom-scheme deep links are the platform-native shape for Android, same as loopback is for the CLI; the code is useless without the PKCE verifier, so scheme interception buys nothing.
- The standard client scope set (shorten:create, urls:read, urls:manage, stats:read), matching the CLI, Raycast, and the extension.
- Status stays `coming_soon`: only `live` apps can authenticate, and flipping it is the deliberate launch-day switch once the app ships.

App repo: https://github.com/spoo-me/spoo-android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile app OAuth configuration, including a custom redirect URI.
  * Added a GitHub project link.
  * Defined permissions for creating, reading, managing, and viewing URL statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->