### PR TITLE
fix(docs): stop serving the legacy API docs page, drop a redirect hop

### DIFF
--- a/routes/static_routes.py
+++ b/routes/static_routes.py
@@ -71,29 +71,21 @@ async def favicon(request: Request) -> Response:
 
 # ── Docs / legal ─────────────────────────────────────────────────────────────
 
+# docs.spoo.me still resolves but 301s here, so pointing at it costs a hop.
+DOCS_ROOT = "https://spoo.me/docs"
+
 
 @router.get("/api")
 @limiter.exempt
 async def api_redirect(request: Request) -> Response:
-    if request.query_params.get("old") == "1":
-        return templates.TemplateResponse(
-            request,
-            "api.html",
-            {
-                "host_url": str(request.base_url),
-                "self_promo": True,
-                "self_promo_uri": "https://docs.spoo.me",
-                "self_promo_text": "We have moved and revamped the docs to https://docs.spoo.me",
-            },
-        )
-    return RedirectResponse("https://docs.spoo.me/introduction", status_code=301)
+    return RedirectResponse(DOCS_ROOT + "/introduction", status_code=301)
 
 
 @router.get("/docs")
 @router.get("/docs/")
 @limiter.exempt
 async def docs_redirect(request: Request) -> Response:
-    return RedirectResponse("https://docs.spoo.me", status_code=301)
+    return RedirectResponse(DOCS_ROOT, status_code=301)
 
 
 @router.get("/docs/privacy-policy")
@@ -127,7 +119,7 @@ async def terms_of_service(request: Request) -> Response:
 @router.get("/docs/{path:path}")
 @limiter.exempt
 async def docs_wildcard(path: str, request: Request) -> Response:
-    return RedirectResponse(f"https://docs.spoo.me/{path}", status_code=301)
+    return RedirectResponse(f"{DOCS_ROOT}/{path}", status_code=301)
 
 
 # ── Contact ──────────────────────────────────────────────────────────────────

--- a/templates/api.html
+++ b/templates/api.html
@@ -1,3 +1,5 @@
+<!-- Reference copy of the pre-Mintlify API docs. No route renders this;
+     the live docs are at spoo.me/docs. -->
 <!DOCTYPE html>
 <html lang="en">
 

--- a/tests/integration/test_static_routes.py
+++ b/tests/integration/test_static_routes.py
@@ -135,7 +135,7 @@ def test_docs_redirects_to_external():
     with TestClient(app, follow_redirects=False) as c:
         resp = c.get("/docs")
     assert resp.status_code == 301
-    assert resp.headers["location"] == "https://docs.spoo.me"
+    assert resp.headers["location"] == "https://spoo.me/docs"
 
 
 def test_docs_wildcard_redirects():
@@ -143,7 +143,7 @@ def test_docs_wildcard_redirects():
     with TestClient(app, follow_redirects=False) as c:
         resp = c.get("/docs/some-topic")
     assert resp.status_code == 301
-    assert resp.headers["location"] == "https://docs.spoo.me/some-topic"
+    assert resp.headers["location"] == "https://spoo.me/docs/some-topic"
 
 
 # ── Legal pages ──────────────────────────────────────────────────────────────
@@ -290,3 +290,13 @@ def test_report_post_success():
         )
     assert resp.status_code == 200
     svc.send_report.assert_called_once()
+
+
+def test_the_legacy_api_docs_page_is_gone():
+    """?old=1 used to render a full copy of the pre-Mintlify docs: indexable,
+    self-titled, and competing with the real docs for the same queries."""
+    app = _build_test_app()
+    with TestClient(app, follow_redirects=False) as c:
+        resp = c.get("/api?old=1")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == "https://spoo.me/docs/introduction"


### PR DESCRIPTION
Backend half of the SEO audit fixes. Frontend half is spoo-me/frontend#66.

## The legacy API docs page is gone

`spoo.me/api?old=1` still rendered the entire pre-Mintlify docs page: 200, 81KB, its own `<title>` reading "spoo.me - API Documentation", no `noindex`, and not in the sitemap. An orphaned second copy of the docs, indexable and competing with the real ones for the same queries, while its own body told the reader the docs had moved.

The audit that surfaced this claimed the page had no canonical. It did, pointing at `/api`, which is itself a 301. A canonical aimed at a redirect is a conflicting signal rather than a clean one, so that detail made it slightly worse rather than better.

The `old=1` branch is gone and `/api` now 301s like any other docs path.

`templates/api.html` stays, with a note at the top saying no route renders it. The problem was that the page was reachable and indexable, not that the file exists, and it is the only copy of what the docs looked like before Mintlify.

## One redirect hop removed

`docs.spoo.me/introduction` still resolves, but it 301s to `spoo.me/docs/introduction`. Every redirect pointing at the old host was therefore costing a second hop before landing anywhere real.

`DOCS_ROOT` now points at `spoo.me/docs` and the three redirects use it.

Worth noting for whoever reads this later: `/docs` and `/docs/{path}` never fire in production. The docs proxy handles those paths ahead of the app, which is observable in the response, since `spoo.me/docs` returns a 308 to `/docs/introduction` rather than the 301 this route would give. They are retargeted anyway so the stale hostname is out of the codebase and self-hosted deployments without the proxy land somewhere current.

## Verified

Static route tests pass, with the two docs assertions retargeted and a new one pinning that `?old=1` is a 301 to the live docs rather than a rendered page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated documentation links to redirect to the current documentation site.
  * Standardized `/docs`, `/docs/`, and documentation topic redirects.
  * Updated `/api` requests to redirect directly to the API introduction.
  * Removed access to the outdated legacy API documentation page, ensuring visitors reach the current documentation instead.
  * Clarified that the previous API documentation page is retained only for reference and is no longer available through the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->