### PR TITLE
chore(caddy): sync the prod vhost from the box and allowlist /tools

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -97,11 +97,112 @@
 	}
 }
 
+# Compose one branded error page: when the origin self-describes an error
+# (X-Error-Code) and the client meaningfully asked for HTML, swap the body
+# for the Next error page while KEEPING the origin status. JSON clients and
+# Accept:*/* scanner probes get the origin response untouched.
+(compose_prod_err) {
+	@err{args[0]} {
+		status {args[0]}
+		header X-Error-Code *
+	}
+	handle_response @err{args[0]} {
+		@html{args[0]} {
+			header Accept *text/html*
+			method GET HEAD
+		}
+		handle @html{args[0]} {
+			rewrite * /_error/{args[0]}?code={rp.header.X-Error-Code}&from={uri}
+			reverse_proxy spoo_next:3000 {
+				@ok{args[0]} status 2xx
+				replace_status @ok{args[0]} {args[0]}
+				header_up Host {host}
+			}
+		}
+		handle {
+			copy_response
+		}
+	}
+}
+
 spoo.me, www.spoo.me {
 	import common_tls
+
+	# Legal/legacy path redirects (old Jinja routes that moved).
+	redir /tos /terms permanent
+	redir /register /signup permanent
+
+	# Only paths with a built Next page belong here — a listed path with
+	# no page behind it 404s in Next instead of falling through to FastAPI.
+	@next {
+		path /about /about/*
+		path /pricing /pricing/*
+		path /apps /apps/*
+		path /product /product/*
+		path /testimonials /testimonials/*
+		path /tools /tools/*
+		path /login /signup /forgot-password
+		path /onboarding /onboarding/*
+		path /privacy /terms /legal
+		path /relay/*
+		path /dashboard /dashboard/*
+		# Composed-error URL (Next rewrites it to error-pages/ internally).
+		path /_error/*
+		path /_next/* /icon.png
+		path /favicon.ico /favicon.png /favicon.svg
+		# Next public/ asset dirs + the favicon-proxy route. A new top-level
+		# dir under public/ needs a line here AND a reserved-aliases entry,
+		# or it 404s through FastAPI and takes client pages down with it.
+		path /geo/* /brand/* /icons-3d/*
+		path /api/favicon
+		# SEO files (robots.ts/sitemap.ts generators + public/ text files).
+		path /robots.txt /sitemap.xml /humans.txt
+		path /security.txt /.well-known/security.txt
+		# OG cards (public/og + the homepage card route) and the AI index.
+		path /og/* /opengraph-image.png /llms.txt
+	}
+	reverse_proxy @next spoo_next:3000 {
+		header_up X-Real-IP {client_ip}
+		header_up X-Forwarded-For {client_ip}
+		header_up Host {host}
+	}
+
+	# Paths whose GET is a Next page but whose POST is a shipped backend
+	# contract: / (the anonymous shorten API), /contact and /report (form
+	# intakes), /stats and /stats/{code} (legacy public JSON API). Next
+	# answers POSTs with a 200, so an unscoped matcher silently breaks
+	# every one of these for API clients.
+	@next_get {
+		method GET HEAD
+		path / /contact /report
+		path /stats /stats/*
+	}
+	reverse_proxy @next_get spoo_next:3000 {
+		header_up X-Real-IP {client_ip}
+		header_up X-Forwarded-For {client_ip}
+		header_up Host {host}
+	}
+
+	# /{code}+ preview — any single segment ending in + (matched against the
+	# DECODED path, so emoji aliases land here too). No valid alias contains
+	# +, so this can never shadow a real code.
+	@preview path_regexp ^/[^/]+\+$
+	reverse_proxy @preview spoo_next:3000 {
+		header_up X-Real-IP {client_ip}
+		header_up X-Forwarded-For {client_ip}
+		header_up Host {host}
+	}
+
+	# Everything else: short codes, /auth/*, /oauth/*, /api/v1/*, /static/*
 	reverse_proxy app:8000 {
 		header_up X-Real-IP {client_ip}
 		header_up X-Forwarded-For {client_ip}
+
+		import compose_prod_err 404
+		import compose_prod_err 410
+		import compose_prod_err 429
+		import compose_prod_err 451
+		import compose_prod_err 500
 	}
 }
 
@@ -129,6 +230,7 @@ Disallow: /" 200
 		path /pricing /pricing/*
 		path /apps /apps/*
 		path /testimonials /testimonials/*
+		path /tools /tools/*
 		path /login /signup /forgot-password
 		path /onboarding /onboarding/*
 		path /privacy /terms /legal
@@ -148,6 +250,8 @@ Disallow: /" 200
 		# with the backend for whatever claims it later.
 		path /robots.txt /sitemap.xml /humans.txt
 		path /security.txt /.well-known/security.txt
+		# OG cards (public/og + the homepage card route) and the AI index.
+		path /og/* /opengraph-image.png /llms.txt
 	}
 	reverse_proxy @next spoo_next_beta:3000 {
 		header_up X-Real-IP {client_ip}

--- a/shared/reserved_aliases.py
+++ b/shared/reserved_aliases.py
@@ -76,6 +76,7 @@ RESERVED_ALIASES: frozenset[str] = frozenset(
         "terms",
         "terms-of-service",
         "testimonials",
+        "tools",
         "tos",
         "twitter",
         "verify",

--- a/tests/unit/shared/test_reserved_aliases.py
+++ b/tests/unit/shared/test_reserved_aliases.py
@@ -7,7 +7,15 @@ from shared.validators import validate_alias
 
 
 def test_frontend_surfaces_are_reserved():
-    for alias in ("about", "pricing", "onboarding", "dashboard", "relay", "terms"):
+    for alias in (
+        "about",
+        "pricing",
+        "onboarding",
+        "dashboard",
+        "relay",
+        "terms",
+        "tools",
+    ):
         assert is_reserved_alias(alias)
 
 


### PR DESCRIPTION
Brings `caddy/Caddyfile` back in line with what is actually running on the box, and adds the routing the free tools pages need.

## Why it drifted

This file was last committed on 14 July, when `spoo.me` was still a bare `import common_tls` block because prod was not serving Next yet. Everything that made it serve Next was written directly onto the box during the cutover and never came back here:

- the prod `@next` path allowlist
- the `@next_get` method scoping, so a POST to `/`, `/contact`, `/report` or `/stats/{code}` still reaches the backend instead of getting a 200 from Next
- the `/{code}+` preview route
- the `compose_prod_err` snippet that swaps in the branded error page while keeping the origin status
- `/og/*`, `/opengraph-image.png` and `/llms.txt`, added yesterday for the OG cards

That is 102 lines, all additions. Nothing was removed live, so the repo copy was a strict subset. `beta.spoo.me` and `qr.spoo.me` had stayed in sync apart from one OG line.

## What is new here

- `/tools` and `/tools/*` in both host allowlists, for the free tools pages
- `tools` added to `RESERVED_ALIASES`, so the path cannot be issued as a short code

## Merging this deploys nothing

`/opt/spoo` is not a git checkout and no workflow writes to it, so the running config only changes when the file is copied up by hand. That copy should happen **after** the frontend deploy, not before: a path listed in `@next` with no page behind it 404s in Next instead of falling through to FastAPI.

Because `sed -i` replaces the inode and breaks the read-only single file bind mount, applying it means writing the file in place and then:

```
docker compose up -d --force-recreate --no-deps caddy
```

## One thing to know before applying

`spoo.me/tools` is a live legacy v1 link with 20 lifetime clicks, pointing at a v0.dev preview that still resolves. Once `/tools` is in the allowlist, Caddy hands that path to Next and the link stops resolving. Its row stays in Mongo. Twenty clicks on a throwaway preview URL looks acceptable to break, but it is a deliberate call rather than an accident.

Validated with `caddy validate` against v2.11.2 in the running container: valid configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added routing for new tools, Open Graph, SEO, geographic, branding, and icon pages.
  - Added branded error pages for common server and access errors.
  - Added preview routing for short-link pages.
  - Added the same page support to the beta site.

- **Bug Fixes**
  - Reserved “tools” as a page path so it cannot be used as a short link alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->