### PR TITLE
refactor(safety): one Web Risk client behind both callers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,8 @@ GITHUB_REPO="" # org/repo format
 # GCP key enabling Google Web Risk lookups, for both the safety analyzer and
 # the URL expander tool's displayed verdict.
 # SAFETY_WEB_RISK_API_KEY=""
+# The expander is public and shares this quota, so its share is capped.
+# SAFETY_WEB_RISK_EXPANDER_DAILY_BUDGET="1000"
 
 # ── Scheduled tasks ──────────────────────────────────────────────────────
 # Recurring background jobs (feed syncs, sweeps, archival) on a Mongo-backed

--- a/.env.example
+++ b/.env.example
@@ -154,7 +154,9 @@ GITHUB_REPO="" # org/repo format
 # SAFETY_ENABLED="false"
 # SAFETY_REVERDICT_TTL_HOURS="24"                # skip re-analysis fresher than this
 # SAFETY_FISHFISH_ENABLED="true"                 # fishfish.gg feed (free, no auth)
-# SAFETY_WEB_RISK_API_KEY=""                     # GCP key enables Google Web Risk lookups
+# GCP key enabling Google Web Risk lookups, for both the safety analyzer and
+# the URL expander tool's displayed verdict.
+# SAFETY_WEB_RISK_API_KEY=""
 
 # ── Scheduled tasks ──────────────────────────────────────────────────────
 # Recurring background jobs (feed syncs, sweeps, archival) on a Mongo-backed

--- a/config.py
+++ b/config.py
@@ -578,6 +578,9 @@ class SafetySettings(BaseSettings):
     # sanctioned equivalent.)
     web_risk_api_key: str = ""
     web_risk_api_base: str = "https://webrisk.googleapis.com"
+    # The public expander shares this quota with the analyzer; its capped
+    # share keeps tool traffic from spending the ~3.3k/day free tier.
+    web_risk_expander_daily_budget: int = Field(default=1_000, ge=0)
 
     @property
     def web_risk_enabled(self) -> bool:

--- a/config.py
+++ b/config.py
@@ -401,29 +401,6 @@ class MetaTagsSettings(BaseSettings):
     fetch_user_agent: str = "spoo.me-og-validator/1.0 (+https://spoo.me)"
 
 
