### PR TITLE
fix(safety): stop paying a model to agree with a feed

### DIFF
--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -96,6 +96,7 @@ from services.public_preview_service import PublicPreviewService
 from services.public_stats_service import PublicStatsService
 from services.report_intake_service import ReportIntakeService
 from services.safety import (
+    CARRIER_FEEDS,
     AdmissionPolicy,
     BlockedPatternProvider,
     CreationPatternScorer,
@@ -109,6 +110,7 @@ from services.safety import (
     SafetyAnalyzer,
     SafetyEnforcer,
     SafetySink,
+    SharedCarrierLookup,
     SweepDeps,
     ToxicVerdictProvider,
     UrlPolicyService,
@@ -614,6 +616,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         reverdict_ttl_hours=sf_settings.reverdict_ttl_hours,
         admission=admission,
         deep_sink=deep_sink if admission is not None else None,
+        carriers=SharedCarrierLookup(feed_domain_repo, feeds=CARRIER_FEEDS),
     )
     app.state.safety_analyzer = safety_analyzer
     safety_sink: SafetySink

--- a/services/safety/__init__.py
+++ b/services/safety/__init__.py
@@ -16,6 +16,7 @@ from services.safety.deep_consumer import DeepAnalysisConsumer
 from services.safety.enforcer import EnforcementResult, SafetyEnforcer
 from services.safety.events import SAFETY_STREAM, SafetyAnalyzeEvent
 from services.safety.feeds import (
+    CARRIER_FEEDS,
     FISHFISH_FEED,
     MANUAL_FEED,
     REDIRECTOR_FEED,
@@ -41,6 +42,7 @@ from services.safety.providers import (
     BlockedPatternProvider,
     FeedDomainProvider,
     ProviderVerdict,
+    SharedCarrierLookup,
     ToxicVerdictProvider,
     WebRiskProvider,
 )
@@ -62,6 +64,7 @@ from services.safety.tools import (
 )
 
 __all__ = [
+    "CARRIER_FEEDS",
     "FISHFISH_FEED",
     "MANUAL_FEED",
     "REDIRECTOR_FEED",
@@ -95,6 +98,7 @@ __all__ = [
     "SafetyAnalyzer",
     "SafetyEnforcer",
     "SafetySink",
+    "SharedCarrierLookup",
     "SweepDeps",
     "ToxicVerdictProvider",
     "UrlPolicyService",

--- a/services/safety/analyzer.py
+++ b/services/safety/analyzer.py
@@ -249,7 +249,8 @@ class SafetyAnalyzer:
                 host=event.host,
                 registrable_domain=event.registrable_domain,
                 source=source,
-                sample_url=event.url,
+                # Query strings on these carry recipient ids and tokens.
+                sample_path=event.url.split("?", 1)[0].split("#", 1)[0],
             )
 
     async def _reenforce(self, event: SafetyAnalyzeEvent, existing: VerdictDoc) -> bool:

--- a/services/safety/analyzer.py
+++ b/services/safety/analyzer.py
@@ -10,8 +10,10 @@ process hosts it (worker consumer or inline sink). Semantics:
 - First non-abstaining provider wins. No provider judging means tier
   UNCERTAIN and a human review embed — BENIGN is never inferred from
   absence of evidence.
-- Screening never originates a host-wide block: it blocks only the links
-  its evidence covers and escalates the host question to the deep tier.
+- Screening enforces exactly as far as its signal reaches. A curated feed
+  naming a host is a host-wide call and needs no second opinion; anything
+  narrower blocks the links it covers and escalates the host question to
+  the deep tier.
 - Everything is best-effort: analysis failures log and drop, they never
   propagate into the trigger path (a report must store even when analysis
   is broken).
@@ -33,6 +35,7 @@ from services.safety.events import SafetyAnalyzeEvent
 from services.safety.providers import (
     AnalysisProvider,
     ProviderVerdict,
+    SharedCarrierLookup,
     verdict_covers,
 )
 from shared.datetime_utils import as_aware_utc
@@ -59,6 +62,10 @@ _TRIGGER_AUTHORITY = {
 # Unresolved machine-volume triggers stay silent; review pings would drown the channel.
 _SILENT_TRIGGERS = frozenset({"sweep", "hot", "redirect"})
 
+# A curated feed naming a host IS the host-wide answer, so there is no reach
+# question left to bill a model for. FeedDomainProvider names itself this way.
+_FEED_SOURCE_PREFIX = "feed_"
+
 
 class SafetyAnalyzer:
     def __init__(
@@ -71,6 +78,7 @@ class SafetyAnalyzer:
         reverdict_ttl_hours: int = 24,
         admission: AdmissionPolicy | None = None,
         deep_sink: DeepAnalysisSink | None = None,
+        carriers: SharedCarrierLookup | None = None,
     ) -> None:
         self._providers = providers
         self._verdict_repo = verdict_repo
@@ -79,6 +87,7 @@ class SafetyAnalyzer:
         self._reverdict_ttl = timedelta(hours=reverdict_ttl_hours)
         self._admission = admission
         self._deep_sink = deep_sink
+        self._carriers = carriers
 
     async def analyze(self, event: SafetyAnalyzeEvent) -> None:
         if event.trigger == "redirect" and not (event.context or {}).get("terminal"):
@@ -210,12 +219,13 @@ class SafetyAnalyzer:
             scope=scope,
             path_pattern=path_pattern,
         )
-        escalated = await self._escalate(event, verdict, source)
-        follow_up = (
-            "host-wide decision sent to investigation"
-            if escalated
-            else "host-wide decision needs review"
-        )
+        if scope == "host" and source.startswith(_FEED_SOURCE_PREFIX):
+            await self._warn_if_shared_carrier(event, source)
+            follow_up = "feed listing is itself the host-wide answer"
+        elif await self._escalate(event, verdict, source):
+            follow_up = "host-wide decision sent to investigation"
+        else:
+            follow_up = "host-wide decision needs review"
         await self._notifier.safety_action(
             host=event.host,
             reason=f"{verdict.reason} ({scope_note}; {follow_up})",
@@ -224,6 +234,23 @@ class SafetyAnalyzer:
             legacy_count=result.legacy_count,
             sample_url=event.url,
         )
+
+    async def _warn_if_shared_carrier(
+        self, event: SafetyAnalyzeEvent, source: str
+    ) -> None:
+        """A feed listing a shortener or share wrapper reaches every
+        unrelated link routed through it. Enforcement still follows the
+        feed; this is the signal that it was wider than the evidence."""
+        if self._carriers is None:
+            return
+        if await self._carriers.covers(event.host, event.registrable_domain):
+            log.warning(
+                "safety_feed_block_on_shared_carrier",
+                host=event.host,
+                registrable_domain=event.registrable_domain,
+                source=source,
+                sample_url=event.url,
+            )
 
     async def _reenforce(self, event: SafetyAnalyzeEvent, existing: VerdictDoc) -> bool:
         """Idempotent re-enforcement bounded by the verdict's scope; True when

--- a/services/safety/analyzer.py
+++ b/services/safety/analyzer.py
@@ -37,6 +37,7 @@ from services.safety.providers import (
     ProviderVerdict,
     SharedCarrierLookup,
     verdict_covers,
+    without_query,
 )
 from shared.datetime_utils import as_aware_utc
 from shared.url_utils import parse_destination
@@ -250,7 +251,7 @@ class SafetyAnalyzer:
                 registrable_domain=event.registrable_domain,
                 source=source,
                 # Query strings on these carry recipient ids and tokens.
-                sample_path=event.url.split("?", 1)[0].split("#", 1)[0],
+                sample_url=without_query(event.url),
             )
 
     async def _reenforce(self, event: SafetyAnalyzeEvent, existing: VerdictDoc) -> bool:

--- a/services/safety/feeds.py
+++ b/services/safety/feeds.py
@@ -58,6 +58,10 @@ _SHORTENER_SEED_PATH = os.path.join(
 # The RESOLVE class: never refused, never a judgment source — membership only
 # marks a created link for terminal-URL resolution of the chain's endpoint.
 REDIRECTOR_FEED = "redirectors"
+
+# Domains that carry OTHER people's links: listed for what routed through
+# them, so a host-wide block reaches every unrelated link too.
+CARRIER_FEEDS = (SHORTENER_FEED, REDIRECTOR_FEED)
 _REDIRECTOR_SEED_PATH = os.path.join(
     os.path.dirname(_SHORTENER_SEED_PATH),
     "redirector_domains.txt",

--- a/services/safety/feeds.py
+++ b/services/safety/feeds.py
@@ -58,14 +58,14 @@ _SHORTENER_SEED_PATH = os.path.join(
 # The RESOLVE class: never refused, never a judgment source — membership only
 # marks a created link for terminal-URL resolution of the chain's endpoint.
 REDIRECTOR_FEED = "redirectors"
-
-# Domains that carry OTHER people's links: listed for what routed through
-# them, so a host-wide block reaches every unrelated link too.
-CARRIER_FEEDS = (SHORTENER_FEED, REDIRECTOR_FEED)
 _REDIRECTOR_SEED_PATH = os.path.join(
     os.path.dirname(_SHORTENER_SEED_PATH),
     "redirector_domains.txt",
 )
+
+# Domains that carry OTHER people's links: listed for what routed through
+# them, so a host-wide block reaches every unrelated link too.
+CARRIER_FEEDS = (SHORTENER_FEED, REDIRECTOR_FEED)
 
 
 def _load_seed(path: str) -> tuple[str, ...]:

--- a/services/safety/providers.py
+++ b/services/safety/providers.py
@@ -61,9 +61,11 @@ class SharedCarrierLookup:
         self._feeds = feeds
 
     async def covers(self, host: str, registrable_domain: str) -> bool:
-        """Never raises: an unreachable feed store must not turn a narrow
-        block into a host-wide one."""
-        candidates = [d for d in (host, registrable_domain) if d]
+        """Never raises. The block and the verdict are already written by
+        the time this runs, so a raise could not widen or narrow them. What
+        it would take out is the operator notification on the next line, and
+        a block nobody hears about is worse than an unflagged one."""
+        candidates = [d for d in dict.fromkeys((host, registrable_domain)) if d]
         for feed in self._feeds:
             for domain in candidates:
                 try:
@@ -156,11 +158,11 @@ def verdict_covers(verdict, url: str) -> bool:
     if scope == "path_pattern" and verdict.path_pattern:
         return matching_blocked_pattern(url, (verdict.path_pattern,)) is not None
     if scope == "links" and verdict.sample_url:
-        return _without_query(url) == _without_query(verdict.sample_url)
+        return without_query(url) == without_query(verdict.sample_url)
     return False
 
 
-def _without_query(url: str) -> str:
+def without_query(url: str) -> str:
     """Scheme, host and path only: a links-scoped verdict covers the judged
     URL, and appending ``?a=1`` is not a different destination."""
     return url.split("?", 1)[0].split("#", 1)[0].rstrip("/")

--- a/services/safety/providers.py
+++ b/services/safety/providers.py
@@ -46,6 +46,41 @@ class AnalysisProvider(Protocol):
     ) -> ProviderVerdict | None: ...
 
 
+class SharedCarrierLookup:
+    """Membership check for feeds whose domains CARRY other people's links.
+
+    A shortener or a platform share wrapper appears on a scam feed because
+    scammers routed through it, never because the domain itself is the
+    scam. Blocking such a host kills every unrelated link that passes
+    through it, so a host-scope hit on one of these is narrowed to the
+    judged link instead.
+    """
+
+    def __init__(self, repo: FeedDomainRepository, *, feeds: tuple[str, ...]) -> None:
+        self._repo = repo
+        self._feeds = feeds
+
+    async def covers(self, host: str, registrable_domain: str) -> bool:
+        """Never raises: an unreachable feed store must not turn a narrow
+        block into a host-wide one."""
+        candidates = [d for d in (host, registrable_domain) if d]
+        for feed in self._feeds:
+            for domain in candidates:
+                try:
+                    if await self._repo.contains(feed, domain):
+                        return True
+                except Exception as exc:
+                    log.warning(
+                        "shared_carrier_lookup_failed",
+                        feed=feed,
+                        domain=domain,
+                        error=str(exc),
+                        error_type=type(exc).__name__,
+                    )
+                    return False
+        return False
+
+
 class FeedDomainProvider:
     """Membership check against a synced external feed's domain set
     (``safety_feed_domains``). An empty or never-synced set abstains — the

--- a/services/safety/providers.py
+++ b/services/safety/providers.py
@@ -51,9 +51,9 @@ class SharedCarrierLookup:
 
     A shortener or a platform share wrapper appears on a scam feed because
     scammers routed through it, never because the domain itself is the
-    scam. Blocking such a host kills every unrelated link that passes
-    through it, so a host-scope hit on one of these is narrowed to the
-    judged link instead.
+    scam. Enforcement still follows the feed and blocks host-wide; this
+    lookup only marks the blocks that therefore reached every unrelated
+    link routed through the same domain.
     """
 
     def __init__(self, repo: FeedDomainRepository, *, feeds: tuple[str, ...]) -> None:

--- a/tests/unit/services/safety/test_analyzer.py
+++ b/tests/unit/services/safety/test_analyzer.py
@@ -463,6 +463,20 @@ class TestDeepAdmission:
         assert "sent to investigation" in reason
 
     @pytest.mark.asyncio
+    async def test_denied_escalation_still_flags_the_host_decision(self):
+        """The review fallback is what an operator sees when the deep tier
+        is unwired or the budget is gone. It must survive both."""
+        provider = _Provider(
+            ProviderVerdict(tier=VerdictTier.TOXIC, reason="operator pattern"),
+            name="blocked_pattern",
+        )
+        analyzer, _verdict_repo, _enforcer, notifier = _build([provider])
+
+        await analyzer.analyze(_event())
+
+        assert "needs review" in notifier.safety_action.await_args.kwargs["reason"]
+
+    @pytest.mark.asyncio
     async def test_feed_block_on_a_shared_carrier_is_flagged(self, capsys):
         """e.vg is on a scam feed because scammers routed through it. The
         block still follows the feed; the warning is how an operator finds
@@ -488,7 +502,7 @@ class TestDeepAdmission:
 
         out = capsys.readouterr().out
         assert "safety_feed_block_on_shared_carrier" in out
-        assert "sample_path=https://e.vg/kit" in out
+        assert "sample_url=https://e.vg/kit" in out
         assert "token=secret" not in out
         assert carriers.covers.await_args.args == ("e.vg", "e.vg")
 

--- a/tests/unit/services/safety/test_analyzer.py
+++ b/tests/unit/services/safety/test_analyzer.py
@@ -438,16 +438,29 @@ class TestDeepAdmission:
 
     @pytest.mark.asyncio
     async def test_host_scoped_hit_from_a_non_feed_source_still_escalates(self):
+        """Only a feed short-circuits the reach question. An operator
+        pattern matching host-wide is still a claim worth investigating."""
+        from services.safety.admission import AdmissionDecision
+
         provider = _Provider(
             ProviderVerdict(tier=VerdictTier.TOXIC, reason="operator pattern"),
             name="blocked_pattern",
         )
-        analyzer, _verdict_repo, _enforcer, notifier = _build([provider])
+        admission = AsyncMock()
+        admission.decide = AsyncMock(
+            return_value=AdmissionDecision(admitted=True, reason="within_budget")
+        )
+        deep_sink = AsyncMock()
+        analyzer, _verdict_repo, _enforcer, notifier = _build(
+            [provider], admission=admission, deep_sink=deep_sink
+        )
 
         await analyzer.analyze(_event())
 
+        deep_sink.emit.assert_awaited_once()
+        assert admission.decide.await_args.kwargs == {"escalation": True}
         reason = notifier.safety_action.await_args.kwargs["reason"]
-        assert "needs review" in reason
+        assert "sent to investigation" in reason
 
     @pytest.mark.asyncio
     async def test_feed_block_on_a_shared_carrier_is_flagged(self, capsys):
@@ -464,9 +477,19 @@ class TestDeepAdmission:
             [provider], carriers=carriers
         )
 
-        await analyzer.analyze(_event(host="e.vg"))
+        await analyzer.analyze(
+            SafetyAnalyzeEvent(
+                url="https://e.vg/kit?token=secret",
+                host="e.vg",
+                registrable_domain="e.vg",
+                trigger="report",
+            )
+        )
 
-        assert "safety_feed_block_on_shared_carrier" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "safety_feed_block_on_shared_carrier" in out
+        assert "sample_path=https://e.vg/kit" in out
+        assert "token=secret" not in out
         assert carriers.covers.await_args.args == ("e.vg", "e.vg")
 
     @pytest.mark.asyncio

--- a/tests/unit/services/safety/test_analyzer.py
+++ b/tests/unit/services/safety/test_analyzer.py
@@ -35,7 +35,7 @@ class _Provider:
         return self._verdict
 
 
-def _build(providers, existing=None):
+def _build(providers, existing=None, **kwargs):
     verdict_repo = AsyncMock()
     verdict_repo.find_by_host = AsyncMock(return_value=existing)
     enforcer = AsyncMock()
@@ -44,7 +44,7 @@ def _build(providers, existing=None):
     )
     notifier = AsyncMock()
     analyzer = SafetyAnalyzer(
-        providers, verdict_repo, enforcer, notifier, reverdict_ttl_hours=24
+        providers, verdict_repo, enforcer, notifier, reverdict_ttl_hours=24, **kwargs
     )
     return analyzer, verdict_repo, enforcer, notifier
 
@@ -411,10 +411,36 @@ class TestDeepAdmission:
         assert "needs review" not in notifier.safety_action.await_args.kwargs["reason"]
 
     @pytest.mark.asyncio
-    async def test_toxic_without_deep_tier_flags_the_host_decision_for_review(self):
+    async def test_host_scoped_feed_hit_never_pays_for_a_second_opinion(self):
+        """The feed already answered the host question, so there is no reach
+        left to investigate and no model call to make."""
+        from services.safety.admission import AdmissionDecision
+
         provider = _Provider(
             ProviderVerdict(tier=VerdictTier.TOXIC, reason="feed hit"),
             name="feed_fishfish",
+        )
+        admission = AsyncMock()
+        admission.decide = AsyncMock(
+            return_value=AdmissionDecision(admitted=True, reason="within_budget")
+        )
+        deep_sink = AsyncMock()
+        analyzer, _verdict_repo, _enforcer, notifier = _build(
+            [provider], admission=admission, deep_sink=deep_sink
+        )
+
+        await analyzer.analyze(_event())
+
+        deep_sink.emit.assert_not_awaited()
+        admission.decide.assert_not_awaited()
+        reason = notifier.safety_action.await_args.kwargs["reason"]
+        assert "feed listing is itself the host-wide answer" in reason
+
+    @pytest.mark.asyncio
+    async def test_host_scoped_hit_from_a_non_feed_source_still_escalates(self):
+        provider = _Provider(
+            ProviderVerdict(tier=VerdictTier.TOXIC, reason="operator pattern"),
+            name="blocked_pattern",
         )
         analyzer, _verdict_repo, _enforcer, notifier = _build([provider])
 
@@ -422,6 +448,42 @@ class TestDeepAdmission:
 
         reason = notifier.safety_action.await_args.kwargs["reason"]
         assert "needs review" in reason
+
+    @pytest.mark.asyncio
+    async def test_feed_block_on_a_shared_carrier_is_flagged(self, capsys):
+        """e.vg is on a scam feed because scammers routed through it. The
+        block still follows the feed; the warning is how an operator finds
+        out it reached every unrelated link too."""
+        provider = _Provider(
+            ProviderVerdict(tier=VerdictTier.TOXIC, reason="feed hit"),
+            name="feed_fishfish",
+        )
+        carriers = AsyncMock()
+        carriers.covers = AsyncMock(return_value=True)
+        analyzer, _verdict_repo, _enforcer, _notifier = _build(
+            [provider], carriers=carriers
+        )
+
+        await analyzer.analyze(_event(host="e.vg"))
+
+        assert "safety_feed_block_on_shared_carrier" in capsys.readouterr().out
+        assert carriers.covers.await_args.args == ("e.vg", "e.vg")
+
+    @pytest.mark.asyncio
+    async def test_feed_block_on_an_ordinary_host_is_not_flagged(self, capsys):
+        provider = _Provider(
+            ProviderVerdict(tier=VerdictTier.TOXIC, reason="feed hit"),
+            name="feed_fishfish",
+        )
+        carriers = AsyncMock()
+        carriers.covers = AsyncMock(return_value=False)
+        analyzer, _verdict_repo, _enforcer, _notifier = _build(
+            [provider], carriers=carriers
+        )
+
+        await analyzer.analyze(_event())
+
+        assert "safety_feed_block_on_shared_carrier" not in capsys.readouterr().out
 
 
 class TestScopedReenforcement:

--- a/tests/unit/services/safety/test_providers.py
+++ b/tests/unit/services/safety/test_providers.py
@@ -330,3 +330,51 @@ class TestToxicVerdictScope:
             )
             is not None
         )
