### PR TITLE
fix(metadata): read to the end of the head, not a fixed prefix

### DIFF
--- a/infrastructure/safe_fetch.py
+++ b/infrastructure/safe_fetch.py
@@ -120,11 +120,21 @@ bracket_ip = _bracket
 
 
 async def _read_body(
-    resp: httpx.Response, max_bytes: int, truncate_over_cap: bool
+    resp: httpx.Response,
+    max_bytes: int,
+    truncate_over_cap: bool,
+    stop_after: bytes | None = None,
 ) -> bytearray:
     buf = bytearray()
+    searched = 0
     async for chunk in resp.aiter_bytes():
         buf += chunk
+        if stop_after is not None:
+            # Resume one marker-width back: it can straddle two chunks.
+            found = buf.find(stop_after, max(0, searched - len(stop_after)))
+            if found != -1:
+                return buf[: found + len(stop_after)]
+            searched = len(buf)
         if len(buf) > max_bytes:
             if truncate_over_cap:
                 return buf[:max_bytes]
@@ -141,6 +151,7 @@ async def fetch_public(
     max_bytes: int = 1_048_576,
     max_redirects: int = 3,
     truncate_over_cap: bool = False,
+    stop_after: bytes | None = None,
     user_agent: str = DEFAULT_USER_AGENT,
 ) -> FetchedBody:
     """Fetch *url* with SSRF guards. ``accept_content`` are content-type
@@ -148,9 +159,12 @@ async def fetch_public(
     fail even when a prefix matched (e.g. ``("svg",)``).
 
     ``truncate_over_cap=True`` returns the first ``max_bytes`` instead of
-    failing when the body exceeds the cap — right for HTML meta parsing
-    (tags live in <head>; github.com's homepage alone is >512KB), wrong
-    for images (a truncated image is not a valid image)."""
+    failing when the body exceeds the cap, which is right for HTML meta
+    parsing and wrong for images (a truncated image is not a valid image).
+
+    ``stop_after`` ends the read at a marker, so an HTML caller pays for
+    the head rather than the cap. Heads are not reliably small: youtube
+    puts ~700KB of inline JSON before its meta tags."""
     # httpx timeouts are per-operation and reset each chunk, so the body
     # read below is bounded by an explicit wall-clock ceiling instead.
     hop_deadline = timeout * 3
@@ -214,7 +228,7 @@ async def fetch_public(
                 # wall-clock ceiling a slow-drip server can't evade.
                 try:
                     buf = await asyncio.wait_for(
-                        _read_body(resp, max_bytes, truncate_over_cap),
+                        _read_body(resp, max_bytes, truncate_over_cap, stop_after),
                         timeout=hop_deadline,
                     )
                 except (asyncio.TimeoutError, TimeoutError) as exc:

--- a/routes/api_v1/metadata.py
+++ b/routes/api_v1/metadata.py
@@ -39,7 +39,10 @@ log = get_logger(__name__)
 
 router = APIRouter(tags=["Metadata"])
 
-_FETCH_MAX_BYTES = 524_288  # tags must be in the head; 512KB is generous
+# Heads are not reliably small (youtube: ~700KB before its meta tags),
+# so the read stops at </head> and this is only the backstop.
+_FETCH_MAX_BYTES = 1_048_576
+_HEAD_END = b"</head>"
 _FETCH_TIMEOUT = 5.0
 
 _metadata_limit, _metadata_key = dynamic_limit(
@@ -112,8 +115,8 @@ async def get_metadata(
             accept_content=("text/html", "application/xhtml"),
             timeout=_FETCH_TIMEOUT,
             max_bytes=_FETCH_MAX_BYTES,
-            # Big pages are fine — tags live in <head>, parse the prefix.
             truncate_over_cap=True,
+            stop_after=_HEAD_END,
             user_agent=settings.meta_tags.fetch_user_agent,
         )
     except FetchTransientError as exc:

--- a/tests/unit/infrastructure/test_safe_fetch.py
+++ b/tests/unit/infrastructure/test_safe_fetch.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from infrastructure.safe_fetch import (
     FetchHardError,
     _is_public,
+    _read_body,
     fetch_public_image,
     resolve_public_ip,
 )
@@ -129,3 +130,71 @@ class TestFetchGuards:
         ):
             await fetch_public_image("https://example.com/a.png")
         assert captured["accept_encoding"] == "identity"
+
+
+class TestReadBodyStopMarker:
+    """``stop_after`` ends the read at </head> so an HTML caller pays for the
+    head, not the cap. Heads are not reliably small: youtube puts ~700KB of
+    inline JSON before its meta tags, which a 512KB cap silently cut off."""
+
+    @staticmethod
+    def _resp(chunks):
+        resp = MagicMock()
+
+        async def aiter_bytes():
+            for chunk in chunks:
+                yield chunk
+
+        resp.aiter_bytes = aiter_bytes
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_read_stops_at_the_marker(self):
+        body = await _read_body(
+            self._resp([b"<head><title>x</title></head>", b"<body>" + b"z" * 5000]),
+            max_bytes=1_000_000,
+            truncate_over_cap=True,
+            stop_after=b"</head>",
+        )
+        assert bytes(body) == b"<head><title>x</title></head>"
+
+    @pytest.mark.asyncio
+    async def test_marker_split_across_chunks_is_still_found(self):
+        body = await _read_body(
+            self._resp([b"<head>a</he", b"ad><body>ignored"]),
+            max_bytes=1_000_000,
+            truncate_over_cap=True,
+            stop_after=b"</head>",
+        )
+        assert bytes(body) == b"<head>a</head>"
+
+    @pytest.mark.asyncio
+    async def test_tags_past_the_old_512kb_cap_survive(self):
+        """The youtube shape: a huge head, then the tags."""
+        head = b"<head>" + b"j" * 700_000 + b'<meta property="og:title"></head>'
+        body = await _read_body(
+            self._resp([head, b"<body>" + b"z" * 600_000]),
+            max_bytes=1_048_576,
+            truncate_over_cap=True,
+            stop_after=b"</head>",
+        )
+        assert b"og:title" in bytes(body)
+
+    @pytest.mark.asyncio
+    async def test_a_missing_marker_still_honours_the_cap(self):
+        body = await _read_body(
+            self._resp([b"x" * 900, b"y" * 900]),
+            max_bytes=1_000,
+            truncate_over_cap=True,
+            stop_after=b"</head>",
+        )
+        assert len(body) == 1_000
+
+    @pytest.mark.asyncio
+    async def test_without_a_marker_the_whole_body_is_read(self):
+        body = await _read_body(
+            self._resp([b"<head></head>", b"<body>tail"]),
+            max_bytes=1_000,
+            truncate_over_cap=True,
+        )
+        assert bytes(body) == b"<head></head><body>tail"


### PR DESCRIPTION
Reported against the freshly launched link preview checker: pasting a youtube watch URL returned a favicon and nine missing tags.

## What happened

`routes/api_v1/metadata.py` capped the fetch at 512KB, with a comment asserting that tags live in the head so the prefix is enough. Measured byte offsets of `og:title` in the served HTML:

| site | og:title at | `</head>` at | document |
|---|---|---|---|
| nytimes | 765 | 189,530 | 1.1MB |
| wikipedia | 7,526 | 8,546 | 266KB |
| github | 28,889 | 31,859 | 456KB |
| **youtube** | **699,117** | **707,278** | **1.38MB** |

Youtube puts roughly 700KB of inline JSON in its head before the meta tags. We read 512KB, caught the favicon link at byte 6,319, and stopped about 185KB short of everything else. The tool then honestly reported what it had, which read as "youtube has no meta tags".

The assumption was that heads are small. They are usually, and youtube is the first URL most people will paste into a link preview checker.

## The fix

`fetch_public` takes an optional `stop_after` marker and ends the read there. The metadata route passes `</head>` and keeps a byte cap as a backstop, raised to 1MB.

Stopping at the marker makes the common case cheaper than it was, because most heads close long before either limit. Github now costs 32KB instead of 512KB, nytimes 190KB instead of 512KB. Youtube costs 707KB, which is the price of it working at all.

The marker search resumes one marker-width back on each chunk, since `</head>` can straddle a chunk boundary. There is a test for exactly that, because it is the part that looks right and silently is not.

## Verified

Against the real pages through a local backend, not fixtures:

- youtube: 14 og tags and 18 twitter tags, with title and image, where it previously returned none
- github and wikipedia unchanged

Full suite in a clean worktree: 3624 passed, 5 skipped.

## Not fixed here

Amazon returns 1,147 bytes and reddit 190KB, both a 200 with no og tags at all. Those are bot walls serving a stripped page rather than refusing. The tool reports every tag missing, which is true of what was served and misleading about why.

Distinguishing that from a page genuinely lacking tags is a heuristic (a 200 with HTML, no title, and zero og or twitter tags is a shape real pages almost never have), and the unfetchable reason is deliberately vague so callers cannot probe address space. Worth its own decision rather than bundling.