-class WebRiskSettings(BaseSettings):
-    """Google Web Risk lookups for the URL expander's safety verdict.
-
-    Env vars are prefixed ``WEB_RISK_`` so a generic ``API_KEY`` set
-    elsewhere in the deploy environment can't configure this. Without a
-    key the check silently doesn't run and the verdict is absent — the
-    tool never shows a fabricated one.
-    """
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        extra="ignore",
-        env_prefix="WEB_RISK_",
-    )
-
-    api_key: str = ""
-    timeout_seconds: float = Field(default=4.0, gt=0)
-
-    @property
-    def enabled(self) -> bool:
-        return bool(self.api_key)
-
-
 class WebhookSettings(BaseSettings):
     """Webhooks system — real-time event deliveries to subscriber URLs.
 
@@ -807,7 +784,6 @@ class AppSettings(BaseSettings):
     edge_cache: EdgeCacheSettings | None = None
     r2: R2StorageSettings | None = None
     meta_tags: MetaTagsSettings | None = None
-    web_risk: WebRiskSettings | None = None
     webhooks: WebhookSettings | None = None
     safety: SafetySettings | None = None
     scheduler: SchedulerSettings | None = None
@@ -851,8 +827,6 @@ class AppSettings(BaseSettings):
             self.r2 = R2StorageSettings()
         if self.meta_tags is None:
             self.meta_tags = MetaTagsSettings()
-        if self.web_risk is None:
-            self.web_risk = WebRiskSettings()
         if self.webhooks is None:
             self.webhooks = WebhookSettings()
         if self.llm is None:

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -19,9 +19,11 @@ from infrastructure.cache.url_cache import UrlCache
 from infrastructure.captcha.hcaptcha import HCaptchaProvider
 from infrastructure.cloudflare_client import CloudflareClient
 from infrastructure.cloudflare_kv import CloudflareKVClient
+from infrastructure.http_client import HttpClient
 from infrastructure.logging import get_logger
 from infrastructure.ops_notify import DiscordOpsNotifier
 from infrastructure.storage.r2 import R2StorageClient
+from infrastructure.web_risk import DEFAULT_THREAT_TYPES, WebRiskClient
 from repositories.api_key_repository import ApiKeyRepository
 from repositories.app_grant_repository import AppGrantRepository
 from repositories.blocked_domain_repository import BlockedDomainRepository
@@ -117,6 +119,29 @@ from services.webhooks.consumers import WebhookFanoutClickSink
 from services.webhooks.renderers import default_renderers
 
 log = get_logger(__name__)
+
+# The expander answers a waiting request, so it can't sit on the safety
+# analyzer's queue-side timeout.
+_EXPANDER_WEB_RISK_TIMEOUT = 4.0
+
+
+def build_expander_web_risk(
+    settings: AppSettings, http_client: HttpClient
+) -> WebRiskClient | None:
+    """The URL expander's Web Risk client, on the same credential as the
+    safety analyzer. Its threat list is wider because this verdict is
+    displayed, never enforced.
+    """
+    safety = settings.safety
+    if not safety.web_risk_enabled:
+        return None
+    return WebRiskClient(
+        http_client,
+        api_key=safety.web_risk_api_key,
+        api_base=safety.web_risk_api_base,
+        threat_types=(*DEFAULT_THREAT_TYPES, "UNWANTED_SOFTWARE"),
+        timeout=_EXPANDER_WEB_RISK_TIMEOUT,
+    )
 
 
 def build_click_service(
@@ -349,9 +374,11 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         # Online lookup: analyzer only, never the create path.
         analyzer_providers.append(
             WebRiskProvider(
-                http_client,
-                api_key=sf_settings.web_risk_api_key,
-                api_base=sf_settings.web_risk_api_base,
+                WebRiskClient(
+                    http_client,
+                    api_key=sf_settings.web_risk_api_key,
+                    api_base=sf_settings.web_risk_api_base,
+                )
             )
         )
         log.info("safety_web_risk_enabled")
@@ -540,8 +567,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         MetaFetchCache(redis_client, prefix="url_expand"),
         regex_timeout=settings.blocked_url_regex_timeout,
         user_agent=settings.meta_tags.fetch_user_agent,
-        http_client=http_client,
-        web_risk_api_key=settings.web_risk.api_key,
+        web_risk=build_expander_web_risk(settings, http_client),
     )
     app.state.domain_intel_service = DomainIntelService(
         MetaFetchCache(redis_client, prefix="domain_intel", ttl_seconds=86_400),

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -16,6 +16,7 @@ from infrastructure.cache.feature_flag_cache import FeatureFlagCache
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
 from infrastructure.cache.onboarding_cache import OnboardingCache
 from infrastructure.cache.url_cache import UrlCache
+from infrastructure.cache.web_risk_budget import WebRiskBudget
 from infrastructure.captcha.hcaptcha import HCaptchaProvider
 from infrastructure.cloudflare_client import CloudflareClient
 from infrastructure.cloudflare_kv import CloudflareKVClient
@@ -23,7 +24,11 @@ from infrastructure.http_client import HttpClient
 from infrastructure.logging import get_logger
 from infrastructure.ops_notify import DiscordOpsNotifier
 from infrastructure.storage.r2 import R2StorageClient
-from infrastructure.web_risk import DEFAULT_THREAT_TYPES, WebRiskClient
+from infrastructure.web_risk import (
+    DISPLAY_THREAT_TYPES,
+    ENFORCEMENT_THREAT_TYPES,
+    WebRiskClient,
+)
 from repositories.api_key_repository import ApiKeyRepository
 from repositories.app_grant_repository import AppGrantRepository
 from repositories.blocked_domain_repository import BlockedDomainRepository
@@ -139,7 +144,7 @@ def build_expander_web_risk(
         http_client,
         api_key=safety.web_risk_api_key,
         api_base=safety.web_risk_api_base,
-        threat_types=(*DEFAULT_THREAT_TYPES, "UNWANTED_SOFTWARE"),
+        threat_types=DISPLAY_THREAT_TYPES,
         timeout=_EXPANDER_WEB_RISK_TIMEOUT,
     )
 
@@ -378,6 +383,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
                     http_client,
                     api_key=sf_settings.web_risk_api_key,
                     api_base=sf_settings.web_risk_api_base,
+                    threat_types=ENFORCEMENT_THREAT_TYPES,
                 )
             )
         )
@@ -568,6 +574,9 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         regex_timeout=settings.blocked_url_regex_timeout,
         user_agent=settings.meta_tags.fetch_user_agent,
         web_risk=build_expander_web_risk(settings, http_client),
+        web_risk_budget=WebRiskBudget(
+            redis_client, limit=settings.safety.web_risk_expander_daily_budget
+        ),
     )
     app.state.domain_intel_service = DomainIntelService(
         MetaFetchCache(redis_client, prefix="domain_intel", ttl_seconds=86_400),

--- a/infrastructure/cache/web_risk_budget.py
+++ b/infrastructure/cache/web_risk_budget.py
@@ -1,0 +1,56 @@
+"""Daily cap on the URL expander's share of the Web Risk quota.
+
+The expander and the safety analyzer run on one project's quota, but only
+the expander is a public endpoint. Without a cap, traffic on the tool can
+spend the free tier and leave abuse analysis with no online reputation
+source for the rest of the day, looking exactly like a transient error.
+So the expander yields first: past its cap it stops asking and its verdict
+is simply absent, which is a state the tool already renders.
+
+Global, not per caller. Per-caller rate limits bound one IP; this bounds
+the bill and the analyzer's headroom.
+
+Without Redis the cap is unenforced, matching every other cache here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+
+from infrastructure.logging import get_logger
+
+log = get_logger(__name__)
+
+_KEY_TTL_SECONDS = 172_800
+
+
+class WebRiskBudget:
+    def __init__(
+        self,
+        redis_client: aioredis.Redis | None,
+        *,
+        limit: int,
+        prefix: str = "web_risk_budget",
+    ) -> None:
+        self._redis = redis_client
+        self._limit = limit
+        self._prefix = prefix
+
+    async def take(self) -> bool:
+        """Claim one lookup. False once the day's cap is spent."""
+        if self._redis is None:
+            return True
+        key = f"{self._prefix}:{datetime.now(timezone.utc):%Y-%m-%d}"
+        try:
+            used = await self._redis.incr(key)
+            if used == 1:
+                await self._redis.expire(key, _KEY_TTL_SECONDS)
+        except Exception as exc:
+            # A broken counter must not take the feature down with it.
+            log.warning("web_risk_budget_error", error=str(exc))
+            return True
+        if used == self._limit + 1:
+            log.warning("web_risk_budget_exhausted", limit=self._limit)
+        return used <= self._limit

--- a/infrastructure/web_risk.py
+++ b/infrastructure/web_risk.py
@@ -14,7 +14,10 @@ from infrastructure.logging import get_logger
 
 log = get_logger(__name__)
 
-DEFAULT_THREAT_TYPES = ("MALWARE", "SOCIAL_ENGINEERING")
+# Enforcement drives auto-blocking, so widening it is a policy change and
+# never a side effect of touching the display list.
+ENFORCEMENT_THREAT_TYPES = ("MALWARE", "SOCIAL_ENGINEERING")
+DISPLAY_THREAT_TYPES = (*ENFORCEMENT_THREAT_TYPES, "UNWANTED_SOFTWARE")
 
 
 class WebRiskClient:
@@ -32,7 +35,7 @@ class WebRiskClient:
         *,
         api_key: str,
         api_base: str = "https://webrisk.googleapis.com",
