### PR TITLE
chore(compose): sync the prod file and scope the spoo.me name to the frontend

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -305,6 +305,43 @@ services:
         max-file: "3"
         tag: "{{.Name}}"
 
+  # Next frontend. Caddy routes page paths here; everything else (short
+  # codes, auth, api) still hits app directly. Health check is wget, not
+  # curl: the runtime image is bare node:22-alpine, and deploy.yml reads
+  # .State.Health.Status to decide rollback.
+  next:
+    image: ghcr.io/spoo-me/frontend:${NEXT_IMAGE_TAG:-edge}
+    container_name: spoo_next
+    restart: always
+    environment:
+      - SPOO_API_URL=http://spoo.me:8000
+    # SSR dials spoo.me so its Host header is the one the tenant resolver
+    # expects. Scoped to this container: a network alias would also make the
+    # app resolve its own domain internally, and the link tools' outbound
+    # fetches need the public address. Pinned to app's ipv4_address above.
+    extra_hosts:
+      - "spoo.me:172.30.0.10"
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "--tries=1", "--timeout=3", "http://127.0.0.1:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    mem_limit: 512m
+    mem_reservation: 128m
+    networks:
+      spoonet:
+        ipv4_address: 172.30.0.80
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+        tag: "{{.Name}}"
+
 volumes:
   redis-data:
   caddy-data:


### PR DESCRIPTION
Two things, both about the running deployment rather than the app.

## The file was 37 lines behind

`docker-compose.prod.yml` here predates the frontend running on the box, so it was missing the entire `next` service and the app's network entry that serves it. Same drift as the Caddyfile in #323, from the same work. This pulls the running file back so the deployment is reviewable and recoverable from git.

## The spoo.me name moves out of the network

The app container carried a network alias `spoo.me` so SSR fetches from the frontend would dial `http://spoo.me:8000` and arrive with the Host header the tenant resolver expects.

A network alias is published to every container on `spoonet`, including the app itself. So the app resolved its own domain to `172.30.0.10`, which is the app. That was invisible until the link tools shipped, and then all three of their endpoints refused every spoo.me URL, because the SSRF guard saw a public hostname resolving into private space and did exactly what it is built to do:

```
metadata     ?url=https://spoo.me       -> unfetchable
expand       ?url=https://spoo.me/tools -> unfetchable
domain-intel ?host=spoo.me              -> that host does not resolve
```

`www.spoo.me` failed too, one hop later, since it redirects to the apex and every hop is re-validated.

The name is now an `extra_hosts` entry on `next` instead. It lands in that one container's `/etc/hosts`, which its resolver reads before DNS, so the frontend still reaches the app at `spoo.me` and its Host header is unchanged. The app resolves the domain publicly and its outbound fetches work.

`SPOO_API_URL` deliberately does not change. The Host header is the whole reason the name exists, so the URL the frontend dials has to stay exactly as it was.

## Verified on prod

Applied and confirmed before this was written. Resolution splits as intended: the app gets Cloudflare's addresses for `spoo.me`, `next` gets `172.30.0.10`.

- `/{code}+` renders the real destination, `/stats/{code}` shows its click total, `/about` serves, a short code still 302s to its destination
- `metadata` returns the real page title for `https://spoo.me`
- `expand` unrolls a `spoo.me` short link to its destination with a Web Risk verdict attached
- `domain-intel` returns DNS records for `spoo.me`

The `172.30.0.10` pin is the one wart. It is the app's `ipv4_address`, statically assigned in this same file, and the comment says so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production frontend service to the deployment configuration.
  * The frontend now connects to the application API and includes health monitoring.
  * Added resource limits and network configuration to support reliable production operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->