### PR TITLE
fix: omit None fields from click inserts to stop bucket churn

### DIFF
--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -122,7 +122,9 @@ async def ensure_indexes(
             timeseries={
                 "timeField": "clicked_at",
                 "metaField": "meta",
-                "granularity": "seconds",
+                # "hours" matches prod (collMod'd from "seconds"): sparse
+                # per-link series need the 30-day bucket span to pack.
+                "granularity": "hours",
             },
         )
     except (CollectionInvalid, OperationFailure) as e:

--- a/schemas/models/click.py
+++ b/schemas/models/click.py
@@ -6,7 +6,7 @@ Maps to the `clicks` MongoDB time-series collection.
 Time-series schema:
   timeField  = "clicked_at"
   metaField  = "meta"
-  granularity = "seconds"
+  granularity = "hours"
 
 The `meta` subdocument groups clicks by URL for efficient range queries.
 owner_id always holds an ObjectId — anonymous clicks use ANONYMOUS_OWNER_ID
@@ -60,3 +60,8 @@ class ClickDoc(MongoBaseModel):
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None
+
+    def to_mongo(self) -> dict:
+        # None must be absent, not null: null↔string type flips hard-close
+        # time-series buckets (schema-change rollover).
+        return self.model_dump(by_alias=True, exclude_none=True)

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -185,7 +185,7 @@ class TestEnsureIndexes:
             timeseries={
                 "timeField": "clicked_at",
                 "metaField": "meta",
-                "granularity": "seconds",
+                "granularity": "hours",
             },
         )
 

--- a/tests/unit/schemas/models/test_click.py
+++ b/tests/unit/schemas/models/test_click.py
@@ -50,3 +50,25 @@ class TestClickDoc:
         restored = ClickDoc.from_mongo(doc.to_mongo())
         assert restored.referrer == "google.com"
         assert restored.redirect_ms == doc.redirect_ms
+
+    def test_to_mongo_omits_none_fields(self):
+        data = self._make().to_mongo()
+        for field in (
+            "referrer",
+            "bot_name",
+            "device",
+            "utm_source",
+            "utm_medium",
+            "utm_campaign",
+        ):
+            assert field not in data
+        assert "domain" not in data["meta"]
+
+    def test_to_mongo_keeps_populated_fields(self):
+        data = self._make(
+            referrer="google.com", device="mobile", utm_source="tw"
+        ).to_mongo()
+        assert data["referrer"] == "google.com"
+        assert data["device"] == "mobile"
+        assert data["utm_source"] == "tw"
+        assert data["redirect_ms"] == 42

--- a/tests/unit/services/test_click_service.py
+++ b/tests/unit/services/test_click_service.py
@@ -296,7 +296,8 @@ class TestV2ClickHandler:
         assert doc["utm_campaign"] == "launch"
 
     @pytest.mark.asyncio
-    async def test_utm_tags_default_to_none(self):
+    async def test_utm_tags_omitted_when_absent(self):
+        # Absent, never null: explicit nulls hard-close time-series buckets.
         d = make_deps()
         handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
         url_data = make_v2_cache()
@@ -304,9 +305,9 @@ class TestV2ClickHandler:
         await handler.handle(make_context(url_data))
 
         doc = d.click_repo.insert.call_args[0][0]
-        assert doc["utm_source"] is None
-        assert doc["utm_medium"] is None
-        assert doc["utm_campaign"] is None
+        assert "utm_source" not in doc
+        assert "utm_medium" not in doc
+        assert "utm_campaign" not in doc
 
     @pytest.mark.asyncio
     async def test_meta_carries_domain_from_cache(self):
@@ -320,9 +321,9 @@ class TestV2ClickHandler:
         assert doc["meta"]["domain"] == "links.acme.com"
 
     @pytest.mark.asyncio
-    async def test_meta_domain_none_when_cache_empty_string(self):
-        # Older cached entries pre-PR1 have domain="". Coerce to None so
-        # per-domain queries can distinguish "unknown" from a real value.
+    async def test_meta_domain_omitted_when_cache_empty_string(self):
+        # Older cached entries pre-PR1 have domain="". Coerced to None and
+        # omitted on insert so per-domain queries see it as unknown.
         d = make_deps()
         handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
         url_data = make_v2_cache(domain="")
@@ -330,7 +331,7 @@ class TestV2ClickHandler:
         await handler.handle(make_context(url_data))
 
         doc = d.click_repo.insert.call_args[0][0]
-        assert doc["meta"]["domain"] is None
+        assert "domain" not in doc["meta"]
 
     @pytest.mark.asyncio
     async def test_blocked_bot_skips_analytics_no_error(self):


### PR DESCRIPTION
## Problem

The clicks time-series collection averages 4.07 docs per bucket (66M docs across 16.2M buckets). The bucket index alone is 3.6GB, about half the database's total index footprint, and the resulting memory pressure is behind the recent Mongo incidents.

Root cause: click documents store empty analytics fields as explicit nulls (`referrer: null`, `utm_source: null`, `bot_name: null`). A time-series bucket cannot hold two BSON types in one column, so every alternation between a direct click (null referrer) and a referred click (string referrer) hard-closes the bucket with a schema-change rollover. Measured on prod: 1,035 of 10,254 inserts closed a bucket this way in one hour; the busiest link created 695 buckets in a single day from 1,106 null/string flips.

## Fix

- `ClickDoc.to_mongo()` now serialises with `exclude_none=True`, so empty fields are absent instead of null. Scoped to clicks only; the shared `MongoBaseModel.to_mongo()` is unchanged.
- Bootstrap now creates the clicks collection with `granularity: "hours"`, matching prod (collMod'd from "seconds" earlier). Fresh deploys previously got the churn-prone setting.

## Why reads are safe

- Group-bys map null and missing identically via `$ifNull` sentinels (Direct / unknown / (none)).
- Sentinel filters already carry a `{$exists: false}` arm because clicks recorded before #259 lack the device/utm fields entirely; mixed shapes are already the norm in this collection.
- Every nullable `ClickDoc` field has a default, so `from_mongo` handles absent keys.

## Verification

- Bucket behaviour on a local Percona Server for MongoDB 8.0: 200 alternating direct/referred clicks produce 200 buckets on main and 1 bucket with this change. Field-appears-later and int/double flips confirmed harmless; only null/type alternation closes buckets.
- Mixed-shape equivalence through the real `StatsService` over a collection holding 120 old-shape and 120 new-shape docs: 15 exact-number checks (totals, every dimension group-by, sentinel filters including `referrer=Direct`, non-sentinel filters, per-link path) all match independently computed values.
- Live app end to end, both sink modes: inline, and stream with the click worker consuming from Redis. Referred+utm, direct, and bot clicks via real HTTP; stored docs contain zero null values and only the keys with real values; public stats aggregate them correctly.
- Full suite: 3,639 passed, 5 skipped. Lint and format clean.

Existing buckets keep their shape (time-series buckets are immutable in place); this stops new churn, and a history repack can reclaim the index separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Click data now omits optional fields when no value is provided, preventing unnecessary `null` values.
  * Empty metadata values are excluded from stored click records.
  * Click time-series storage now uses hourly granularity for improved alignment with production behavior.

* **Tests**
  * Added coverage verifying omitted and populated click fields are serialized correctly.
  * Updated click-handler tests to reflect the streamlined stored data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->