-        threat_types: Sequence[str] = DEFAULT_THREAT_TYPES,
+        threat_types: Sequence[str],
         timeout: float = 10.0,
     ) -> None:
         self._http = http_client

--- a/infrastructure/web_risk.py
+++ b/infrastructure/web_risk.py
@@ -1,0 +1,66 @@
+"""Google Web Risk Lookup API (``uris:search``).
+
+One credential and one implementation behind both callers: the safety
+pipeline's analyzer provider and the URL expander tool. The Safe Browsing
+API is non-commercial-only; Web Risk is the sanctioned equivalent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from infrastructure.http_client import HttpClient
+from infrastructure.logging import get_logger
+
+log = get_logger(__name__)
+
+DEFAULT_THREAT_TYPES = ("MALWARE", "SOCIAL_ENGINEERING")
+
+
+class WebRiskClient:
+    """Judges a full URL against Google's threat lists.
+
+    ``lookup`` returns the matched threat types, an empty list when the URL
+    is clean, and None when the lookup could not answer. Callers must treat
+    None as absence, never as a clean verdict. A match Google declines to
+    categorise still counts, as ``["UNKNOWN"]``.
+    """
+
+    def __init__(
+        self,
+        http_client: HttpClient,
+        *,
+        api_key: str,
+        api_base: str = "https://webrisk.googleapis.com",
+        threat_types: Sequence[str] = DEFAULT_THREAT_TYPES,
+        timeout: float = 10.0,
+    ) -> None:
+        self._http = http_client
+        self._api_key = api_key
+        self._api_base = api_base.rstrip("/")
+        self._threat_types = list(threat_types)
+        self._timeout = timeout
+
+    async def lookup(self, url: str) -> list[str] | None:
+        try:
+            # Key rides a header: httpx logs full request URLs at INFO.
+            response = await self._http.get(
+                f"{self._api_base}/v1/uris:search",
+                params={"uri": url, "threatTypes": self._threat_types},
+                headers={"X-Goog-Api-Key": self._api_key},
+                timeout=self._timeout,
+            )
+            if response.status_code != 200:
+                log.warning(
+                    "web_risk_lookup_failed", error=f"http {response.status_code}"
+                )
+                return None
+            threat = response.json().get("threat")
+            if not threat:
+                return []
+            return threat.get("threatTypes") or ["UNKNOWN"]
+        # Broad on purpose: every caller treats an unanswered lookup as
+        # absence, so no failure here may propagate.
+        except Exception as exc:
+            log.warning("web_risk_lookup_failed", error=type(exc).__name__)
+            return None

--- a/services/safety/providers.py
+++ b/services/safety/providers.py
@@ -17,8 +17,8 @@ import time
 from dataclasses import dataclass
 from typing import Protocol
 
-from infrastructure.http_client import HttpClient
 from infrastructure.logging import get_logger
+from infrastructure.web_risk import WebRiskClient
 from repositories.blocked_url_repository import BlockedUrlRepository
 from repositories.feed_domain_repository import FeedDomainRepository
 from repositories.verdict_repository import VerdictRepository
@@ -85,65 +85,29 @@ class FeedDomainProvider:
 
 
 class WebRiskProvider:
-    """Google Web Risk Lookup API (``uris:search``) — judges the full URL
-    against Google's MALWARE and SOCIAL_ENGINEERING lists. Online lookup
-    (100k/month free tier covers report-triggered volume by orders of
-    magnitude); the local hash-DB variant is a later create-gate concern.
+    """Google Web Risk verdict for the full URL. Online lookup (100k/month
+    free tier covers report-triggered volume by orders of magnitude); the
+    local hash-DB variant is a later create-gate concern.
 
-    Network or quota failures abstain.
+    An unanswered lookup abstains.
     """
 
     name = "web_risk"
 
-    _THREAT_TYPES = ("MALWARE", "SOCIAL_ENGINEERING")
-
-    def __init__(
-        self,
-        http_client: HttpClient,
-        *,
-        api_key: str,
-        api_base: str = "https://webrisk.googleapis.com",
-    ) -> None:
-        self._http = http_client
-        self._api_key = api_key
-        self._api_base = api_base.rstrip("/")
+    def __init__(self, client: WebRiskClient) -> None:
+        self._client = client
 
     async def analyze(
         self, url: str, host: str, registrable_domain: str
     ) -> ProviderVerdict | None:
-        try:
-            # Key rides a header: httpx logs full request URLs at INFO.
-            response = await self._http.get(
-                f"{self._api_base}/v1/uris:search",
-                params={
-                    "uri": url,
-                    "threatTypes": list(self._THREAT_TYPES),
-                },
-                headers={"X-Goog-Api-Key": self._api_key},
-                timeout=10.0,
-            )
-            if response.status_code != 200:
-                log.warning(
-                    "safety_provider_failed",
-                    provider=self.name,
-                    error=f"http {response.status_code}",
-                )
-                return None
-            threat = response.json().get("threat")
-            if threat:
-                types = ",".join(threat.get("threatTypes", [])) or "UNKNOWN"
-                return ProviderVerdict(
-                    tier=VerdictTier.TOXIC,
-                    reason=f"flagged by Google Web Risk ({types})",
-                    scope="links",
-                )
-        except Exception as exc:
-            log.warning(
-                "safety_provider_failed",
-                provider=self.name,
-                error=type(exc).__name__,
-            )
-        return None
+        threats = await self._client.lookup(url)
+        if not threats:
+            return None
+        return ProviderVerdict(
+            tier=VerdictTier.TOXIC,
+            reason=f"flagged by Google Web Risk ({','.join(threats)})",
+            scope="links",
+        )
 
 
 def verdict_covers(verdict, url: str) -> bool:

--- a/services/safety/providers.py
+++ b/services/safety/providers.py
@@ -85,9 +85,12 @@ class FeedDomainProvider:
 
 
 class WebRiskProvider:
