### PR TITLE
feat(safety): see every destination a link routes to, not only long_url

### DIFF
--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -118,6 +118,10 @@ async def ensure_indexes(
         )
         # Every enforcement query is an equality match on dest.host.
         await _url_col.create_index([("dest.host", 1)], name="dest_host", sparse=True)
+    # Only v2 links carry geo rules or a pre-start page.
+    await urls_v2_col.create_index(
+        [("dest.secondary_hosts", 1)], name="dest_secondary_hosts", sparse=True
+    )
 
     # ── clicks (time-series) ───────────────────────────────────────────────
     # Create the time-series collection if it doesn't exist yet.

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -22,6 +22,18 @@ from schemas.models.url import UrlStatus, UrlV2Doc
 log = get_logger(__name__)
 
 
+def dest_host_filter(host: str) -> dict:
+    """A host verdict reaches links that hide the host in a geo rule or a
+    variant, not only links whose long_url points there. The legacy urls and
+    emojis collections carry no rules, so their host-only queries stay
+    complete without this."""
+    return {"$or": [{"dest.host": host}, {"dest.secondary_hosts": host}]}
+
+
+# Every host a link can route to, for grouping: main plus secondary.
+_ALL_HOSTS = {"$setUnion": [["$dest.host"], {"$ifNull": ["$dest.secondary_hosts", []]}]}
+
+
 # Mongo caps a single query document at 16MB; a host-wide block can name
 # tens of thousands of (alias, domain) pairs, so the $or is chunked.
 _ALIAS_CHUNK = 1_000
@@ -478,7 +490,7 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         deliberately status-blind: a re-delivered block must still evict
         entries the first attempt flipped but failed to evict."""
         cursor = self._col.find(
-            {"dest.host": host},
+            dest_host_filter(host),
             {"alias": 1, "domain": 1, "long_url": 1},
         ).limit(limit)
         docs = await cursor.to_list(length=limit)
@@ -492,13 +504,24 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         return [(d["alias"], d.get("domain", ""), d.get("long_url", "")) for d in docs]
 
     async def unblock_by_dest_host(self, host: str) -> int:
-        """Flip BLOCKED links pointing at *host* back to ACTIVE, scoped to
-        docs carrying ``blocked_reason`` so a manual operator ban is never
-        undone. Stamps stay; ``unblocked_at`` records the reversal."""
+        """Remove *host* as a block cause and reactivate the links that have
+        no cause left. A link also blocked for another of its destinations
+        stays BLOCKED; a per-link block (``blocked_hosts`` null) is never
+        touched by a host unblock. Blocks stamped before ``blocked_hosts``
+        existed were host-of-long_url blocks, so they match on ``dest.host``.
+        Scoped to docs carrying ``blocked_reason`` so a manual operator ban is
+        never undone. Stamps stay; ``unblocked_at`` records the reversal."""
         now = datetime.now(timezone.utc)
+        await self._col.update_many(
+            {"blocked_hosts": host, "status": UrlStatus.BLOCKED.value},
+            {"$pull": {"blocked_hosts": host}},
+        )
         result = await self._col.update_many(
             {
-                "dest.host": host,
+                "$or": [
+                    {**dest_host_filter(host), "blocked_hosts": []},
+                    {"blocked_hosts": {"$exists": False}, "dest.host": host},
+                ],
                 "status": UrlStatus.BLOCKED.value,
                 "blocked_reason": {"$exists": True},
             },
@@ -519,7 +542,7 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         event set (anonymous links have no possible webhook subscriber)."""
         cursor = self._col.find(
             {
-                "dest.host": host,
+                **dest_host_filter(host),
                 "status": UrlStatus.ACTIVE.value,
                 "owner_id": {"$ne": ANONYMOUS_OWNER_ID},
             }
@@ -543,6 +566,8 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
                     "status": UrlStatus.ACTIVE.value,
                 }
             },
+            # Main host only: a secondary host's own registrable domain is not
+            # the matched one, so fanning it out here would tag it wrongly.
             {
                 "$group": {
                     "_id": "$dest.host",
@@ -570,9 +595,11 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         since_id = ObjectId.from_datetime(since)
         pipeline = [
             {"$match": {"_id": {"$gte": since_id}, "dest.host": {"$exists": True}}},
+            {"$project": {"hosts": _ALL_HOSTS, "long_url": 1}},
+            {"$unwind": "$hosts"},
             {
                 "$group": {
-                    "_id": "$dest.host",
+                    "_id": "$hosts",
                     "sample_url": {"$first": "$long_url"},
                 }
             },
@@ -623,6 +650,8 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
                         "updated_at": now,
                         "blocked_at": now,
                         "blocked_reason": reason,
+                        # Per-link cause: a host unblock never reactivates it.
+                        "blocked_hosts": None,
                     }
                 },
             )
