### PR TITLE
Open Sign in with Spoo to the Android app

### DIFF
--- a/config/apps.yaml
+++ b/config/apps.yaml
@@ -56,7 +56,7 @@ apps:
     icon: spoo-mobile.svg
     description: Shorten links on the go
     verified: true
-    status: coming_soon
+    status: live
     type: device_auth
     redirect_uris:
       - spoo://oauth/callback


### PR DESCRIPTION
`spoo-mobile` has had its redirect URI and scopes registered since #315, but only `live` apps authenticate, so the device-auth flow still answers "Unknown or unsupported application".

The app is published and installable from GitHub releases (v0.1.1), so this flips the flag and lets sign-in work.

Nothing else changes: the redirect allowlist, the scopes, and the PKCE requirements were all set in #315.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Spoo mobile app is now available for use in the consent flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->