-    """Google Web Risk verdict for the full URL. Online lookup (100k/month
-    free tier covers report-triggered volume by orders of magnitude); the
-    local hash-DB variant is a later create-gate concern.
+    """Google Web Risk verdict for the full URL. Online lookup; the local
+    hash-DB variant is a later create-gate concern.
+
+    The 100k/month free tier no longer belongs to reports alone: the public
+    URL expander spends the same project quota, which is why its share is
+    capped and this consumer's is not.
 
     An unanswered lookup abstains.
     """

--- a/services/url_expand_service.py
+++ b/services/url_expand_service.py
@@ -8,19 +8,14 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 
-import httpx
-
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
-from infrastructure.http_client import HttpClient
 from infrastructure.logging import get_logger
 from infrastructure.safe_fetch import expand_public
+from infrastructure.web_risk import WebRiskClient
 from repositories.blocked_url_repository import BlockedUrlRepository
 from shared.validators import validate_blocked_url
 
 log = get_logger(__name__)
-
-_WEB_RISK_ENDPOINT = "https://webrisk.googleapis.com/v1/uris:search"
-_WEB_RISK_THREATS = ("MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE")
 
 
 class UrlExpandService:
@@ -31,15 +26,13 @@ class UrlExpandService:
         *,
         regex_timeout: float,
         user_agent: str,
-        http_client: HttpClient,
-        web_risk_api_key: str = "",
+        web_risk: WebRiskClient | None = None,
     ) -> None:
         self._blocked_url_repo = blocked_url_repo
         self._cache = cache
         self._regex_timeout = regex_timeout
         self._user_agent = user_agent
-        self._http = http_client
-        self._web_risk_api_key = web_risk_api_key
+        self._web_risk = web_risk
 
     async def expand(self, url: str) -> dict:
         cached = await self._cache.get(url)
@@ -52,7 +45,7 @@ class UrlExpandService:
         urls = [hop.url for hop in chain.hops] + [chain.final_url]
         blocklist_match, web_risk = await asyncio.gather(
             asyncio.to_thread(self._any_blocked, urls, patterns),
-            self._web_risk(chain.final_url),
+            self._web_risk_verdict(chain.final_url),
         )
 
         payload = {
@@ -75,30 +68,18 @@ class UrlExpandService:
         # A configured-but-failing Web Risk call returns None, and caching
         # that would hide the safety signal for the whole TTL. Skip the
         # write so the next caller asks again.
-        if not (self._web_risk_api_key and web_risk is None):
+        if not (self._web_risk and web_risk is None):
             await self._cache.set(url, payload)
         return payload
 
-    async def _web_risk(self, url: str) -> dict | None:
+    async def _web_risk_verdict(self, url: str) -> dict | None:
         """Google Web Risk verdict for the final URL. None whenever the
         check didn't run (no key, API error) — absence, never a verdict."""
-        if not self._web_risk_api_key:
+        if self._web_risk is None:
             return None
-        params = [
-            ("key", self._web_risk_api_key),
-            ("uri", url),
-            *(("threatTypes", t) for t in _WEB_RISK_THREATS),
-        ]
-        try:
-            resp = await self._http.get(_WEB_RISK_ENDPOINT, params=params)
-            if resp.status_code != 200:
-                log.warning("web_risk_status", status=resp.status_code)
-                return None
-            data = resp.json()
-        except (httpx.HTTPError, ValueError) as exc:
-            log.warning("web_risk_error", error=str(exc))
+        threats = await self._web_risk.lookup(url)
+        if threats is None:
             return None
-        threats = data.get("threat", {}).get("threatTypes", [])
         return {"checked": True, "threats": threats}
 
     def _any_blocked(self, urls: list[str], patterns: list[str]) -> bool:

--- a/services/url_expand_service.py
+++ b/services/url_expand_service.py
@@ -9,6 +9,7 @@ import asyncio
 from datetime import datetime, timezone
 
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
+from infrastructure.cache.web_risk_budget import WebRiskBudget
 from infrastructure.logging import get_logger
 from infrastructure.safe_fetch import expand_public
 from infrastructure.web_risk import WebRiskClient
@@ -27,12 +28,14 @@ class UrlExpandService:
         regex_timeout: float,
         user_agent: str,
         web_risk: WebRiskClient | None = None,
+        web_risk_budget: WebRiskBudget | None = None,
     ) -> None:
         self._blocked_url_repo = blocked_url_repo
         self._cache = cache
         self._regex_timeout = regex_timeout
         self._user_agent = user_agent
         self._web_risk = web_risk
+        self._web_risk_budget = web_risk_budget
 
     async def expand(self, url: str) -> dict:
         cached = await self._cache.get(url)
@@ -43,7 +46,7 @@ class UrlExpandService:
 
         patterns = await self._blocked_url_repo.get_patterns()
         urls = [hop.url for hop in chain.hops] + [chain.final_url]
-        blocklist_match, web_risk = await asyncio.gather(
+        blocklist_match, (web_risk, asked) = await asyncio.gather(
             asyncio.to_thread(self._any_blocked, urls, patterns),
             self._web_risk_verdict(chain.final_url),
         )
@@ -65,22 +68,23 @@ class UrlExpandService:
             "web_risk": web_risk,
             "fetched_at": datetime.now(timezone.utc).isoformat(),
         }
-        # A configured-but-failing Web Risk call returns None, and caching
-        # that would hide the safety signal for the whole TTL. Skip the
-        # write so the next caller asks again.
-        if not (self._web_risk and web_risk is None):
+        # Caching an unanswered ask would hide the signal for the whole TTL;
+        # a lookup we declined to make is a sustained state, so it caches.
+        if not (asked and web_risk is None):
             await self._cache.set(url, payload)
         return payload
 
