### PR TITLE
fix(worker): construct Web Risk through its client

### DIFF
--- a/tests/unit/workers/test_click_worker_app.py
+++ b/tests/unit/workers/test_click_worker_app.py
@@ -8,6 +8,7 @@ import pytest
 
 from config import AppSettings, ClickEventsSettings
 from workers.click_worker import (
+    _build_runtime,
     _first_message_id,
     create_worker_app,
     enabled_groups,
@@ -190,3 +191,40 @@ class TestRuntimeWiring:
             build.assert_awaited_once()
             await app._on_shutdown_calling[0]()  # type: ignore[attr-defined]
             fake_runtime.aclose.assert_awaited_once()
+
+
+class TestSafetyRuntime:
+    """The worker builds its own safety providers instead of sharing the
+    app's wiring, so a provider signature change lands here silently. This
+    boots the safety branch to make that a red test, not a crash loop."""
+
+    @pytest.mark.asyncio
+    async def test_builds_safety_consumer_with_web_risk(self):
+        settings = _settings()
+        settings.safety.enabled = True
+        settings.safety.web_risk_api_key = "k123"
+
+        with patch(
+            "workers.click_worker.create_redis_client", new=AsyncMock()
+        ) as redis_factory:
+            redis_factory.return_value = MagicMock()
+            runtime = await _build_runtime(settings, ["stats"], run_safety=True)
+
+        assert runtime.safety_consumer is not None
+
+    @pytest.mark.asyncio
+    async def test_builds_deep_consumer_when_investigation_is_on(self):
+        settings = _settings()
+        settings.safety.enabled = True
+        settings.safety.deep_enabled = True
+        settings.safety.web_risk_api_key = "k123"
+        settings.llm.enabled = True
+        settings.llm.api_key = "k456"
+
+        with patch(
+            "workers.click_worker.create_redis_client", new=AsyncMock()
+        ) as redis_factory:
+            redis_factory.return_value = MagicMock()
+            runtime = await _build_runtime(settings, ["stats"], run_safety=True)
+
+        assert runtime.deep_consumer is not None

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -55,6 +55,7 @@ from infrastructure.http_client import HttpClient
 from infrastructure.llm import LlmTaskRunner
 from infrastructure.logging import get_logger, setup_logging
 from infrastructure.ops_notify import DiscordOpsNotifier
+from infrastructure.web_risk import ENFORCEMENT_THREAT_TYPES, WebRiskClient
 from repositories.blocked_url_repository import BlockedUrlRepository
 from repositories.click_repository import ClickRepository
 from repositories.feed_domain_repository import FeedDomainRepository
@@ -393,9 +394,12 @@ async def _build_runtime(
         if sf.web_risk_enabled:
             safety_providers.append(
                 WebRiskProvider(
-                    runtime.http_client,
-                    api_key=sf.web_risk_api_key,
-                    api_base=sf.web_risk_api_base,
+                    WebRiskClient(
+                        runtime.http_client,
+                        api_key=sf.web_risk_api_key,
+                        api_base=sf.web_risk_api_base,
+                        threat_types=ENFORCEMENT_THREAT_TYPES,
+                    )
                 )
             )
         # Deep tier: unresolved screenings this worker judges get handed
@@ -473,9 +477,12 @@ async def _build_runtime(
                     own_domains=settings.blocked_self_domains,
                     web_risk=(
                         WebRiskProvider(
-                            runtime.http_client,
-                            api_key=sf.web_risk_api_key,
-                            api_base=sf.web_risk_api_base,
+                            WebRiskClient(
+                                runtime.http_client,
+                                api_key=sf.web_risk_api_key,
+                                api_base=sf.web_risk_api_base,
+                                threat_types=ENFORCEMENT_THREAT_TYPES,
+                            )
                         )
                         if sf.web_risk_enabled
                         else None


### PR DESCRIPTION
## What

The click worker builds its own safety providers rather than sharing the app's wiring. When `WebRiskProvider` moved onto a shared `WebRiskClient`, `dependencies/wiring.py` was updated and the worker was not, so it kept passing `http_client` plus `api_key`.

Turning `SAFETY_ENABLED` on in production crash-looped the worker on startup while the app booted fine:

```
TypeError: WebRiskProvider.__init__() got an unexpected keyword argument 'api_key'
ERROR:    Application startup failed. Exiting.
```

Clicks stopped being consumed for the few minutes the flag was on. No events were lost: the stream is capped well above the ~475 that queued, and both groups are back at `pending 0, lag 0`.

## Fix

Both worker call sites now build through `WebRiskClient` with `ENFORCEMENT_THREAT_TYPES`, matching the wiring exactly.

## Why it went unnoticed

Nothing booted the worker's safety branch. `_build_runtime` now gets tests that construct both the screening consumer and the investigation consumer, so the next signature change fails a test instead of a deploy. Reverting the fix turns the new test red with the exact production error.

The deep-tier test covers the second call site, which is the one that would bite when `SAFETY_DEEP_ENABLED` is turned on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web safety checks by applying a broader set of threat detections during enforcement.
  * Strengthened safety processing to ensure enhanced protection features are consistently activated when configured.

* **Tests**
  * Added coverage to verify that safety-related processing components are created correctly when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->