+
+
+class TestSharedCarrierLookup:
+    """e.vg sits on a scam feed for what routed through it. This lookup is
+    how a host-wide block on such a domain gets flagged rather than passing
+    silently."""
+
+    @staticmethod
+    def _lookup(listed: set[str]):
+        from services.safety.providers import SharedCarrierLookup
+
+        repo = AsyncMock()
+        repo.contains = AsyncMock(side_effect=lambda feed, domain: domain in listed)
+        return SharedCarrierLookup(repo, feeds=("shorteners", "redirectors")), repo
+
+    @pytest.mark.asyncio
+    async def test_listed_host_is_covered(self):
+        lookup, _repo = self._lookup({"e.vg"})
+        assert await lookup.covers("e.vg", "e.vg") is True
+
+    @pytest.mark.asyncio
+    async def test_registrable_domain_matches_when_the_host_does_not(self):
+        lookup, _repo = self._lookup({"bitly.cx"})
+        assert await lookup.covers("sub.bitly.cx", "bitly.cx") is True
+
+    @pytest.mark.asyncio
+    async def test_unlisted_host_is_not_covered(self):
+        lookup, repo = self._lookup({"e.vg"})
+        assert await lookup.covers("rbxtools.st", "rbxtools.st") is False
+        assert repo.contains.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_blank_registrable_domain_is_skipped(self):
+        lookup, repo = self._lookup(set())
+        assert await lookup.covers("e.vg", "") is False
+        assert repo.contains.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_backend_failure_reports_not_covered(self):
+        """A dead feed store must not invent a carrier, and must not raise
+        into the enforcement path either."""
+        from services.safety.providers import SharedCarrierLookup
+
+        repo = AsyncMock()
+        repo.contains = AsyncMock(side_effect=RuntimeError("mongo down"))
+        lookup = SharedCarrierLookup(repo, feeds=("shorteners",))
+
+        assert await lookup.covers("e.vg", "e.vg") is False