-    async def _web_risk_verdict(self, url: str) -> dict | None:
-        """Google Web Risk verdict for the final URL. None whenever the
-        check didn't run (no key, API error) — absence, never a verdict."""
+    async def _web_risk_verdict(self, url: str) -> tuple[dict | None, bool]:
+        """Google Web Risk verdict for the final URL, and whether Google was
+        actually asked. Absence is never a verdict."""
         if self._web_risk is None:
-            return None
+            return None, False
+        if self._web_risk_budget is not None and not await self._web_risk_budget.take():
+            return None, False
         threats = await self._web_risk.lookup(url)
         if threats is None:
-            return None
-        return {"checked": True, "threats": threats}
+            return None, True
+        return {"checked": True, "threats": threats}, True
 
     def _any_blocked(self, urls: list[str], patterns: list[str]) -> bool:
         seen: set[str] = set()

--- a/tests/integration/api_v1/test_expand.py
+++ b/tests/integration/api_v1/test_expand.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from dependencies import get_current_user
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
 from infrastructure.safe_fetch import ChainHop, ExpandedChain, FetchHardError
+from infrastructure.web_risk import WebRiskClient
 from services.url_expand_service import UrlExpandService
 
 from .conftest import _build_test_app
@@ -33,8 +34,11 @@ def _service(patterns=None, *, web_risk_key="", http=None, cache=None):
         cache or MetaFetchCache(None),
         regex_timeout=0.2,
         user_agent="test",
-        http_client=http or MagicMock(get=AsyncMock()),
-        web_risk_api_key=web_risk_key,
+        web_risk=(
+            WebRiskClient(http or MagicMock(get=AsyncMock()), api_key=web_risk_key)
+            if web_risk_key
+            else None
+        ),
     )
 
 

--- a/tests/integration/api_v1/test_expand.py
+++ b/tests/integration/api_v1/test_expand.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from dependencies import get_current_user
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
 from infrastructure.safe_fetch import ChainHop, ExpandedChain, FetchHardError
-from infrastructure.web_risk import WebRiskClient
+from infrastructure.web_risk import DISPLAY_THREAT_TYPES, WebRiskClient
 from services.url_expand_service import UrlExpandService
 
 from .conftest import _build_test_app
@@ -26,7 +26,7 @@ CHAIN = ExpandedChain(
 )
 
 
-def _service(patterns=None, *, web_risk_key="", http=None, cache=None):
+def _service(patterns=None, *, web_risk_key="", http=None, cache=None, budget=None):
     repo = AsyncMock()
     repo.get_patterns = AsyncMock(return_value=patterns or [])
     return UrlExpandService(
@@ -35,10 +35,15 @@ def _service(patterns=None, *, web_risk_key="", http=None, cache=None):
         regex_timeout=0.2,
         user_agent="test",
         web_risk=(
-            WebRiskClient(http or MagicMock(get=AsyncMock()), api_key=web_risk_key)
+            WebRiskClient(
+                http or MagicMock(get=AsyncMock()),
+                api_key=web_risk_key,
+                threat_types=DISPLAY_THREAT_TYPES,
+            )
             if web_risk_key
             else None
         ),
+        web_risk_budget=budget,
     )
 
 
@@ -146,3 +151,47 @@ def test_a_failed_web_risk_call_is_not_cached_as_absence():
         resp = client.get("/api/v1/expand", params={"url": "https://bit.ly/x"})
     assert resp.json()["web_risk"] is None
     cache.set.assert_not_called()
+
+
+def test_a_spent_budget_stops_asking_google():
+    """The expander shares one project quota with the safety analyzer but
+    is the only public consumer, so it yields first: past its cap the
+    verdict is absent and no lookup leaves the box."""
+    http = MagicMock()
+    http.get = AsyncMock()
+    budget = AsyncMock()
+    budget.take = AsyncMock(return_value=False)
+    with (
+        patch(
+            "services.url_expand_service.expand_public",
+            new=AsyncMock(return_value=CHAIN),
+        ),
+        TestClient(
+            _app(web_risk_key="k", http=http, budget=budget),
+            raise_server_exceptions=True,
+        ) as client,
+    ):
+        resp = client.get("/api/v1/expand", params={"url": "https://bit.ly/x"})
+    assert resp.json()["web_risk"] is None
+    http.get.assert_not_awaited()
+
+
+def test_a_lookup_we_declined_to_make_is_still_cached():
+    """Unlike an unanswered ask, a spent budget is a sustained state — not
+    caching it would re-enter this path on every single request."""
+    cache = MetaFetchCache(None)
+    cache.set = AsyncMock()
+    budget = AsyncMock()
+    budget.take = AsyncMock(return_value=False)
+    with (
+        patch(
+            "services.url_expand_service.expand_public",
+            new=AsyncMock(return_value=CHAIN),
+        ),
+        TestClient(
+            _app(web_risk_key="k", cache=cache, budget=budget),
+            raise_server_exceptions=True,
+        ) as client,
+    ):
+        client.get("/api/v1/expand", params={"url": "https://bit.ly/x"})
+    cache.set.assert_awaited_once()

--- a/tests/unit/infrastructure/test_web_risk.py
+++ b/tests/unit/infrastructure/test_web_risk.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from infrastructure.web_risk import DEFAULT_THREAT_TYPES, WebRiskClient
+from infrastructure.web_risk import (
+    DISPLAY_THREAT_TYPES,
+    ENFORCEMENT_THREAT_TYPES,
+    WebRiskClient,
+)
 
 
 def _http(payload, status=200):
@@ -23,39 +27,48 @@ async def test_the_key_never_rides_the_query_string():
     """httpx logs full request URLs at INFO, so a key in the query string
     lands in the log store in plaintext on every lookup."""
     http = _http({})
-    await WebRiskClient(http, api_key="k123").lookup("https://ok.example/x")
+    await WebRiskClient(
+        http, api_key="k123", threat_types=ENFORCEMENT_THREAT_TYPES
+    ).lookup("https://ok.example/x")
 
-    _, kwargs = http.get.await_args
+    args, kwargs = http.get.await_args
     assert kwargs["headers"]["X-Goog-Api-Key"] == "k123"
