### PR TITLE
fix(safety): fail the Web Risk budget closed

### DIFF
--- a/infrastructure/cache/web_risk_budget.py
+++ b/infrastructure/cache/web_risk_budget.py
@@ -10,7 +10,10 @@ is simply absent, which is a state the tool already renders.
 Global, not per caller. Per-caller rate limits bound one IP; this bounds
 the bill and the analyzer's headroom.
 
-Without Redis the cap is unenforced, matching every other cache here.
+Unlike the caches here, it fails closed. It shares its Redis with the
+expander's result cache, so an outage removes the cache that absorbs
+lookups and the cap that bounds them at the same moment. Unable to count
+means unable to spend.
 """
 
 from __future__ import annotations
@@ -39,18 +42,18 @@ class WebRiskBudget:
         self._prefix = prefix
 
     async def take(self) -> bool:
-        """Claim one lookup. False once the day's cap is spent."""
+        """Claim one lookup. False once the day's cap is spent, and false
+        whenever the count is unavailable."""
         if self._redis is None:
-            return True
+            return False
         key = f"{self._prefix}:{datetime.now(timezone.utc):%Y-%m-%d}"
         try:
             used = await self._redis.incr(key)
             if used == 1:
                 await self._redis.expire(key, _KEY_TTL_SECONDS)
         except Exception as exc:
-            # A broken counter must not take the feature down with it.
             log.warning("web_risk_budget_error", error=str(exc))
-            return True
+            return False
         if used == self._limit + 1:
             log.warning("web_risk_budget_exhausted", limit=self._limit)
         return used <= self._limit

--- a/tests/unit/infrastructure/test_web_risk_budget.py
+++ b/tests/unit/infrastructure/test_web_risk_budget.py
@@ -44,12 +44,16 @@ async def test_the_daily_key_expires_so_it_self_clears():
 
 
 @pytest.mark.asyncio
-async def test_without_redis_the_cap_is_unenforced():
-    assert await WebRiskBudget(None, limit=0).take() is True
+async def test_without_redis_nothing_is_spent():
+    assert await WebRiskBudget(None, limit=1_000).take() is False
 
 
 @pytest.mark.asyncio
-async def test_a_broken_counter_does_not_take_the_feature_down():
+async def test_a_broken_counter_refuses_rather_than_waving_calls_through():
+    """The counter shares its Redis with the expander's result cache, so an
+    outage drops the cache and the cap together. Unable to count means
+    unable to spend, or the quota goes exactly when it is least affordable.
+    """
     redis = AsyncMock()
     redis.incr = AsyncMock(side_effect=RuntimeError("redis down"))
-    assert await WebRiskBudget(redis, limit=1).take() is True
+    assert await WebRiskBudget(redis, limit=1_000).take() is False


### PR DESCRIPTION
Follow-up to #324. `WebRiskBudget.take()` failed open both when Redis was absent and when `INCR` raised. That is the right instinct for a cache and the wrong one here.

## Why the pairing matters

The budget and `MetaFetchCache` are handed the same `redis_client`. So a Redis outage does two things at once:

- the expander's result cache goes, and lookups stop being absorbed by the hour-long TTL
- the cap goes, and nothing bounds them

Volume spikes and the brake comes off from the same cause. The protection is disabled in precisely the window it was written for, and the outcome is the quota exhaustion #324 exists to prevent: the analyzer silently loses its only online reputation source, looking exactly like a transient error.

## The change

`take()` now returns `False` whenever the count is unavailable, on a failed `INCR` and with no Redis configured.

The cost is that the expander shows no Web Risk verdict while the counter is unavailable. That is a state the tool already renders, and it is the yielding the expander is supposed to do: it is the public consumer, the analyzer is the abuse pipeline, and the analyzer wins ties.

## On the no-Redis case

Failing closed there too means a deployment without Redis never shows a verdict, rather than running uncapped against its own analyzer's quota.

That is a smaller loss than it sounds. Anyone provisioning a GCP Web Risk key is not running spoo without Redis, and one rule is easier to reason about than a rule that changes with deployment shape. Setting `SAFETY_WEB_RISK_EXPANDER_DAILY_BUDGET=0` remains the explicit way to switch the expander's lookups off.

## Verification

`uv run pytest tests/unit/infrastructure tests/integration/api_v1/test_expand.py`: 301 passed. Both budget tests were inverted to assert refusal, with the shared-store reasoning recorded on the one that would otherwise read as a puzzling expectation.
