### PR TITLE
chore(vector): ship the frontend container's logs

### DIFF
--- a/vector.toml
+++ b/vector.toml
@@ -13,7 +13,7 @@ address = "127.0.0.1:8686"
 
 [sources.docker]
 type = "docker_logs"
-include_containers = ["spoo_app", "spoo_qr", "spoo_click_worker"]
+include_containers = ["spoo_app", "spoo_qr", "spoo_click_worker", "spoo_next"]
 exclude_containers = ["spoo_vector", "spoo_redis_exporter"]
 
 [transforms.parse_and_clean]


### PR DESCRIPTION
Completes the sweep started by #323 (Caddyfile) and #326 (compose): every deployment config file on the box compared against its copy here.

## The gap

`vector.toml` collects logs from `spoo_app`, `spoo_qr` and `spoo_click_worker`. The running file also collects `spoo_next`, added when the frontend moved onto the box. This file never got it.

It matters because the file is bind-mounted read-only into the vector container, so it is live config, not documentation. A deploy that ever restored it from git would stop shipping frontend logs to Axiom while every container stayed healthy and nothing errored. The failure is silence.

## The rest of the sweep

Checked and already in sync, listed so the next person does not repeat it:

| file | state |
|---|---|
| `caddy/Caddyfile` | synced by #323 |
| `docker-compose.prod.yml` | synced by #326 |
| `docker-compose.beta.yml` | identical |
| `caddy/.gitignore` | identical, already tracked |
| `vector.toml` | this PR |

Deliberately not brought over:

- `caddy/origin.crt` and `caddy/origin.key`, already ignored, and `caddy/cf-aop-zone-ca.crt`, which is a self-signed CA for authenticated origin pulls rather than a published one. Crypto material stays off the repo even when only the public half is involved.
- `caddy/Caddyfile.pre-freeze` and the various `.bak` files, which are snapshots rather than config.
- `bin/mongo-mcp`, an operator helper rather than part of the deployment.
- `.env.production`, obviously.

## One thing this does not close

Nineteen environment variables are set in production and appear nowhere in `.env.example`, including whole feature switches like `CUSTOM_DOMAINS_ENABLED`, the `EDGE_CACHE_CF_*` credentials, `LLM_API_KEY` and `SHORTEN_API_RATE_LIMIT_PER_HOUR`. For a project people self-host, that means real knobs are undiscoverable without reading `config.py`.

That is a documentation change rather than a config-file sync, so it is not in here. Worth its own pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logging support for the `spoo_next` container in the Vector Docker logs pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->