-    assert "k123" not in str(kwargs["params"])
+    # Scoped to the whole call, not just params: the key must not reappear
+    # in the URL or anywhere else a request logger would render.
+    kwargs_without_headers = {k: v for k, v in kwargs.items() if k != "headers"}
+    assert "k123" not in f"{args}{kwargs_without_headers}"
 
 
 @pytest.mark.asyncio
 async def test_matched_threat_types_are_returned():
     http = _http({"threat": {"threatTypes": ["MALWARE"], "expireTime": "x"}})
-    assert await WebRiskClient(http, api_key="k").lookup("https://bad.example") == [
-        "MALWARE"
-    ]
+    assert await WebRiskClient(
+        http, api_key="k", threat_types=ENFORCEMENT_THREAT_TYPES
+    ).lookup("https://bad.example") == ["MALWARE"]
 
 
 @pytest.mark.asyncio
 async def test_clean_url_returns_an_empty_list():
-    client = WebRiskClient(_http({}), api_key="k")
+    client = WebRiskClient(
+        _http({}), api_key="k", threat_types=ENFORCEMENT_THREAT_TYPES
+    )
     assert await client.lookup("https://ok.example") == []
 
 
 @pytest.mark.asyncio
 async def test_uncategorised_match_still_counts():
     http = _http({"threat": {"expireTime": "x"}})
-    assert await WebRiskClient(http, api_key="k").lookup("https://bad.example") == [
-        "UNKNOWN"
-    ]
+    assert await WebRiskClient(
+        http, api_key="k", threat_types=ENFORCEMENT_THREAT_TYPES
+    ).lookup("https://bad.example") == ["UNKNOWN"]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status", [400, 429, 500])
 async def test_non_200_abstains(status):
-    client = WebRiskClient(_http({}, status=status), api_key="k")
+    client = WebRiskClient(
+        _http({}, status=status), api_key="k", threat_types=ENFORCEMENT_THREAT_TYPES
+    )
     assert await client.lookup("https://ok.example") is None
 
 
@@ -63,15 +76,20 @@ async def test_non_200_abstains(status):
 async def test_transport_failure_abstains():
     http = AsyncMock()
     http.get = AsyncMock(side_effect=RuntimeError("boom"))
-    assert await WebRiskClient(http, api_key="k").lookup("https://ok.example") is None
+    assert (
+        await WebRiskClient(
+            http, api_key="k", threat_types=ENFORCEMENT_THREAT_TYPES
+        ).lookup("https://ok.example")
+        is None
+    )
 
 
 @pytest.mark.asyncio
 async def test_threat_types_are_caller_chosen():
     http = _http({})
