### PR TITLE
chore: reserve the restore-account alias

### DIFF
--- a/shared/reserved_aliases.py
+++ b/shared/reserved_aliases.py
@@ -60,6 +60,7 @@ RESERVED_ALIASES: frozenset[str] = frozenset(
         "profile-pictures",
         "public",
         "register",
+        "restore-account",
         "relay",
         "report",
         "reset",


### PR DESCRIPTION
The frontend now serves /restore-account, the page where the account-deletion cancel link lands. Caddy routes the path to Next, so a short link with this alias could never resolve anyway; reserving it keeps the namespace honest. Nobody currently owns the alias (checked prod, v2 and legacy, case-insensitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reserved the `restore-account` short code to prevent conflicts with account recovery navigation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->