### PR TITLE
ci: match branches with slashes in the formatting workflow

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -3,7 +3,7 @@ name: Check Code Formatting
 on:
   push:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - '**/*.md'
       - '**/*.rst'


### PR DESCRIPTION
The push trigger used `branches: ['*']`, whose single star does not match a branch name containing a slash. Every feature branch here has one, so this required check only ever ran through the pull request event, and a pull request whose event did not fire was left permanently missing a required check.

`tests.yaml` already carries the same fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run for pushes to branch names containing slashes, such as `feature/foo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->