-    await WebRiskClient(
-        http, api_key="k", threat_types=(*DEFAULT_THREAT_TYPES, "UNWANTED_SOFTWARE")
-    ).lookup("https://ok.example")
+    await WebRiskClient(http, api_key="k", threat_types=DISPLAY_THREAT_TYPES).lookup(
+        "https://ok.example"
+    )
 
     _, kwargs = http.get.await_args
     assert kwargs["params"]["threatTypes"] == [

--- a/tests/unit/infrastructure/test_web_risk.py
+++ b/tests/unit/infrastructure/test_web_risk.py
@@ -1,0 +1,81 @@
+"""Google Web Risk client — infrastructure/web_risk.py."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrastructure.web_risk import DEFAULT_THREAT_TYPES, WebRiskClient
+
+
+def _http(payload, status=200):
+    http = AsyncMock()
+    http.get = AsyncMock(
+        return_value=SimpleNamespace(status_code=status, json=lambda: payload)
+    )
+    return http
+
+
+@pytest.mark.asyncio
+async def test_the_key_never_rides_the_query_string():
+    """httpx logs full request URLs at INFO, so a key in the query string
+    lands in the log store in plaintext on every lookup."""
+    http = _http({})
+    await WebRiskClient(http, api_key="k123").lookup("https://ok.example/x")
+
+    _, kwargs = http.get.await_args
+    assert kwargs["headers"]["X-Goog-Api-Key"] == "k123"
+    assert "k123" not in str(kwargs["params"])
+
+
+@pytest.mark.asyncio
+async def test_matched_threat_types_are_returned():
+    http = _http({"threat": {"threatTypes": ["MALWARE"], "expireTime": "x"}})
+    assert await WebRiskClient(http, api_key="k").lookup("https://bad.example") == [
+        "MALWARE"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_clean_url_returns_an_empty_list():
+    client = WebRiskClient(_http({}), api_key="k")
+    assert await client.lookup("https://ok.example") == []
+
+
+@pytest.mark.asyncio
+async def test_uncategorised_match_still_counts():
+    http = _http({"threat": {"expireTime": "x"}})
+    assert await WebRiskClient(http, api_key="k").lookup("https://bad.example") == [
+        "UNKNOWN"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 429, 500])
+async def test_non_200_abstains(status):
+    client = WebRiskClient(_http({}, status=status), api_key="k")
+    assert await client.lookup("https://ok.example") is None
+
+
+@pytest.mark.asyncio
+async def test_transport_failure_abstains():
+    http = AsyncMock()
+    http.get = AsyncMock(side_effect=RuntimeError("boom"))
+    assert await WebRiskClient(http, api_key="k").lookup("https://ok.example") is None
+
+
+@pytest.mark.asyncio
+async def test_threat_types_are_caller_chosen():
+    http = _http({})
+    await WebRiskClient(
+        http, api_key="k", threat_types=(*DEFAULT_THREAT_TYPES, "UNWANTED_SOFTWARE")
+    ).lookup("https://ok.example")
+
+    _, kwargs = http.get.await_args
+    assert kwargs["params"]["threatTypes"] == [
+        "MALWARE",
+        "SOCIAL_ENGINEERING",
+        "UNWANTED_SOFTWARE",
+    ]

--- a/tests/unit/infrastructure/test_web_risk_budget.py
+++ b/tests/unit/infrastructure/test_web_risk_budget.py
@@ -1,0 +1,55 @@
+"""Expander Web Risk budget — infrastructure/cache/web_risk_budget.py."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrastructure.cache.web_risk_budget import WebRiskBudget
+
+
+def _redis(counts):
+    redis = AsyncMock()
+    redis.incr = AsyncMock(side_effect=counts)
+    redis.expire = AsyncMock()
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_calls_within_the_cap_are_granted():
+    budget = WebRiskBudget(_redis([1, 2, 3]), limit=3)
+    assert [await budget.take() for _ in range(3)] == [True, True, True]
+
+
+@pytest.mark.asyncio
+async def test_the_call_past_the_cap_is_refused():
+    budget = WebRiskBudget(_redis([3, 4]), limit=3)
+    assert await budget.take() is True
+    assert await budget.take() is False
+
+
+@pytest.mark.asyncio
+async def test_the_daily_key_expires_so_it_self_clears():
+    redis = _redis([1])
+    await WebRiskBudget(redis, limit=5).take()
+    key, ttl = redis.expire.await_args[0]
+    assert key.startswith("web_risk_budget:")
+    assert ttl > 86_400
+
+    # Only the call that created the key sets the TTL.
+    redis = _redis([2])
+    await WebRiskBudget(redis, limit=5).take()
+    redis.expire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_without_redis_the_cap_is_unenforced():
+    assert await WebRiskBudget(None, limit=0).take() is True
+
+
+@pytest.mark.asyncio
+async def test_a_broken_counter_does_not_take_the_feature_down():
+    redis = AsyncMock()
+    redis.incr = AsyncMock(side_effect=RuntimeError("redis down"))
+    assert await WebRiskBudget(redis, limit=1).take() is True

--- a/tests/unit/services/safety/test_providers.py
+++ b/tests/unit/services/safety/test_providers.py
@@ -99,21 +99,25 @@ class TestWebRiskProvider:
 
     @pytest.mark.asyncio
     async def test_threat_match_is_toxic(self):
+        from infrastructure.web_risk import WebRiskClient
         from services.safety.providers import WebRiskProvider
 
         http = self._http(
             {"threat": {"threatTypes": ["SOCIAL_ENGINEERING"], "expireTime": "x"}}
         )
-        provider = WebRiskProvider(http, api_key="k123")
+        provider = WebRiskProvider(WebRiskClient(http, api_key="k123"))
         verdict = await provider.analyze(
             "https://phish.com/x", "phish.com", "phish.com"
         )
         assert verdict is not None
         assert verdict.tier == VerdictTier.TOXIC
         assert "SOCIAL_ENGINEERING" in verdict.reason
-        # Request carries the uri, both threat types, and the key as params.
+        # Request carries the uri and both threat types, and the key
+        # never rides the query string.
         _, kwargs = http.get.await_args
         assert kwargs["params"]["uri"] == "https://phish.com/x"
+        assert kwargs["headers"]["X-Goog-Api-Key"] == "k123"
+        assert "key" not in kwargs["params"]
         assert set(kwargs["params"]["threatTypes"]) == {
             "MALWARE",
             "SOCIAL_ENGINEERING",
@@ -121,21 +125,25 @@ class TestWebRiskProvider:
 
     @pytest.mark.asyncio
     async def test_empty_response_abstains(self):
+        from infrastructure.web_risk import WebRiskClient
         from services.safety.providers import WebRiskProvider
 
-        provider = WebRiskProvider(self._http({}), api_key="k123")
+        provider = WebRiskProvider(WebRiskClient(self._http({}), api_key="k123"))
         assert await provider.analyze("https://ok.com/x", "ok.com", "ok.com") is None
 
     @pytest.mark.asyncio
     async def test_http_error_and_exception_abstain(self):
+        from infrastructure.web_risk import WebRiskClient
         from services.safety.providers import WebRiskProvider
 
-        provider = WebRiskProvider(self._http({}, status=429), api_key="k123")
+        provider = WebRiskProvider(
+            WebRiskClient(self._http({}, status=429), api_key="k123")
+        )
         assert await provider.analyze("https://ok.com/x", "ok.com", "ok.com") is None
 
         http = AsyncMock()
         http.get = AsyncMock(side_effect=RuntimeError("boom"))
-        provider = WebRiskProvider(http, api_key="k123")
+        provider = WebRiskProvider(WebRiskClient(http, api_key="k123"))
         assert await provider.analyze("https://ok.com/x", "ok.com", "ok.com") is None
 
 

--- a/tests/unit/services/safety/test_providers.py
+++ b/tests/unit/services/safety/test_providers.py
@@ -99,13 +99,15 @@ class TestWebRiskProvider:
 
     @pytest.mark.asyncio
     async def test_threat_match_is_toxic(self):
-        from infrastructure.web_risk import WebRiskClient
+        from infrastructure.web_risk import ENFORCEMENT_THREAT_TYPES, WebRiskClient
         from services.safety.providers import WebRiskProvider
 
         http = self._http(
             {"threat": {"threatTypes": ["SOCIAL_ENGINEERING"], "expireTime": "x"}}
         )
-        provider = WebRiskProvider(WebRiskClient(http, api_key="k123"))
+        provider = WebRiskProvider(
+            WebRiskClient(http, api_key="k123", threat_types=ENFORCEMENT_THREAT_TYPES)
+        )
         verdict = await provider.analyze(
             "https://phish.com/x", "phish.com", "phish.com"
         )
@@ -125,25 +127,35 @@ class TestWebRiskProvider:
 
     @pytest.mark.asyncio
     async def test_empty_response_abstains(self):
-        from infrastructure.web_risk import WebRiskClient
+        from infrastructure.web_risk import ENFORCEMENT_THREAT_TYPES, WebRiskClient
         from services.safety.providers import WebRiskProvider
 
-        provider = WebRiskProvider(WebRiskClient(self._http({}), api_key="k123"))
+        provider = WebRiskProvider(
+            WebRiskClient(
+                self._http({}), api_key="k123", threat_types=ENFORCEMENT_THREAT_TYPES
+            )
+        )
         assert await provider.analyze("https://ok.com/x", "ok.com", "ok.com") is None
 
     @pytest.mark.asyncio
     async def test_http_error_and_exception_abstain(self):
-        from infrastructure.web_risk import WebRiskClient
+        from infrastructure.web_risk import ENFORCEMENT_THREAT_TYPES, WebRiskClient
         from services.safety.providers import WebRiskProvider
 
         provider = WebRiskProvider(
-            WebRiskClient(self._http({}, status=429), api_key="k123")
+            WebRiskClient(
+                self._http({}, status=429),
+                api_key="k123",
+                threat_types=ENFORCEMENT_THREAT_TYPES,
+            )
         )
         assert await provider.analyze("https://ok.com/x", "ok.com", "ok.com") is None
 
         http = AsyncMock()
         http.get = AsyncMock(side_effect=RuntimeError("boom"))
-        provider = WebRiskProvider(WebRiskClient(http, api_key="k123"))
+        provider = WebRiskProvider(
+            WebRiskClient(http, api_key="k123", threat_types=ENFORCEMENT_THREAT_TYPES)
+        )
         assert await provider.analyze("https://ok.com/x", "ok.com", "ok.com") is None
 
 


### PR DESCRIPTION
Two Google Web Risk integrations landed on 29 August a couple of hours apart, so neither review saw the other. `main` currently has:

| | safety analyzer | URL expander |
|---|---|---|
| settings | `SafetySettings` (`SAFETY_`) | `WebRiskSettings` (`WEB_RISK_`) |
| client | `WebRiskProvider` | `UrlExpandService._web_risk` |
| auth | `X-Goog-Api-Key` header | key in the query string |
| threat types | MALWARE, SOCIAL_ENGINEERING | plus UNWANTED_SOFTWARE |

Same API, same credential, two of everything. This consolidates them onto one client in `infrastructure/web_risk.py`, then deals with what sharing a credential implies.

## The consolidation

- **`infrastructure/web_risk.py`** is new. `lookup()` returns the matched threat types, an empty list for a clean URL, and `None` when the lookup could not answer. Callers must read `None` as absence, never as clean.
- **`WebRiskProvider`** becomes a thin adapter that maps a match to a `ProviderVerdict`.
- **`UrlExpandService`** takes a client instead of a raw key.
- **`WebRiskSettings` is deleted**, along with `WEB_RISK_TIMEOUT_SECONDS`, which nothing ever read.
- The expander reads `SAFETY_WEB_RISK_API_KEY`, which prod already has set, so the verdict works on deploy with no new variable.

## The key was going into the logs

The expander passed the key as a query parameter. `httpx` logs full request URLs at INFO, prod runs `LOG_LEVEL=INFO`, and unlike `urllib3`, `pymongo` and `botocore`, the `httpx` logger is not demoted in `infrastructure/logging.py`. `redact_sensitive_fields` matches event-dict keys, not substrings inside a message, so it would not have caught it. Every lookup would have written the key into the log store in plaintext.

Nothing has leaked, because `WEB_RISK_API_KEY` was never set in prod. Worth knowing that setting it would have started the leak rather than fixing the feature.

`test_the_key_never_rides_the_query_string` guards it, asserting against the whole recorded call rather than just `params`, so it survives a change in call shape.

## One credential means one quota

The consequence of consolidating: the expander is public and the analyzer is not, but they now spend the same project quota. The free tier is roughly 3,300 lookups a day. The expander allows 300/day per anonymous caller, so a handful of IPs using distinct URLs can exhaust it.

That is worse than a billing problem. When the quota is gone Google returns non-200, `lookup()` returns `None`, and the analyzer abstains, so the safety pipeline silently loses its only online reputation source and the trace looks identical to a transient error. A public endpoint should not be able to blind the abuse pipeline.

So the expander yields first. `WebRiskBudget` is a global daily counter in Redis, capped at `SAFETY_WEB_RISK_EXPANDER_DAILY_BUDGET` (default 1,000), leaving the analyzer roughly 2,300. Past the cap the expander stops asking and its verdict is absent, which is a state the tool already renders. Per-caller rate limits bound one IP; this bounds the bill and the analyzer's headroom. Without Redis the cap is unenforced, matching every other cache here.

Caching now distinguishes the two cases. An ask Google did not answer still is not cached, since that would hide the signal for a whole TTL. A lookup we declined to make is cached, because a spent budget is a sustained state, and without that the tool would re-ask and pay the 4s timeout on every request precisely when it is busiest.

## Behaviour kept deliberately

- Threat lists are explicit at both call sites now, as `ENFORCEMENT_THREAT_TYPES` and `DISPLAY_THREAT_TYPES`, with no default. Adding a type to the display list can no longer silently widen auto-blocking.
- The expander gets a 4s timeout against the analyzer's 10s, because a user is waiting on the response.
- A match Google declines to categorise still counts, as `["UNKNOWN"]`, matching the old provider's behaviour.
- `openapi.json` regenerates unchanged, so the wire contract is untouched.

## Verification

Full suite in a clean worktree at this head: **3423 passed, zero failures.**

An earlier revision of this description claimed 20 environment-dependent failures. That was wrong, and the cause is worth recording: `BaseSettings` reads `.env` directly, so a checkout that has one picks up real local configuration during tests. A clean worktree has no `.env` and the whole suite passes.

The header auth form was checked against the live API and reaches Google's IP check, which confirms the form is accepted. An end-to-end verdict could not be observed locally, because the key is IP-restricted and returns `API_KEY_IP_ADDRESS_BLOCKED` for this machine's current address. Both the header and query forms fail identically, which is what isolates the 403 to the restriction rather than to the change. A live verdict is worth confirming on prod after deploy.
