### PR TITLE
fix(safety): say what a block does to future links, drop blocklist claim

### DIFF
--- a/services/safety/analyzer.py
+++ b/services/safety/analyzer.py
@@ -233,6 +233,9 @@ class SafetyAnalyzer:
             legacy_count=result.legacy_count,
             sample_url=event.url,
             scope=scope_note,
+            scope_kind={"host": "host", "path_pattern": "pattern", "links": "links"}[
+                scope
+            ],
             follow_up=follow_up,
         )
 
@@ -272,7 +275,7 @@ class SafetyAnalyzer:
                 reason=reason,
             )
             await self._notify_reenforced(
-                event, result, reason, scope=f"pattern: {pattern}"
+                event, result, reason, scope=f"pattern: {pattern}", scope_kind="pattern"
             )
             return matching_blocked_pattern(event.url, (pattern,)) is not None
         # links scope: already blocked and the create gate refuses the exact URL.
@@ -326,10 +329,16 @@ class SafetyAnalyzer:
                 legacy_count=result.legacy_count,
                 sample_url=event.url,
                 scope=f"the judged link only (reached through {event.host})",
+                scope_kind="links",
             )
 
     async def _notify_reenforced(
-        self, event, result, reason: str, scope: str = "host-wide"
+        self,
+        event,
+        result,
+        reason: str,
+        scope: str = "host-wide",
+        scope_kind: str = "host",
     ) -> None:
         """Blocked something: the operator hears about it. Zero blocks stays quiet."""
         if result.blocked_count + result.legacy_count == 0:
@@ -342,6 +351,7 @@ class SafetyAnalyzer:
             legacy_count=result.legacy_count,
             sample_url=event.url,
             scope=f"{scope} (re-enforced existing verdict)",
+            scope_kind=scope_kind,
         )
 
     async def _escalate(

--- a/services/safety/investigation.py
+++ b/services/safety/investigation.py
@@ -388,6 +388,7 @@ class DeepInvestigator:
                 legacy_count=result.legacy_count,
                 sample_url=event.url,
                 scope="host-wide",
+                scope_kind="host",
                 screenshot=shot,
             )
         elif decision.action == "block_aliases":
@@ -409,7 +410,7 @@ class DeepInvestigator:
                     result.blocked_count,
                     result.legacy_count,
                 )
-                scope_note = f"pattern: {pattern} (proposed for the blocklist)"
+                scope_note, scope_kind = f"pattern: {pattern}", "pattern"
             else:
                 pairs = await self._aliases_to_block(event)
                 if pairs:
@@ -431,7 +432,10 @@ class DeepInvestigator:
                         result.blocked_count,
                         result.legacy_count,
                     )
-                scope_note = "specific links only, host left serving"
+                scope_note, scope_kind = (
+                    "specific links only, host left serving",
+                    "links",
+                )
             await self._notifier.safety_action(
                 host=event.host,
                 reason=verdict.reason,
@@ -440,6 +444,7 @@ class DeepInvestigator:
                 legacy_count=legacy_count,
                 sample_url=event.url,
                 scope=scope_note,
+                scope_kind=scope_kind,
                 screenshot=shot,
             )
         elif decision.action == "apply_list":

--- a/services/safety/notify.py
+++ b/services/safety/notify.py
@@ -8,12 +8,22 @@ and that the screenshot the model judged travels with the verdict.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from infrastructure.ops_notify import OpsNotifier
 
 ACTION_COLOR = 15548997  # red: automatic enforcement happened
 REVIEW_COLOR = 16705372  # yellow: a human decision is needed
+
+ScopeKind = Literal["host", "pattern", "links"]
+
+# What the verdict store, which is the create-time gate, does from now on.
+# Nothing here touches the operator blocklist; saying so is the point.
+_FUTURE: dict[str, str] = {
+    "host": "new links to this host are REFUSED at create (verdict store, not the blocklist)",
+    "pattern": "new links matching the pattern are REFUSED at create; other paths on the host stay open",
+    "links": "this URL (query variants included) is refused at create; the host stays open",
+}
 
 
 def _code(value: object) -> str:
@@ -34,14 +44,16 @@ class SafetyNotifier:
         legacy_count: int,
         sample_url: str | None,
         scope: str = "",
+        scope_kind: ScopeKind | None = None,
         screenshot: bytes | None = None,
         follow_up: str = "",
     ) -> bool:
         """Enforcement already happened; this states the action taken.
-        ``scope`` is its own field because "host-wide" and "one link" are
-        read very differently by the person deciding whether to intervene,
-        and ``follow_up`` is separate so a link-scoped block never reads
-        "host-wide decision..." beside a Scope that says otherwise."""
+        ``scope`` says how far the block reached on links that exist;
+        ``scope_kind`` adds what happens to the next link someone creates,
+        because "host-wide" alone does not answer that. ``follow_up`` is
+        separate so a link-scoped block never reads "host-wide decision..."
+        beside a Scope that says otherwise."""
         fields: list[dict[str, Any]] = [
             {"name": "Destination Host", "value": _code(host)},
             {"name": "Scope", "value": _code(scope or "unspecified")},
@@ -49,6 +61,8 @@ class SafetyNotifier:
             {"name": "Trigger", "value": _code(trigger)},
             {"name": "Links Blocked (v2)", "value": _code(blocked_count)},
         ]
+        if scope_kind:
+            fields.append({"name": "Future links", "value": _code(_FUTURE[scope_kind])})
         if legacy_count:
             fields.append(
                 {"name": "Legacy v1/emoji Blocked", "value": _code(legacy_count)}

--- a/services/safety/providers.py
+++ b/services/safety/providers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Literal, Protocol
 
 from infrastructure.logging import get_logger
 from infrastructure.web_risk import WebRiskClient
@@ -28,13 +28,15 @@ from shared.validators import matching_blocked_pattern
 log = get_logger(__name__)
 
 
+VerdictScope = Literal["host", "links", "path_pattern"]
+
+
 @dataclass(frozen=True)
 class ProviderVerdict:
     tier: VerdictTier
     reason: str
-    # "host", "links" (one exact URL) or "path_pattern" (regex in
-    # ``path_pattern``): how far the evidence reaches, not what it enforces.
-    scope: str = "host"
+    # How far the evidence reaches, not what it enforces.
+    scope: VerdictScope = "host"
     path_pattern: str | None = None
 
 

--- a/tests/unit/services/safety/test_analyzer.py
+++ b/tests/unit/services/safety/test_analyzer.py
@@ -650,6 +650,7 @@ class TestReenforcementNotify:
 
         kw = notifier.safety_action.await_args.kwargs
         assert kw["scope"] == "host-wide (re-enforced existing verdict)"
+        assert kw["scope_kind"] == "host"
         assert kw["reason"] == "old verdict"
 
     @pytest.mark.asyncio

--- a/tests/unit/services/safety/test_investigation.py
+++ b/tests/unit/services/safety/test_investigation.py
@@ -399,11 +399,12 @@ class TestScopeAuthority:
         assert prov["scope"] == "path_pattern"
         assert "sites" in prov["path_pattern"]
         assert prov["scope_justification"] == "shared site builder, 210 creators"
-        # The operator is told the pattern to add, since a pattern reaches
-        # every FUTURE link and only a human may apply it.
+        # The verdict store refuses future matches itself; nothing here writes
+        # to the operator blocklist, so the embed must not say it does.
         kw = notifier.safety_action.await_args.kwargs
         assert kw["scope"].startswith("pattern: ")
-        assert "proposed for the blocklist" in kw["scope"]
+        assert kw["scope_kind"] == "pattern"
+        assert "blocklist" not in kw["scope"]
         assert (
             "pattern" not in kw["reason"]
         )  # the reason is the model's reason, nothing else
@@ -785,6 +786,7 @@ class TestEnactCarriesScopeAndScreenshot:
         enforcer.block_host.assert_awaited_once()
         kw = notifier.safety_action.await_args.kwargs
         assert kw["scope"] == "host-wide"
+        assert kw["scope_kind"] == "host"
         # The judged URL's render, not the root fetched after it.
         assert kw["screenshot"] == b"the-page"
 

--- a/tests/unit/services/safety/test_notify.py
+++ b/tests/unit/services/safety/test_notify.py
@@ -111,3 +111,51 @@ class TestReviewEmbed:
         f = _fields(ops)
         assert "classification: uncertain" in f["Context"]
         assert f["Sample URL"] == "```https://h/x```"
+
+
+class TestFutureLinks:
+    """Scope says how far the block reached on links that already exist.
+    It says nothing about the next link someone creates, and it must never
+    imply the operator blocklist changed: nothing in the pipeline writes to
+    it, the verdict store is the create-time gate."""
+
+    @pytest.mark.asyncio
+    async def test_host_kind_says_new_links_are_refused(self):
+        n, ops = _notifier()
+        await _action(n, scope="host-wide", scope_kind="host")
+        f = _fields(ops)["Future links"]
+        assert "new links to this host are REFUSED at create" in f
+        assert "not the blocklist" in f
+
+    @pytest.mark.asyncio
+    async def test_pattern_kind_says_matches_refused_host_stays_open(self):
+        n, ops = _notifier()
+        await _action(
+            n, scope="pattern: ^https://evil.example/l.*", scope_kind="pattern"
+        )
+        f = _fields(ops)["Future links"]
+        assert "matching the pattern are REFUSED" in f
+        assert "other paths on the host stay open" in f
+
+    @pytest.mark.asyncio
+    async def test_links_kind_says_host_stays_open(self):
+        n, ops = _notifier()
+        await _action(n, scope="the judged link only", scope_kind="links")
+        f = _fields(ops)["Future links"]
+        assert "query variants included" in f
+        assert "the host stays open" in f
+
+    @pytest.mark.asyncio
+    async def test_no_kind_no_field(self):
+        n, ops = _notifier()
+        await _action(n, scope="host-wide")
+        assert "Future links" not in _fields(ops)
+
+    def test_future_text_never_promises_the_blocklist(self):
+        """A "proposed for the blocklist" claim shipped and survived two
+        review rounds. Pin it out."""
+        from services.safety.notify import _FUTURE
+
+        for text in _FUTURE.values():
+            assert "proposed" not in text
+            assert "blocklist" not in text.replace("not the blocklist", "")


### PR DESCRIPTION
## What

The Discord block embed gets a **Future links** field, derived from the block's scope kind:

| scope kind | Future links |
|---|---|
| host | new links to this host are REFUSED at create (verdict store, not the blocklist) |
| pattern | new links matching the pattern are REFUSED at create; other paths on the host stay open |
| links | only this exact URL is refused at create; the host stays open |

The pattern branch of `_enact` also claimed the pattern was "proposed for the blocklist". That was never true: nothing in the pipeline writes to the operator blocklist. The verdict store is the create-time gate and it refuses future matches on its own. The claim is removed and a test asserts no future-links text mentions the blocklist.

## Why

The embed answered "how far did this reach on existing links" and nothing else. The operator's real question after a block ping is what happens to the next link, and whether any list changed. Now the embed answers both, and the wording is derived in one place so call sites cannot drift.

## Verification

- `uv run pytest tests/unit tests/integration` (minus the env-only app-token scopes file): 3571 passed, 5 new in `test_notify.py`
- Rendered all three scope kinds locally, fields print as in the table above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Safety notifications now clearly identify whether an action applies to an entire host, a URL pattern, or specific links.
  - Notifications can include relevant “Future links” information based on the action’s scope.
  - Pattern-based notifications now use clearer wording and no longer imply that blocklist changes have been proposed.
  - Redirect screening and re-enforced verdict notifications now display more accurate scope details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->