--- a/tests/unit/services/safety/test_providers.py
+++ b/tests/unit/services/safety/test_providers.py
@@ -337,13 +337,20 @@ class TestSharedCarrierLookup:
     how a host-wide block on such a domain gets flagged rather than passing
     silently."""
 
-    @staticmethod
-    def _lookup(listed: set[str]):
+    FEEDS = ("shorteners", "redirectors")
+
+    @classmethod
+    def _lookup(cls, listed: set[str]):
+        """The mock keys on (feed, domain) like the real repository, so a
+        lookup against a feed this instance was never configured with is a
+        miss rather than a silent pass."""
         from services.safety.providers import SharedCarrierLookup
 
         repo = AsyncMock()
-        repo.contains = AsyncMock(side_effect=lambda feed, domain: domain in listed)
-        return SharedCarrierLookup(repo, feeds=("shorteners", "redirectors")), repo
+        repo.contains = AsyncMock(
+            side_effect=lambda feed, domain: feed in cls.FEEDS and domain in listed
+        )
+        return SharedCarrierLookup(repo, feeds=cls.FEEDS), repo
 
     @pytest.mark.asyncio
     async def test_listed_host_is_covered(self):
@@ -359,13 +366,37 @@ class TestSharedCarrierLookup:
     async def test_unlisted_host_is_not_covered(self):
         lookup, repo = self._lookup({"e.vg"})
         assert await lookup.covers("rbxtools.st", "rbxtools.st") is False
-        assert repo.contains.await_count == 4
+        # Apex: host and registrable domain are the same read, once per feed.
+        assert [c.args for c in repo.contains.await_args_list] == [
+            ("shorteners", "rbxtools.st"),
+            ("redirectors", "rbxtools.st"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_subdomain_checks_both_forms_against_every_feed(self):
+        lookup, repo = self._lookup(set())
+        assert await lookup.covers("sub.rbxtools.st", "rbxtools.st") is False
+        assert [c.args for c in repo.contains.await_args_list] == [
+            ("shorteners", "sub.rbxtools.st"),
+            ("shorteners", "rbxtools.st"),
+            ("redirectors", "sub.rbxtools.st"),
+            ("redirectors", "rbxtools.st"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_feed_it_was_not_configured_with_is_never_consulted(self):
+        lookup, repo = self._lookup({"e.vg"})
+        await lookup.covers("e.vg", "e.vg")
+        assert {c.args[0] for c in repo.contains.await_args_list} <= set(self.FEEDS)
 
     @pytest.mark.asyncio
     async def test_blank_registrable_domain_is_skipped(self):
         lookup, repo = self._lookup(set())
         assert await lookup.covers("e.vg", "") is False
-        assert repo.contains.await_count == 2
+        assert [c.args for c in repo.contains.await_args_list] == [
+            ("shorteners", "e.vg"),
+            ("redirectors", "e.vg"),
+        ]
 
     @pytest.mark.asyncio
     async def test_backend_failure_reports_not_covered(self):

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -103,6 +103,8 @@ from services.safety import (
     build_sweep_tasks,
 )
 from services.safety.consumers import SafetyAnalysisConsumer
+from services.safety.feeds import CARRIER_FEEDS
+from services.safety.providers import SharedCarrierLookup
 from services.scheduler import TaskScheduler
 from services.scheduler.tasks import build_task_registry
 from services.webhooks import (
@@ -435,6 +437,7 @@ async def _build_runtime(
             reverdict_ttl_hours=sf.reverdict_ttl_hours,
             admission=admission,
             deep_sink=deep_sink,
+            carriers=SharedCarrierLookup(worker_feed_repo, feeds=CARRIER_FEEDS),
         )
         runtime.safety_consumer = SafetyAnalysisConsumer(safety_analyzer)
         # Sweeps emitted from THIS process run inline through the worker's


### PR DESCRIPTION
## What happened

The first fishfish sync after the deep tier went live ran 53 investigations. 51 of them were feed escalations, and the outcome was:

```
scam_host  block_host     auto=True   corroborated=True   45
scam_host  review         auto=False  corroborated=True    5
scam_host  block_aliases  auto=True   corroborated=True    1
benign     benign         auto=True   corroborated=False   2
```

Zero changed an outcome. 45 called `block_host` on a host screening had already blocked, which is idempotent. The 5 medium-confidence ones were already blocked too. About $1.15 spent confirming decisions the feed had already made and enforced.

## Change

`_handle_toxic` escalated unconditionally. A feed naming a host is the host-wide answer, so there is no reach question to hand a model. Host-scope feed hits now skip the deep tier.

Narrower verdicts still escalate. A link-scoped or pattern-scoped finding genuinely raises the question of how far it reaches, and that path is unchanged.

## The one result worth keeping

`e.vg` came back `scam_host`, high confidence, scope `links`. That was correct: `e.vg` is a general-purpose shortener, and it sits on fishfish because scammers routed through it, not because the domain is the scam. It is in this repo's own `shorteners` feed as well.

It arrived after the host block, so it changed nothing, but it was the only reason anyone found out. Dropping the escalation drops that signal too.

So a feed block landing on a domain in the `shorteners` or `redirectors` feed now logs `safety_feed_block_on_shared_carrier` with the host and sample URL. Enforcement is unchanged and still follows the feed. The warning is how an operator learns the block reached wider than the evidence, at no cost per event.

## Notes

The module docstring claimed screening never originates a host-wide block. That has not been true since feed providers landed, since `FeedDomainProvider` returns host scope. Corrected to describe what the code does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved safety analysis for host-wide verdicts from curated feeds.
  * Shared link carriers, including shorteners and redirect wrappers, now receive additional warnings when blocks may affect unrelated links.
  * Added resilient carrier detection that safely handles unavailable feed data.

* **Bug Fixes**
  * Prevented unnecessary deep investigations for trusted host-level feed verdicts.
  * Preserved escalation for non-feed sources and review flags when escalation is unavailable.
  * Sanitized warning details to exclude query strings and fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->