@@ -635,7 +664,7 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         how many links point here, the anon/owned split, total clicks, and
         the earliest sighting. All facts we already own; no network."""
         pipeline = [
-            {"$match": {"dest.host": host}},
+            {"$match": dest_host_filter(host)},
             {
                 "$group": {
                     "_id": None,
@@ -698,7 +727,7 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         benefit of the doubt.
         """
         pipeline = [
-            {"$match": {"dest.host": host}},
+            {"$match": dest_host_filter(host)},
             {
                 "$group": {
                     "_id": None,
@@ -748,15 +777,57 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         audit trail — ``updated_at`` is lossy, these survive later edits."""
         now = datetime.now(timezone.utc)
         result = await self._col.update_many(
-            {"dest.host": host, "status": UrlStatus.ACTIVE.value},
+            {**dest_host_filter(host), "status": UrlStatus.ACTIVE.value},
             {
                 "$set": {
                     "status": UrlStatus.BLOCKED.value,
                     "updated_at": now,
                     "blocked_at": now,
                     "blocked_reason": reason,
+                    "blocked_hosts": [host],
                 }
             },
+        )
+        # Already-blocked links gain this host as a second cause; a pre-field
+        # block's first cause is dest.host. Per-link blocks (null) are skipped.
+        await self._col.update_many(
+            {
+                **dest_host_filter(host),
+                "status": UrlStatus.BLOCKED.value,
+                "blocked_reason": {"$exists": True},
+                "$or": [
+                    {"blocked_hosts": {"$type": "array"}},
+                    {"blocked_hosts": {"$exists": False}},
+                ],
+            },
+            [
+                {
+                    "$set": {
+                        "blocked_hosts": {
+                            "$setUnion": [
+                                {
+                                    "$ifNull": [
+                                        "$blocked_hosts",
+                                        {
+                                            "$cond": [
+                                                {
+                                                    "$eq": [
+                                                        {"$type": "$dest.host"},
+                                                        "string",
+                                                    ]
+                                                },
+                                                ["$dest.host"],
+                                                [],
+                                            ]
+                                        },
+                                    ]
+                                },
+                                [host],
+                            ]
+                        }
+                    }
+                }
+            ],
         )
         return int(result.modified_count)
 

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from schemas.models.base import ANONYMOUS_OWNER_ID, MongoBaseModel, PyObjectId
 from shared.datetime_utils import as_aware_utc
-from shared.url_utils import parse_destination
+from shared.url_utils import link_destination_urls, parse_destination, secondary_hosts
 
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
 
@@ -143,11 +143,49 @@ class UrlDestination(BaseModel):
     host: str = ""
     subdomain: str = ""
     registrable_domain: str = ""
+    # Hosts the link can ALSO route to (geo rules today, A/B variants
+    # later), main host excluded. Enforcement matches host OR these.
+    secondary_hosts: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_url(cls, url: str | None) -> UrlDestination | None:
         parts = parse_destination(url)
         return cls(**parts) if parts else None
+
+    @classmethod
+    def for_link(
+        cls,
+        long_url: str | None,
+        *,
+        geo_rules: dict[str, str] | None = None,
+        variants: list[str] | None = None,
+        pre_start_url: str | None = None,
+    ) -> UrlDestination | None:
+        """Main parts plus every secondary host. None only when nothing
+        about the link parses."""
+        main = parse_destination(long_url)
+        extra = secondary_hosts(
+            link_destination_urls(
+                None,
+                geo_rules=geo_rules,
+                variants=variants,
+                pre_start_url=pre_start_url,
+            ),
+            exclude=(main or {}).get("host", ""),
+        )
+        if main is None and not extra:
+            return None
+        return cls(**(main or {}), secondary_hosts=extra)
+
+    def to_doc(self) -> dict:
+        """Mongo shape: secondary_hosts absent when empty so the sparse index
+        holds only links that actually have them. The backfill is the one
+        writer of an empty list, as its convergence marker for geo links
+        whose rules add no host (see scripts/backfill_url_dest.py)."""
+        data = self.model_dump()
+        if not data["secondary_hosts"]:
+            data.pop("secondary_hosts")
+        return data
 
 
 class UrlV2Doc(MongoBaseModel):
@@ -217,6 +255,9 @@ class UrlV2Doc(MongoBaseModel):
     # deliberately write no host-wide verdict.
     blocked_at: datetime | None = None
     blocked_reason: str | None = None
+    # Host causes of the block; reactivates only when the last one is removed.
+    # None marks a per-link block that no host unblock may undo.
+    blocked_hosts: list[str] | None = None
     # Stamped on reversal; blocked_at/blocked_reason stay.
     unblocked_at: datetime | None = None
     private_stats: bool | None = True  # None for anonymous/unowned URLs

--- a/scripts/backfill_url_dest.py
+++ b/scripts/backfill_url_dest.py
@@ -7,15 +7,21 @@
 #     "tldextract>=5.1",
 # ]
 # ///
-"""One-shot migration: stamp parsed `dest` parts on every url doc missing it.
+"""Migration: stamp parsed `dest` parts on every url doc missing them.
 
-Covers urlsV2 (long_url), urls (url) and emojis (url). Standalone — no spoo
+Covers urlsV2 (long_url), urls (url) and emojis (url). Standalone: no spoo
 project context required. Parse logic mirrors
-``shared/url_utils.parse_destination`` — keep the two in sync.
+``shared/url_utils.parse_destination``; keep the two in sync.
 
 Unparseable destinations are stamped ``dest: null`` so the needs-backfill
 filter converges to zero; null adds nothing to the sparse dest_registrable
 index.
+
+Second pass, urlsV2 only: links with geo_rules or a pre_start_url get
+``dest.secondary_hosts`` (every extra destination host but the main one) so a host block
+reaches links that hide the host in a rule. Idempotent: docs already
+carrying the field are skipped, and a link whose rules add no new host
+gets an empty list so the filter converges.
 
 Usage::
 
@@ -40,6 +46,27 @@ from pymongo import MongoClient, UpdateOne
 from pymongo.errors import BulkWriteError
 
 _FILTER = {"dest": {"$exists": False}}
+_SECONDARY_FILTER = {
+    "$and": [
+        {
+            "$or": [
+                {"geo_rules": {"$type": "object"}},
+                {"pre_start_url": {"$type": "string"}},
+            ]
+        },
+        {
+            "$or": [
+                {
+                    "dest": {"$type": "object"},
+                    "dest.secondary_hosts": {"$exists": False},
+                },
+                # An unparseable long_url left dest null; its geo hosts still count.
+                {"dest": None},
+            ]
+        },
+    ]
+}
+_EMPTY_DEST = {"scheme": "", "host": "", "subdomain": "", "registrable_domain": ""}
 _BATCH = 1_000
 _COLLECTIONS = (("urlsV2", "long_url"), ("urls", "url"), ("emojis", "url"))
 _tld = tldextract.TLDExtract(cache_dir=None, suffix_list_urls=())
@@ -75,17 +102,95 @@ def parse_destination(url: object) -> dict | None:
     }
 
 
+def secondary_urls(doc: dict) -> list:
+    """Every extra destination a link routes to: geo rules and the pre-start page."""
+    geo = doc.get("geo_rules")
+    urls = list(geo.values()) if isinstance(geo, dict) else []
+    if isinstance(doc.get("pre_start_url"), str):
+        urls.append(doc["pre_start_url"])
+    return urls
+
+
+def secondary_hosts(urls: list, main_host: str) -> list[str]:
+    """Mirror of shared/url_utils.secondary_hosts."""
+    hosts = {
+        parts["host"]
+        for parts in (parse_destination(u) for u in urls)
+        if parts is not None and parts["host"] != main_host
+    }
+    return sorted(hosts)
+
+
+def dest_for(doc: dict, url_field: str) -> dict | None:
+    """The full dest stamp for one doc: parsed parts plus secondary hosts."""
+    parts = parse_destination(doc.get(url_field))
+    extra = secondary_hosts(secondary_urls(doc), (parts or {}).get("host", ""))
+    if parts is None and not extra:
+        return None
+    stamp = dict(
+        parts or {"scheme": "", "host": "", "subdomain": "", "registrable_domain": ""}
+    )
+    if extra:
+        stamp["secondary_hosts"] = extra
+    return stamp
+
+
+def _secondary_set(d: dict) -> dict:
+    """What the second pass writes: the list on an existing stamp, or a whole
+    stamp when dest is null. [] is the convergence marker either way."""
+    if isinstance(d.get("dest"), dict):
+        hosts = secondary_hosts(secondary_urls(d), d["dest"].get("host", ""))
+        return {"dest.secondary_hosts": hosts}
+    stamp = dest_for(d, "long_url") or dict(_EMPTY_DEST)
+    stamp.setdefault("secondary_hosts", [])
+    return {"dest": stamp}
+
+
+def backfill_secondary(coll, dry_run: bool) -> None:
+    todo = coll.count_documents(_SECONDARY_FILTER)
+    print(f"[{coll.name}] geo or scheduled links needing secondary_hosts: {todo}")
+    if todo == 0 or dry_run:
+        return
+    stamped = failed = 0
+    last_id = None
+    while True:
+        query = dict(_SECONDARY_FILTER)
+        if last_id is not None:
+            query["_id"] = {"$gt": last_id}
+        batch = list(
+            coll.find(
+                query,
+                {"dest": 1, "long_url": 1, "geo_rules": 1, "pre_start_url": 1},
+            )
+            .sort("_id", 1)
+            .limit(_BATCH)
+        )
+        if not batch:
+            break
+        last_id = batch[-1]["_id"]
+        ops = [UpdateOne({"_id": d["_id"]}, {"$set": _secondary_set(d)}) for d in batch]
+        try:
+            coll.bulk_write(ops, ordered=False)
+        except BulkWriteError as exc:
+            failed += len(exc.details.get("writeErrors", []))
+        stamped += len(batch)
+    remaining = coll.count_documents(_SECONDARY_FILTER)
+    print(
+        f"[{coll.name}] secondary_hosts stamped {stamped - failed}; failed: {failed}; "
+        f"remaining (expect {failed}): {remaining}"
+    )
+
+
 def backfill(coll, url_field: str, dry_run: bool) -> None:
     todo = coll.count_documents(_FILTER)
     print(f"[{coll.name}] docs needing backfill: {todo}")
     if todo == 0:
         return
     if dry_run:
-        sample = coll.find_one(_FILTER, {url_field: 1})
-        print(
-            f"[{coll.name}] sample parse: "
-            f"{parse_destination((sample or {}).get(url_field))}"
+        sample = coll.find_one(
+            _FILTER, {url_field: 1, "geo_rules": 1, "pre_start_url": 1}
         )
+        print(f"[{coll.name}] sample parse: {dest_for(sample or {}, url_field)}")
         return
     done = 0
     failed = 0
@@ -96,15 +201,16 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         query = dict(_FILTER)
         if last_id is not None:
             query["_id"] = {"$gt": last_id}
-        batch = list(coll.find(query, {url_field: 1}).sort("_id", 1).limit(_BATCH))
+        batch = list(
+            coll.find(query, {url_field: 1, "geo_rules": 1, "pre_start_url": 1})
+            .sort("_id", 1)
+            .limit(_BATCH)
+        )
         if not batch:
             break
         last_id = batch[-1]["_id"]
         ops = [
-            UpdateOne(
-                {"_id": d["_id"]},
-                {"$set": {"dest": parse_destination(d.get(url_field))}},
-            )
+            UpdateOne({"_id": d["_id"]}, {"$set": {"dest": dest_for(d, url_field)}})
             for d in batch
         ]
         try:
@@ -147,6 +253,7 @@ def main() -> None:
     db = client[db_name]
     for name, field in _COLLECTIONS:
         backfill(db[name], field, args.dry_run)
+    backfill_secondary(db["urlsV2"], args.dry_run)
     client.close()
 
 

--- a/services/report_intake_service.py
+++ b/services/report_intake_service.py
@@ -38,7 +38,7 @@ from schemas.enums.report import RejectionCode
 from services.public_link_resolver import PublicLinkResolver
 from services.safety.events import SafetyAnalyzeEvent
 from services.safety.sinks import SafetySink
-from shared.url_utils import parse_destination
+from shared.url_utils import link_destination_urls, parse_destination
 
 log = get_logger(__name__)
 
@@ -285,7 +285,7 @@ class ReportIntakeService:
         enqueue never resolves twice).
         """
         seen: set[tuple[str | None, str]] = set()
-        accepted: list[tuple[str | None, str, ReportItemRequest, str | None]] = []
+        accepted: list[tuple[str | None, str, ReportItemRequest, list[str]]] = []
         rejected: list[RejectedItem] = []
 
         for index, item in enumerate(items):
@@ -303,76 +303,93 @@ class ReportIntakeService:
             seen.add(target)
 
             domain, code = target
-            long_url = await self._resolve_long_url(domain, code)
-            if long_url is not None:
-                accepted.append((domain, code, item, long_url or None))
+            destinations = await self._resolve_destinations(domain, code)
+            if destinations is not None:
+                accepted.append((domain, code, item, destinations))
             else:
                 rejected.append(RejectedItem(index, item.code_or_url, "not_found"))
 
         return accepted, rejected
 
-    async def _resolve_long_url(self, domain: str | None, code: str) -> str | None:
-        """Domain-scoped existence check that also yields the destination.
+    async def _resolve_destinations(
+        self, domain: str | None, code: str
+    ) -> list[str] | None:
+        """Domain-scoped existence check that also yields every destination
+        the link routes to (long_url, geo overrides, pre-start page).
 
         System-domain codes resolve via the shared PublicLinkResolver —
         the same generation dispatch (v1/v2/emoji) as the redirect, and
         status-agnostic on purpose: expired/blocked links are still
-        reportable. Custom-domain codes are exact v2 lookups. Returns the
-        stored long_url, "" when the link exists but the destination is
-        unreadable, or None when the code does not exist.
+        reportable. Custom-domain codes are exact v2 lookups. Returns an
+        empty list when the link exists but no destination is readable,
+        or None when the code does not exist.
         """
         if domain is None:
             resolved = await self._resolver.resolve(code)
             if resolved is None:
                 return None
             if resolved.v2_doc is not None:
-                return resolved.v2_doc.long_url
-            return str((resolved.raw_v1 or {}).get("url") or "")
+                doc = resolved.v2_doc
+                return link_destination_urls(
+                    doc.long_url,
+                    geo_rules=doc.geo_rules,
+                    pre_start_url=doc.pre_start_url,
+                )
+            return link_destination_urls(str((resolved.raw_v1 or {}).get("url") or ""))
         doc = await self._url_repo.find_by_alias(code, domain)
-        return doc.long_url if doc is not None else None
+        if doc is None:
+            return None
+        return link_destination_urls(
+            doc.long_url, geo_rules=doc.geo_rules, pre_start_url=doc.pre_start_url
+        )
 
     async def _enqueue_safety_analysis(
-        self, accepted: list[tuple[str | None, str, ReportItemRequest, str | None]]
+        self, accepted: list[tuple[str | None, str, ReportItemRequest, list[str]]]
     ) -> None:
-        """One analysis request per distinct destination host in the batch
-        (many reported codes often point at one campaign host). Best-effort:
-        the sink swallows failures and None means safety is not wired."""
+        """One analysis request per distinct destination host in the batch,
+        every destination of every reported link included (many reported
+        codes often point at one campaign host). Best-effort: the sink
+        swallows failures and None means safety is not wired."""
         if self._safety_sink is None or not accepted:
             return
         by_host: dict[str, SafetyAnalyzeEvent] = {}
-        for domain, code, item, long_url in accepted:
-            parts = parse_destination(long_url)
-            if parts is None:
-                continue
-            host = parts["host"]
-            existing = by_host.get(host)
-            if existing is not None:
-                reasons = set(existing.context.get("reasons", []))
-                reasons.add(item.reason.value)
-                by_host[host] = existing.model_copy(
-                    update={
-                        "context": {
-                            **existing.context,
-                            "reasons": sorted(reasons),
-                            "reported_codes": [
-                                *existing.context.get("reported_codes", []),
-                                f"{domain or self._system_default_domain}/{code}",
-                            ],
-                        }
+        for domain, code, item, destinations in accepted:
+            reported = f"{domain or self._system_default_domain}/{code}"
+            for url in destinations:
+                parts = parse_destination(url)
+                if parts is None:
+                    continue
+                host = parts["host"]
+                existing = by_host.get(host)
+                if existing is not None:
+                    reasons = set(existing.context.get("reasons", []))
+                    reasons.add(item.reason.value)
+                    codes = existing.context.get("reported_codes", [])
+                    known = existing.context.get("link_destinations") or [existing.url]
+                    merged = [*known, *(u for u in destinations if u not in known)]
+                    context = {
+                        **existing.context,
+                        "reasons": sorted(reasons),
+                        "reported_codes": (
+                            codes if reported in codes else [*codes, reported]
+                        ),
                     }
-                )
-                continue
-            by_host[host] = SafetyAnalyzeEvent(
-                url=long_url or "",
-                host=host,
-                registrable_domain=parts["registrable_domain"],
-                trigger="report",
-                context={
+                    if len(merged) > 1:
+                        context["link_destinations"] = merged
+                    by_host[host] = existing.model_copy(update={"context": context})
+                    continue
+                context: dict = {
                     "reasons": [item.reason.value],
-                    "reported_codes": [
-                        f"{domain or self._system_default_domain}/{code}"
-                    ],
-                },
-            )
+                    "reported_codes": [reported],
+                }
+                if len(destinations) > 1:
+                    context["link_destinations"] = destinations
+                by_host[host] = SafetyAnalyzeEvent(
+                    url=url,
+                    host=host,
+                    registrable_domain=parts["registrable_domain"],
+                    trigger="report",
+                    context=context,
+                )
         for event in by_host.values():
             await self._safety_sink.emit(event)

--- a/services/safety/hot.py
+++ b/services/safety/hot.py
@@ -14,7 +14,7 @@ from repositories.verdict_repository import VerdictRepository
 from services.click.consumers.hotness import HotUrl
 from services.safety.events import SafetyAnalyzeEvent
 from services.safety.sinks import SafetySink
-from shared.url_utils import parse_destination
+from shared.url_utils import link_destination_urls, parse_destination
 
 log = get_logger(__name__)
 
@@ -40,28 +40,34 @@ class HotLinkScreen:
 
     async def on_hot(self, hot: HotUrl) -> None:
         try:
-            url = await self._destination(hot)
-            if not url:
-                return
-            parts = parse_destination(url)
-            if parts is None:
-                return
-            if await self._verdict_repo.find_by_host(parts["host"]) is not None:
-                return
-            await self._sink.emit(
-                SafetyAnalyzeEvent(
-                    url=url,
-                    host=parts["host"],
-                    registrable_domain=parts["registrable_domain"],
-                    trigger="hot",
-                    context={
-                        "short_code": hot.short_code,
-                        "domain": hot.domain,
-                        "clicks_in_window": hot.count,
-                    },
+            urls = await self._destinations(hot)
+            seen: set[str] = set()
+            for url in urls:
+                parts = parse_destination(url)
+                if parts is None or parts["host"] in seen:
+                    continue
+                seen.add(parts["host"])
+                if await self._verdict_repo.find_by_host(parts["host"]) is not None:
+                    continue
+                context = {
+                    "short_code": hot.short_code,
+                    "domain": hot.domain,
+                    "clicks_in_window": hot.count,
+                }
+                if len(urls) > 1:
+                    context["link_destinations"] = urls
+                await self._sink.emit(
+                    SafetyAnalyzeEvent(
+                        url=url,
+                        host=parts["host"],
+                        registrable_domain=parts["registrable_domain"],
+                        trigger="hot",
+                        context=context,
+                    )
                 )
-            )
-            log.info("safety_hot_screening", host=parts["host"], alias=hot.short_code)
+                log.info(
+                    "safety_hot_screening", host=parts["host"], alias=hot.short_code
+                )
         except Exception as exc:
             log.warning(
                 "safety_hot_screen_failed",
@@ -70,10 +76,13 @@ class HotLinkScreen:
                 error_type=type(exc).__name__,
             )
 
-    async def _destination(self, hot: HotUrl) -> str | None:
+    async def _destinations(self, hot: HotUrl) -> list[str]:
+        """Every destination the link routes to: main, geo overrides, pre-start page."""
         domain = self._system_domain if hot.domain in ("default", "") else hot.domain
         doc = await self._url_repo.find_by_alias(hot.short_code, domain)
         if doc is not None:
-            return doc.long_url
+            return link_destination_urls(
+                doc.long_url, geo_rules=doc.geo_rules, pre_start_url=doc.pre_start_url
+            )
         legacy = await self._legacy_repo.find_by_id(hot.short_code)
-        return legacy.url if legacy is not None else None
+        return link_destination_urls(legacy.url) if legacy is not None else []

--- a/services/safety/investigation.py
+++ b/services/safety/investigation.py
@@ -238,6 +238,17 @@ async def build_evidence_bundle(
         f"first seen: {history['first_seen'] or 'unknown'}",
         f"links edited after creation: {history['edited_count']}",
         "",
+    ]
+    others = [u for u in ctx.get("link_destinations") or [] if u != event.url]
+    if others:
+        lines += [
+            "## Other destinations of the reported link(s) (geo rules or variants)",
+            *(f"- {u}" for u in others),
+            "A visitor to one of the reported links may be routed to any of "
+            "these; judge the destination above knowing it is one of a set.",
+            "",
+        ]
+    lines += [
         "## Why this reached you",
         f"trigger: {event.trigger}",
     ]

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -162,10 +162,6 @@ async def _handle_long_url(
             log.info("url_update_rejected", reason=rejection.code)
             raise ValidationError(rejection.public_message, field="long_url")
         ops["long_url"] = request.long_url
-        # Destination changed -> re-stamp the parsed parts (meta_tags
-        # precedent: plain model_dump dicts go into ops).
-        dest = UrlDestination.from_url(request.long_url)
-        ops["dest"] = dest.model_dump() if dest else None
 
 
 async def _handle_alias(
@@ -987,7 +983,11 @@ class UrlService:
             creation_ip=client_ip,
             created_via=created_via,
             long_url=request.long_url,
-            dest=UrlDestination.from_url(request.long_url),
+            dest=UrlDestination.for_link(
+                request.long_url,
+                geo_rules=request.geo_rules,
+                pre_start_url=request.pre_start_url or None,
+            ),
             password=password_hash,
             block_bots=request.block_bots,
             max_clicks=request.max_clicks,
@@ -1021,6 +1021,8 @@ class UrlService:
         for _absent_if_none in ("claim_token_hash", "claimed_at", "dest"):
             if doc.get(_absent_if_none) is None:
                 doc.pop(_absent_if_none, None)
+        if url_doc.dest is not None:
+            doc["dest"] = url_doc.dest.to_doc()
 
         # 8. Insert
         inserted_id = await self._url_repo.insert(doc)
@@ -1190,6 +1192,15 @@ class UrlService:
                 update_ops.get("starts_at", existing.starts_at),
                 update_ops.get("expire_after", existing.expire_after),
             )
+
+        # Any destination change re-stamps dest, secondary hosts included.
+        if {"long_url", "geo_rules", "pre_start_url"} & update_ops.keys():
+            dest = UrlDestination.for_link(
+                update_ops.get("long_url", existing.long_url),
+                geo_rules=update_ops.get("geo_rules", existing.geo_rules),
+                pre_start_url=update_ops.get("pre_start_url", existing.pre_start_url),
+            )
+            update_ops["dest"] = dest.to_doc() if dest else None
 
         # Handlers don't see the request context; stamp the writer's IP
         # onto a fresh meta_tags value here (None stays None on clears).

--- a/shared/url_utils.py
+++ b/shared/url_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import re
+from collections.abc import Iterable
 from urllib.parse import urlparse, urlsplit
 
 import idna
@@ -86,6 +87,40 @@ def parse_destination(url: str | None) -> dict | None:
         "subdomain": subdomain,
         "registrable_domain": registrable,
     }
+
+
+def link_destination_urls(
+    long_url: str | None,
+    *,
+    geo_rules: dict[str, str] | None = None,
+    variants: Iterable[str] | None = None,
+    pre_start_url: str | None = None,
+) -> list[str]:
+    """Every URL a link can send a visitor to: the main destination, geo
+    overrides, A/B variants, and the pre-start page a scheduled link shows
+    before it goes live. Distinct, first occurrence kept."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for url in (
+        long_url,
+        *(geo_rules or {}).values(),
+        *(variants or ()),
+        pre_start_url,
+    ):
+        if isinstance(url, str) and url and url not in seen:
+            seen.add(url)
+            out.append(url)
+    return out
+
+
+def secondary_hosts(urls: Iterable[str], *, exclude: str = "") -> list[str]:
+    """Distinct parsed hosts of *urls* without *exclude*, sorted."""
+    hosts = {
+        parts["host"]
+        for parts in (parse_destination(u) for u in urls)
+        if parts is not None and parts["host"] != exclude
+    }
+    return sorted(hosts)
 
 
 def extract_hostname(url: str | None) -> str | None:

--- a/tests/integration/api_v1/test_reports.py
+++ b/tests/integration/api_v1/test_reports.py
@@ -718,3 +718,71 @@ def test_safety_sink_absent_means_no_enqueue_and_no_failure():
         resp = c.post(_URL, json={"items": _items("abc1234")})
     assert resp.status_code == 200
     assert len(reports_col.update_calls) == 1
+
+
+def test_reported_link_enqueues_every_destination_including_geo_rules():
+    """A phish hidden in a geo rule must be judged, not just long_url."""
+    doc = _make_v2_doc("geo1234")
+    doc.long_url = "https://clean.example/"
+    doc.geo_rules = {
+        "IN": "https://hidden.example/kit",
+        "US": "https://clean.example/us",
+    }
+    sink = _CapturingSafetySink()
+    service, _, _ = _build_service(v2_docs=[doc], safety_sink=sink)
+
+    with _client(service) as c:
+        resp = c.post(
+            _URL, json={"items": [{"code_or_url": "geo1234", "reason": "phishing"}]}
+        )
+    assert resp.status_code == 200
+
+    # One event per distinct host: the US rule echoing the main host is folded in.
+    assert len(sink.events) == 2
+    by_host = {e.host: e for e in sink.events}
+    assert set(by_host) == {"clean.example", "hidden.example"}
+    hidden = by_host["hidden.example"]
+    assert hidden.url == "https://hidden.example/kit"
+    assert hidden.context["reported_codes"] == [f"{_DOMAIN}/geo1234"]
+    assert hidden.context["link_destinations"] == [
+        "https://clean.example/",
+        "https://hidden.example/kit",
+        "https://clean.example/us",
+    ]
+
+
+def test_links_sharing_a_host_keep_every_links_destinations():
+    """Two reported links land on one host event; the bundle must still see
+    the geo destinations of BOTH, not only the first link's."""
+    doc_a = _make_v2_doc("aaa1234")
+    doc_a.long_url = "https://shared.example/a"
+    doc_a.geo_rules = {"IN": "https://geo-a.example/"}
+    doc_b = _make_v2_doc("bbb1234")
+    doc_b.long_url = "https://shared.example/b"
+    doc_b.geo_rules = {"BR": "https://geo-b.example/"}
+    sink = _CapturingSafetySink()
+    service, _, _ = _build_service(v2_docs=[doc_a, doc_b], safety_sink=sink)
+
+    with _client(service) as c:
+        resp = c.post(
+            _URL,
+            json={
+                "items": [
+                    {"code_or_url": "aaa1234", "reason": "phishing"},
+                    {"code_or_url": "bbb1234", "reason": "phishing"},
+                ]
+            },
+        )
+    assert resp.status_code == 200
+    assert len(sink.events) == 3
+    shared = {e.host: e for e in sink.events}["shared.example"]
+    assert shared.context["reported_codes"] == [
+        f"{_DOMAIN}/aaa1234",
+        f"{_DOMAIN}/bbb1234",
+    ]
+    assert shared.context["link_destinations"] == [
+        "https://shared.example/a",
+        "https://geo-a.example/",
+        "https://shared.example/b",
+        "https://geo-b.example/",
+    ]

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -112,6 +112,15 @@ class TestEnsureIndexes:
             _c.create_index.assert_any_await(
                 [("dest.registrable_domain", 1)], name="dest_registrable", sparse=True
             )
+        # Secondary hosts exist only on v2 links (geo rules, pre-start page).
+        urls_v2_col.create_index.assert_any_await(
+            [("dest.secondary_hosts", 1)], name="dest_secondary_hosts", sparse=True
+        )
+        for _c in (urls_legacy_col, emojis_col):
+            assert not any(
+                call.kwargs.get("name") == "dest_secondary_hosts"
+                for call in _c.create_index.await_args_list
+            )
         # Scheduler: the task runner's claim index.
         scheduled_tasks_col.create_index.assert_any_await(
             [("enabled", 1), ("next_run_at", 1)], name="ix_claim"

--- a/tests/unit/repositories/test_url_repository.py
+++ b/tests/unit/repositories/test_url_repository.py
@@ -737,3 +737,121 @@ class TestUrlRepositoryOwnerErasure:
         with pytest.raises(OperationFailure):
             async for _ in self._repo(col).iter_by_owner(USER_OID):
                 pass
+
+
+class TestSecondaryHostMatching:
+    """A host verdict must reach links that hide the host in a geo rule."""
+
+    def _col(self):
+        col = make_collection()
+        col.name = "urlsV2"
+        return col
+
+    @pytest.mark.asyncio
+    async def test_block_matches_main_or_secondary_host(self):
+        from repositories.url_repository import UrlRepository, dest_host_filter
+
+        col = self._col()
+        col.update_many = AsyncMock(return_value=MagicMock(modified_count=1))
+        await UrlRepository(col).block_active_by_dest_host("hidden.example", reason="r")
+        # First call flips ACTIVE links; the second records the cause on already-blocked ones.
+        flt, _ops = col.update_many.await_args_list[0].args
+        assert flt["$or"] == dest_host_filter("hidden.example")["$or"]
+        assert {"dest.secondary_hosts": "hidden.example"} in flt["$or"]
+        assert flt["status"] == "ACTIVE"
+
+    @pytest.mark.asyncio
+    async def test_listing_for_eviction_matches_either_field(self):
+        from repositories.url_repository import UrlRepository
+
+        col = self._col()
+        cursor = MagicMock()
+        cursor.limit = MagicMock(return_value=cursor)
+        cursor.to_list = AsyncMock(return_value=[])
+        col.find = MagicMock(return_value=cursor)
+        await UrlRepository(col).list_by_dest_host_with_urls("hidden.example")
+        flt = col.find.call_args.args[0]
+        assert {"dest.secondary_hosts": "hidden.example"} in flt["$or"]
+
+    @pytest.mark.asyncio
+    async def test_recent_hosts_sweep_unwinds_secondary_hosts(self):
+        from datetime import datetime, timezone
+
+        from repositories.url_repository import UrlRepository
+
+        col = self._col()
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(return_value=[])
+        col.aggregate = AsyncMock(return_value=cursor)
+        await UrlRepository(col).list_recent_destination_hosts(
+            datetime(2026, 9, 1, tzinfo=timezone.utc)
+        )
+        pipeline = col.aggregate.await_args.args[0]
+        stages = [next(iter(s)) for s in pipeline]
+        assert stages == ["$match", "$project", "$unwind", "$group", "$limit"]
+        assert pipeline[3]["$group"]["_id"] == "$hosts"
+
+
+class TestBlockCausesPerHost:
+    """A link blocked for two of its destinations reactivates only when the
+    last cause is removed; a per-link block is never undone by a host
+    unblock; blocks stamped before the field are host-of-long_url blocks."""
+
+    def _repo(self):
+        from repositories.url_repository import UrlRepository
+
+        col = make_collection()
+        col.name = "urlsV2"
+        col.update_many = AsyncMock(return_value=MagicMock(modified_count=1))
+        return UrlRepository(col), col
+
+    @pytest.mark.asyncio
+    async def test_host_block_stamps_its_cause_and_adds_to_already_blocked_links(self):
+        repo, col = self._repo()
+        await repo.block_active_by_dest_host("b.example", reason="r")
+        flip, add_cause = col.update_many.await_args_list
+        assert flip.args[1]["$set"]["blocked_hosts"] == ["b.example"]
+        assert add_cause.args[0]["status"] == "BLOCKED"
+        assert {"blocked_hosts": {"$type": "array"}} in add_cause.args[0]["$or"]
+        union = add_cause.args[1][0]["$set"]["blocked_hosts"]["$setUnion"]
+        assert union[1] == ["b.example"]
+
+    @pytest.mark.asyncio
+    async def test_unblock_pulls_the_cause_then_reactivates_only_cause_free_links(self):
+        repo, col = self._repo()
+        await repo.unblock_by_dest_host("a.example")
+        pull, flip = col.update_many.await_args_list
+        assert pull.args == (
+            {"blocked_hosts": "a.example", "status": "BLOCKED"},
+            {"$pull": {"blocked_hosts": "a.example"}},
+        )
+        branches = flip.args[0]["$or"]
+        assert branches[0]["blocked_hosts"] == []
+        assert {"dest.host": "a.example"} in branches[0]["$or"]
+        assert branches[1] == {
+            "blocked_hosts": {"$exists": False},
+            "dest.host": "a.example",
+        }
+        assert flip.args[1]["$set"]["status"] == "ACTIVE"
+
+    @pytest.mark.asyncio
+    async def test_per_link_block_carries_no_host_cause(self):
+        repo, col = self._repo()
+        await repo.block_active_by_aliases([("abc", "spoo.me")], reason="r")
+        assert col.update_many.await_args.args[1]["$set"]["blocked_hosts"] is None
+
+    @pytest.mark.asyncio
+    async def test_second_cause_is_recorded_on_legacy_blocks_too(self):
+        """A link blocked before blocked_hosts existed must not come back when
+        its long_url host is unblocked while a geo host stays blocked."""
+        repo, col = self._repo()
+        await repo.block_active_by_dest_host("b.example", reason="r")
+        _flip, add_cause = col.update_many.await_args_list
+        flt, update = add_cause.args
+        assert {"blocked_hosts": {"$exists": False}} in flt["$or"]
+        assert flt["blocked_reason"] == {"$exists": True}
+        union = update[0]["$set"]["blocked_hosts"]["$setUnion"]
+        # Missing list: seed it with dest.host (the original cause), then add ours.
+        assert union[0]["$ifNull"][0] == "$blocked_hosts"
+        assert union[0]["$ifNull"][1]["$cond"][1] == ["$dest.host"]
+        assert union[1] == ["b.example"]

--- a/tests/unit/schemas/models/test_url.py
+++ b/tests/unit/schemas/models/test_url.py
@@ -469,3 +469,82 @@ class TestEffectiveStatusScheduled:
 
         doc = self._make(starts_at=now() + timedelta(hours=1))
         assert v2_effective_status(doc) == "scheduled"
+
+
+class TestUrlDestinationSecondaryHosts:
+    """Geo rules (and later variants) add destinations; enforcement must be
+    able to find them by host, so the stamp carries every extra host."""
+
+    def test_for_link_collects_geo_hosts_without_the_main_one(self):
+        dest = UrlDestination.for_link(
+            "https://main.example/x",
+            geo_rules={
+                "IN": "https://geo-b.example/in",
+                "US": "https://geo-a.example/us",
+                "DE": "https://main.example/de",
+            },
+        )
+        assert dest is not None
+        assert dest.host == "main.example"
+        assert dest.secondary_hosts == ["geo-a.example", "geo-b.example"]
+
+    def test_variants_plug_into_the_same_field(self):
+        dest = UrlDestination.for_link(
+            "https://main.example/", variants=["https://v2.example/b", "not a url"]
+        )
+        assert dest is not None
+        assert dest.secondary_hosts == ["v2.example"]
+
+    def test_geo_hosts_survive_an_unparseable_main_destination(self):
+        dest = UrlDestination.for_link(
+            "nonsense", geo_rules={"IN": "https://geo.example/"}
+        )
+        assert dest is not None
+        assert dest.host == ""
+        assert dest.secondary_hosts == ["geo.example"]
+
+    def test_nothing_parseable_is_none(self):
+        assert (
+            UrlDestination.for_link("nonsense", geo_rules={"IN": "also nonsense"})
+            is None
+        )
+
+    def test_to_doc_omits_empty_secondary_hosts(self):
+        plain = UrlDestination.for_link("https://main.example/")
+        assert plain is not None
+        assert "secondary_hosts" not in plain.to_doc()
+        geo = UrlDestination.for_link(
+            "https://main.example/", geo_rules={"IN": "https://geo.example/"}
+        )
+        assert geo is not None
+        assert geo.to_doc()["secondary_hosts"] == ["geo.example"]
+
+    def test_docs_predating_the_field_read_as_no_secondary_hosts(self):
+        dest = UrlDestination.model_validate(
+            {
+                "scheme": "https",
+                "host": "a.example",
+                "subdomain": "",
+                "registrable_domain": "a.example",
+            }
+        )
+        assert dest.secondary_hosts == []
+
+
+class TestPreStartUrlIsADestination:
+    """A scheduled link sends visitors to pre_start_url until it goes live,
+    so that host is a destination safety must see."""
+
+    def test_pre_start_host_is_stamped_as_secondary(self):
+        dest = UrlDestination.for_link(
+            "https://main.example/", pre_start_url="https://teaser.example/soon"
+        )
+        assert dest is not None
+        assert dest.secondary_hosts == ["teaser.example"]
+
+    def test_pre_start_on_the_main_host_adds_nothing(self):
+        dest = UrlDestination.for_link(
+            "https://main.example/", pre_start_url="https://main.example/soon"
+        )
+        assert dest is not None
+        assert dest.secondary_hosts == []

--- a/tests/unit/scripts/test_backfill_url_dest.py
+++ b/tests/unit/scripts/test_backfill_url_dest.py
@@ -1,0 +1,128 @@
+"""The backfill stamps secondary hosts on existing geo links, once."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "backfill_url_dest", Path(__file__).parents[3] / "scripts" / "backfill_url_dest.py"
+)
+backfill = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(backfill)
+
+
+def test_secondary_hosts_mirror_the_shared_helper():
+    from shared.url_utils import secondary_hosts
+
+    rules = {
+        "IN": "https://B.example/x",
+        "US": "https://a.example/",
+        "DE": "https://main.example/",
+    }
+    urls = backfill.secondary_urls(
+        {"geo_rules": rules, "pre_start_url": "https://teaser.example/"}
+    )
+    assert backfill.secondary_hosts(urls, "main.example") == [
+        "a.example",
+        "b.example",
+        "teaser.example",
+    ]
+    assert backfill.secondary_hosts(urls, "main.example") == secondary_hosts(
+        urls, exclude="main.example"
+    )
+    assert backfill.secondary_urls({"geo_rules": None, "pre_start_url": None}) == []
+
+
+def test_dest_for_includes_secondary_hosts_only_when_present():
+    plain = backfill.dest_for({"long_url": "https://main.example/p"}, "long_url")
+    assert plain["host"] == "main.example" and "secondary_hosts" not in plain
+    geo = backfill.dest_for(
+        {
+            "long_url": "https://main.example/p",
+            "geo_rules": {"IN": "https://geo.example/"},
+        },
+        "long_url",
+    )
+    assert geo["secondary_hosts"] == ["geo.example"]
+    assert backfill.dest_for({"long_url": "nonsense"}, "long_url") is None
+    scheduled = backfill.dest_for(
+        {
+            "long_url": "https://main.example/",
+            "pre_start_url": "https://teaser.example/",
+        },
+        "long_url",
+    )
+    assert scheduled["secondary_hosts"] == ["teaser.example"]
+
+
+def test_backfill_secondary_stamps_and_reports(capsys):
+    docs = [
+        {
+            "_id": 1,
+            "dest": {"host": "main.example"},
+            "geo_rules": {"IN": "https://geo.example/"},
+        },
+        {
+            "_id": 2,
+            "dest": {"host": "main.example"},
+            "geo_rules": {"IN": "https://main.example/in"},
+        },
+    ]
+    col = MagicMock()
+    col.name = "urlsV2"
+    col.count_documents = MagicMock(side_effect=[2, 0])
+    cursor = MagicMock()
+    cursor.sort.return_value.limit = MagicMock(side_effect=[docs, []])
+    col.find = MagicMock(return_value=cursor)
+
+    backfill.backfill_secondary(col, dry_run=False)
+
+    ops = col.bulk_write.call_args.args[0]
+    sets = {op._filter["_id"]: op._doc["$set"]["dest.secondary_hosts"] for op in ops}
+    # A rule that adds no new host still gets [] so the filter converges.
+    assert sets == {1: ["geo.example"], 2: []}
+    out = capsys.readouterr().out
+    assert "geo or scheduled links needing secondary_hosts: 2" in out
+    assert "secondary_hosts stamped 2; failed: 0; remaining (expect 0): 0" in out
+
+
+def test_backfill_secondary_dry_run_writes_nothing(capsys):
+    col = MagicMock()
+    col.name = "urlsV2"
+    col.count_documents = MagicMock(return_value=5)
+    backfill.backfill_secondary(col, dry_run=True)
+    col.bulk_write.assert_not_called()
+    assert "needing secondary_hosts: 5" in capsys.readouterr().out
+
+
+def test_secondary_pass_repairs_a_null_dest_with_valid_geo_hosts():
+    stamp = backfill._secondary_set(
+        {
+            "_id": 9,
+            "dest": None,
+            "long_url": "nonsense",
+            "geo_rules": {"IN": "https://geo.example/"},
+        }
+    )
+    assert stamp == {
+        "dest": {
+            "scheme": "",
+            "host": "",
+            "subdomain": "",
+            "registrable_domain": "",
+            "secondary_hosts": ["geo.example"],
+        }
+    }
+    # Nothing parseable at all still converges instead of matching forever.
+    nothing = backfill._secondary_set(
+        {
+            "_id": 10,
+            "dest": None,
+            "long_url": "nonsense",
+            "geo_rules": {"IN": "also nonsense"},
+        }
+    )
+    assert nothing["dest"]["secondary_hosts"] == []
+    assert backfill._SECONDARY_FILTER["$and"][1]["$or"][1] == {"dest": None}

--- a/tests/unit/services/safety/test_hot.py
+++ b/tests/unit/services/safety/test_hot.py
@@ -71,3 +71,62 @@ class TestHotLinkScreen:
         url_repo2.find_by_alias = AsyncMock(side_effect=RuntimeError("mongo down"))
         await screen2.on_hot(_hot())
         sink2.emit.assert_not_awaited()
+
+
+class TestHotLinkScreenSecondaryDestinations:
+    @pytest.mark.asyncio
+    async def test_geo_destinations_each_get_an_event(self):
+        doc = MagicMock(
+            long_url="https://clean.example/",
+            geo_rules={
+                "IN": "https://hidden.example/kit",
+                "US": "https://clean.example/us",
+            },
+        )
+        screen, _u, sink = _screen(v2_doc=doc)
+
+        await screen.on_hot(_hot())
+
+        hosts = [c.args[0].host for c in sink.emit.await_args_list]
+        assert hosts == ["clean.example", "hidden.example"]
+        event = sink.emit.await_args_list[1].args[0]
+        assert event.url == "https://hidden.example/kit"
+        assert event.context["link_destinations"] == [
+            "https://clean.example/",
+            "https://hidden.example/kit",
+            "https://clean.example/us",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_verdicted_geo_host_is_skipped_but_main_still_screened(self):
+        doc = MagicMock(
+            long_url="https://clean.example/",
+            geo_rules={"IN": "https://known.example/"},
+        )
+        screen, _u, sink = _screen(v2_doc=doc)
+        screen._verdict_repo.find_by_host = AsyncMock(
+            side_effect=lambda h: MagicMock() if h == "known.example" else None
+        )
+
+        await screen.on_hot(_hot())
+
+        assert [c.args[0].host for c in sink.emit.await_args_list] == ["clean.example"]
+
+    @pytest.mark.asyncio
+    async def test_single_destination_carries_no_link_destinations(self):
+        doc = MagicMock(long_url="https://only.example/", geo_rules=None)
+        screen, _u, sink = _screen(v2_doc=doc)
+        await screen.on_hot(_hot())
+        assert "link_destinations" not in sink.emit.await_args.args[0].context
+
+    @pytest.mark.asyncio
+    async def test_pre_start_destination_is_screened_too(self):
+        doc = MagicMock(
+            long_url="https://clean.example/",
+            geo_rules=None,
+            pre_start_url="https://teaser.example/soon",
+        )
+        screen, _u, sink = _screen(v2_doc=doc)
+        await screen.on_hot(_hot())
+        hosts = [c.args[0].host for c in sink.emit.await_args_list]
+        assert hosts == ["clean.example", "teaser.example"]

--- a/tests/unit/services/safety/test_investigation.py
+++ b/tests/unit/services/safety/test_investigation.py
@@ -799,3 +799,66 @@ class TestEnactCarriesScopeAndScreenshot:
         await inv.investigate(_event())
 
         assert notifier.safety_action.await_args.kwargs["screenshot"] is None
+
+
+class TestBundleListsEveryDestination:
+    @pytest.mark.asyncio
+    async def test_other_destinations_of_the_link_are_listed(self):
+        from services.safety.investigation import build_evidence_bundle
+
+        url_repo = AsyncMock()
+        url_repo.destination_history = AsyncMock(
+            return_value={
+                "link_count": 1,
+                "anon_count": 1,
+                "owned_count": 0,
+                "distinct_owners": 0,
+                "total_clicks": 0,
+                "first_seen": None,
+                "edited_count": 0,
+            }
+        )
+        event = SafetyAnalyzeEvent(
+            url="https://hidden.example/kit",
+            host="hidden.example",
+            registrable_domain="hidden.example",
+            trigger="report",
+            context={
+                "link_destinations": [
+                    "https://clean.example/",
+                    "https://hidden.example/kit",
+                ]
+            },
+        )
+        text = await build_evidence_bundle(event, url_repo)
+        assert "## Other destinations of the reported link(s)" in text
+        assert "- https://clean.example/" in text
+        assert "- https://hidden.example/kit" not in text
+        assert text.index("## Other destinations") < text.index(
+            "## Why this reached you"
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_destination_link_has_no_section(self):
+        from services.safety.investigation import build_evidence_bundle
+
+        url_repo = AsyncMock()
+        url_repo.destination_history = AsyncMock(
+            return_value={
+                "link_count": 1,
+                "anon_count": 1,
+                "owned_count": 0,
+                "distinct_owners": 0,
+                "total_clicks": 0,
+                "first_seen": None,
+                "edited_count": 0,
+            }
+        )
+        event = SafetyAnalyzeEvent(
+            url="https://only.example/",
+            host="only.example",
+            registrable_domain="only.example",
+            trigger="report",
+            context={},
+        )
+        assert "Other destinations" not in await build_evidence_bundle(event, url_repo)

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -1154,8 +1154,8 @@ class TestUrlServiceUpdate:
         from schemas.dto.requests.url import UpdateUrlRequest
 
         monkeypatch.setattr(
-            "services.url_service.UrlDestination.from_url",
-            classmethod(lambda cls, url: None),
+            "services.url_service.UrlDestination.for_link",
+            classmethod(lambda cls, long_url, **_: None),
         )
         req = UpdateUrlRequest(long_url="https://b.new-dest.com/x")
         await svc.update(URL_OID, req, USER_OID)
@@ -4082,3 +4082,140 @@ class TestUrlServiceScheduling:
                         assert (doc.effective_status == UrlStatus.SCHEDULED) == (
                             _matches_scheduled_clause(doc, now)
                         ), case
+
+
+class TestSecondaryDestinationStamping:
+    """A blocked host hidden in a geo rule must be findable by host."""
+
+    @pytest.mark.asyncio
+    async def test_create_with_geo_rules_stamps_secondary_hosts(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://clean.example/",
+            geo_rules={"IN": "https://hidden.example/kit"},
+        )
+        await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        inserted = url_repo.insert.call_args.args[0]
+        assert inserted["dest"]["host"] == "clean.example"
+        assert inserted["dest"]["secondary_hosts"] == ["hidden.example"]
+
+    @pytest.mark.asyncio
+    async def test_create_without_geo_rules_writes_no_secondary_field(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        await svc.create(
+            CreateUrlRequest(long_url="https://clean.example/"),
+            owner_id=USER_OID,
+            client_ip="1.2.3.4",
+        )
+        # Absent, not [] or null: the sparse index holds only real cases.
+        assert "secondary_hosts" not in url_repo.insert.call_args.args[0]["dest"]
+
+    @pytest.mark.asyncio
+    async def test_update_geo_rules_restamps_secondary_hosts(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        existing = make_url_v2_doc()
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = True
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        req = UpdateUrlRequest(geo_rules={"BR": "https://hidden.example/br"})
+        await svc.update(URL_OID, req, USER_OID)
+
+        written = url_repo.update.call_args[0][1]["$set"]
+        assert written["geo_rules"] == {"BR": "https://hidden.example/br"}
+        assert written["dest"]["secondary_hosts"] == ["hidden.example"]
+        from shared.url_utils import parse_destination
+
+        assert written["dest"]["host"] == parse_destination(existing.long_url)["host"]
+
+    @pytest.mark.asyncio
+    async def test_clearing_geo_rules_drops_secondary_hosts(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        existing = make_url_v2_doc()
+        existing.geo_rules = {"BR": "https://hidden.example/br"}
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = True
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(URL_OID, UpdateUrlRequest(geo_rules=None), USER_OID)
+
+        written = url_repo.update.call_args[0][1]["$set"]
+        assert written["geo_rules"] is None
+        assert "secondary_hosts" not in written["dest"]
+
+
+class TestPreStartUrlStamping:
+    @pytest.mark.asyncio
+    async def test_create_with_pre_start_url_stamps_its_host(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from datetime import timedelta
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://clean.example/",
+            starts_at=datetime.now(timezone.utc) + timedelta(days=1),
+            pre_start_url="https://teaser.example/soon",
+        )
+        await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        inserted = url_repo.insert.call_args.args[0]
+        assert inserted["dest"]["secondary_hosts"] == ["teaser.example"]
+
+    @pytest.mark.asyncio
+    async def test_update_pre_start_url_restamps_dest(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        existing = make_url_v2_doc()
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = True
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(
+            URL_OID,
+            UpdateUrlRequest(pre_start_url="https://teaser.example/soon"),
+            USER_OID,
+        )
+
+        written = url_repo.update.call_args[0][1]["$set"]
+        assert written["pre_start_url"] == "https://teaser.example/soon"
+        assert written["dest"]["secondary_hosts"] == ["teaser.example"]

--- a/tests/unit/test_ab_testing_launch_guard.py
+++ b/tests/unit/test_ab_testing_launch_guard.py
@@ -1,0 +1,40 @@
+"""Tripwire: A/B variants must not go live before safety can see them.
+
+Variants add destinations exactly like geo rules do. Safety enforcement
+matches ``dest.host`` or ``dest.secondary_hosts``; a variant host that is
+never stamped there matches nothing. The flag does not exist yet; this
+test names the work the moment someone adds it and flips it on.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from config import AppSettings
+from schemas.models.url import UrlDestination
+
+_FLAGS = ("ab_testing_enabled", "ab_variants_enabled")
+
+_WORK = """
+A/B variants were enabled but safety cannot see variant destinations.
+Required before shipping them:
+
+  1. pass the variant URLs as ``variants=`` to UrlDestination.for_link at
+     every write point (create, update, backfill) so secondary_hosts
+     carries them
+  2. include variant URLs in link_destination_urls callers (report intake,
+     hot screening) so each variant gets its own safety event
+  3. stamp existing links: scripts/backfill_url_dest.py
+"""
+
+
+def test_ab_variants_stay_dark_until_enforcement_sees_them():
+    settings = AppSettings()
+    if not any(getattr(settings, flag, False) for flag in _FLAGS):
+        return
+    assert "secondary_hosts" in UrlDestination.model_fields, _WORK
+    assert "variants" in inspect.signature(UrlDestination.for_link).parameters, _WORK
+    stamped = UrlDestination.for_link(
+        "https://main.example/", variants=["https://variant.example/b"]
+    )
+    assert stamped is not None and stamped.secondary_hosts == ["variant.example"], _WORK

--- a/tests/unit/test_geo_launch_guard.py
+++ b/tests/unit/test_geo_launch_guard.py
@@ -18,10 +18,10 @@ _WORK = """
 geo targeting was enabled (GEO_RULES_ENABLED=true) but safety cannot see
 geo destinations. Required before shipping it:
 
-  1. stamp geo destination hosts at every write point, e.g.
-     UrlDestination gains `geo_hosts: list[str]`, plus a sparse index
-  2. enforcement matches dest.host OR dest.geo_hosts (SafetyEnforcer +
-     UrlRepository/legacy repos), so a host block reaches these links
+  1. stamp geo destination hosts at every write point:
+     UrlDestination.secondary_hosts, plus a sparse index
+  2. enforcement matches dest.host OR dest.secondary_hosts (SafetyEnforcer +
+     UrlRepository), so a host block reaches these links
   3. report intake and hot screening emit one event per distinct
      destination, geo included
   4. build_evidence_bundle lists geo destinations so the deep tier
@@ -33,4 +33,8 @@ geo destinations. Required before shipping it:
 def test_geo_targeting_stays_dark_until_enforcement_sees_it():
     if not AppSettings().geo_rules_enabled:
         return
-    assert "geo_hosts" in UrlDestination.model_fields, _WORK
+    assert "secondary_hosts" in UrlDestination.model_fields, _WORK
+    stamped = UrlDestination.for_link(
+        "https://main.example/", geo_rules={"IN": "https://geo.example/x"}
+    )
+    assert stamped is not None and stamped.secondary_hosts == ["geo.example"], _WORK


### PR DESCRIPTION
Beads ticket spoo-v3f.37.

## What

URL safety only ever saw a link's `long_url`. Geo rules add destinations that the blocklist enforcer, report intake, hot screening and the evidence bundle never looked at, so a phish hidden in a rule stayed up. This is why geo targeting is held dark by `tests/unit/test_geo_launch_guard.py`.

- `UrlDestination.secondary_hosts`: every host the link can also route to. Sources today: geo rules and the scheduling `pre_start_url` from #349 (visitors go there until the link is live); A/B variants plug into the same call. Stamped at create and on any update touching `long_url`, `geo_rules` or `pre_start_url`; absent when empty so the new sparse index stays lean.
- `dest_host_filter(host)` in the URL repository matches `dest.host` or `dest.secondary_hosts`. Used by block, unblock, eviction listing, owned listing, destination history and host breadth. Sweep aggregations unwind every host of a link.
- Report intake and hot screening emit one safety event per distinct destination of the link, with `context.link_destinations` when there are several. The evidence bundle lists the link's other destinations.
- `scripts/backfill_url_dest.py` stamps existing geo links in an idempotent second pass.
- The geo tripwire asserts the real stamp; a matching tripwire covers the future A/B flag.

- Blocks record their host causes in `blocked_hosts`; a host unblock removes its cause and reactivates only links with none left, and per-link blocks are never touched by a host unblock.

## Proof (worktree app against local Mongo and Redis, geo enabled)

Geo link `7xPbX6z` with a clean `long_url` and a geo rule to `hidden-geo.test`; control link to the same clean host with no rule.

```
GEO  dest: {host: clean-geo.test, secondary_hosts: [hidden-geo.test]}
CTRL dest: {host: clean-geo.test}            (no secondary_hosts field)
before block: both 302
SafetyEnforcer.block_host("hidden-geo.test"): blocked_count=1 legacy_count=0 cache_invalidated=1
list_by_dest_host_with_urls("hidden-geo.test") -> [("7xPbX6z", ...)]
after block: GET /7xPbX6z -> 451, GET /norkOIF -> 302
backfill after unsetting the field: "geo links needing secondary_hosts: 1 ... stamped 1 ... remaining 0"; second run 0
```

## Tests

`GEO_RULES_ENABLED=true uv run pytest tests/unit tests/integration` (app-token scopes file deselected, env-only): 3790 passed after rebasing onto main (link scheduling and tags), 31 new.

Follow-ups (feed-delta sweep by registrable domain, L1 counters on secondary hosts) are in #343 stacked on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links now track alternate destinations from geo rules, variants, and pre-start pages.
  * Safety screening and investigations evaluate every destination a link may reach.
  * Host-based blocking and unblocking apply consistently across primary and alternate destinations.
  * Destination metadata updates automatically when routing settings change.

* **Bug Fixes**
  * Prevented per-link blocks from being unintentionally reversed by host-based unblocking.
  * Improved handling of links with multiple destination hosts and consolidated safety reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->