### PR TITLE
feat(safety): feed-delta sweep and L1 counters see secondary destinations

### DIFF
--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -122,6 +122,11 @@ async def ensure_indexes(
     await urls_v2_col.create_index(
         [("dest.secondary_hosts", 1)], name="dest_secondary_hosts", sparse=True
     )
+    await urls_v2_col.create_index(
+        [("dest.secondary_registrable", 1)],
+        name="dest_secondary_registrable",
+        sparse=True,
+    )
 
     # ── clicks (time-series) ───────────────────────────────────────────────
     # Create the time-series collection if it doesn't exist yet.

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -18,6 +18,7 @@ from infrastructure.logging import get_logger
 from repositories.base import BaseRepository
 from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.url import UrlStatus, UrlV2Doc
+from shared.url_utils import parse_destination
 
 log = get_logger(__name__)
 
@@ -32,6 +33,43 @@ def dest_host_filter(host: str) -> dict:
 
 # Every host a link can route to, for grouping: main plus secondary.
 _ALL_HOSTS = {"$setUnion": [["$dest.host"], {"$ifNull": ["$dest.secondary_hosts", []]}]}
+# Every URL the link routes to; the sweeps pick the one on the host they emit.
+_ALL_URLS = {
+    "$concatArrays": [
+        ["$long_url"],
+        {
+            "$map": {
+                "input": {"$objectToArray": {"$ifNull": ["$geo_rules", {}]}},
+                "as": "rule",
+                "in": "$$rule.v",
+            }
+        },
+        {
+            "$cond": [
+                {"$eq": [{"$type": "$pre_start_url"}, "string"]},
+                ["$pre_start_url"],
+                [],
+            ]
+        },
+    ]
+}
+# (host, registrable) pairs for every destination; secondary_registrable is
+# index-aligned with secondary_hosts by construction (UrlDestination.for_link).
+# $zip stops at the shorter list: a doc stamped before secondary_registrable
+# existed yields no pairs until the backfill's second pass re-stamps it.
+_HOST_PAIRS = {
+    "$concatArrays": [
+        [["$dest.host", "$dest.registrable_domain"]],
+        {
+            "$zip": {
+                "inputs": [
+                    {"$ifNull": ["$dest.secondary_hosts", []]},
+                    {"$ifNull": ["$dest.secondary_registrable", []]},
+                ]
+            }
+        },
+    ]
+}
 
 
 # Mongo caps a single query document at 16MB; a host-wide block can name
@@ -44,6 +82,24 @@ def _alias_chunks(
 ) -> list[list[dict[str, str]]]:
     clauses = [{"alias": a, "domain": d} for a, d in pairs]
     return [clauses[i : i + _ALIAS_CHUNK] for i in range(0, len(clauses), _ALIAS_CHUNK)]
+
+
+def _host_samples(docs: list[dict]) -> list[tuple[str, str]]:
+    """(host, sample URL on that host) per grouped row. A secondary host's
+    sample must be the geo or variant URL, not the link's main destination,
+    or the analyzer screens the wrong page."""
+    out: list[tuple[str, str]] = []
+    for d in docs:
+        host = d.get("_id")
+        if not host:
+            continue
+        urls = [u for u in d.get("urls") or [] if isinstance(u, str) and u]
+        sample = next(
+            (u for u in urls if (parse_destination(u) or {}).get("host") == host),
+            urls[0] if urls else "",
+        )
+        out.append((host, sample))
+    return out
 
 
 class UrlRepository(BaseRepository[UrlV2Doc]):
@@ -562,16 +618,20 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         pipeline = [
             {
                 "$match": {
-                    "dest.registrable_domain": registrable_domain,
+                    "$or": [
+                        {"dest.registrable_domain": registrable_domain},
+                        {"dest.secondary_registrable": registrable_domain},
+                    ],
                     "status": UrlStatus.ACTIVE.value,
                 }
             },
-            # Main host only: a secondary host's own registrable domain is not
-            # the matched one, so fanning it out here would tag it wrongly.
+            {"$project": {"pairs": _HOST_PAIRS, "urls": _ALL_URLS}},
+            {"$unwind": "$pairs"},
+            {"$match": {"pairs.1": registrable_domain}},
             {
                 "$group": {
-                    "_id": "$dest.host",
-                    "sample_url": {"$first": "$long_url"},
+                    "_id": {"$arrayElemAt": ["$pairs", 0]},
+                    "urls": {"$first": "$urls"},
                 }
             },
             {"$limit": limit},
@@ -584,7 +644,7 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
                 registrable_domain=registrable_domain,
                 limit=limit,
             )
-        return [(d["_id"], d.get("sample_url", "")) for d in docs if d.get("_id")]
+        return _host_samples(docs)
 
     async def list_recent_destination_hosts(
         self, since: datetime, *, limit: int = 20_000
@@ -595,18 +655,18 @@ class UrlRepository(BaseRepository[UrlV2Doc]):
         since_id = ObjectId.from_datetime(since)
         pipeline = [
             {"$match": {"_id": {"$gte": since_id}, "dest.host": {"$exists": True}}},
-            {"$project": {"hosts": _ALL_HOSTS, "long_url": 1}},
+            {"$project": {"hosts": _ALL_HOSTS, "urls": _ALL_URLS}},
             {"$unwind": "$hosts"},
             {
                 "$group": {
                     "_id": "$hosts",
-                    "sample_url": {"$first": "$long_url"},
+                    "urls": {"$first": "$urls"},
                 }
             },
             {"$limit": limit},
         ]
         docs = await self._aggregate(pipeline)
-        return [(d["_id"], d.get("sample_url", "")) for d in docs if d.get("_id")]
+        return _host_samples(docs)
 
     async def list_active_owned_by_aliases(
         self, pairs: list[tuple[str, str]], *, limit: int = 1_000

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -21,7 +21,12 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from schemas.models.base import ANONYMOUS_OWNER_ID, MongoBaseModel, PyObjectId
 from shared.datetime_utils import as_aware_utc
-from shared.url_utils import link_destination_urls, parse_destination, secondary_hosts
+from shared.url_utils import (
+    link_destination_urls,
+    parse_destination,
+    secondary_hosts,
+    secondary_registrables,
+)
 
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
 
@@ -146,6 +151,9 @@ class UrlDestination(BaseModel):
     # Hosts the link can ALSO route to (geo rules today, A/B variants
     # later), main host excluded. Enforcement matches host OR these.
     secondary_hosts: list[str] = Field(default_factory=list)
+    # Registrable domain of each secondary host, same index. Feed sweeps
+    # fan out by domain; this is what lets them reach a hidden host.
+    secondary_registrable: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_url(cls, url: str | None) -> UrlDestination | None:
@@ -164,18 +172,18 @@ class UrlDestination(BaseModel):
         """Main parts plus every secondary host. None only when nothing
         about the link parses."""
         main = parse_destination(long_url)
-        extra = secondary_hosts(
-            link_destination_urls(
-                None,
-                geo_rules=geo_rules,
-                variants=variants,
-                pre_start_url=pre_start_url,
-            ),
-            exclude=(main or {}).get("host", ""),
+        urls = link_destination_urls(
+            None, geo_rules=geo_rules, variants=variants, pre_start_url=pre_start_url
         )
+        exclude = (main or {}).get("host", "")
+        extra = secondary_hosts(urls, exclude=exclude)
         if main is None and not extra:
             return None
-        return cls(**(main or {}), secondary_hosts=extra)
+        return cls(
+            **(main or {}),
+            secondary_hosts=extra,
+            secondary_registrable=secondary_registrables(urls, exclude=exclude),
+        )
 
     def to_doc(self) -> dict:
         """Mongo shape: secondary_hosts absent when empty so the sparse index
@@ -183,8 +191,9 @@ class UrlDestination(BaseModel):
         writer of an empty list, as its convergence marker for geo links
         whose rules add no host (see scripts/backfill_url_dest.py)."""
         data = self.model_dump()
-        if not data["secondary_hosts"]:
-            data.pop("secondary_hosts")
+        for field in ("secondary_hosts", "secondary_registrable"):
+            if not data[field]:
+                data.pop(field)
         return data
 
 

--- a/scripts/backfill_url_dest.py
+++ b/scripts/backfill_url_dest.py
@@ -18,10 +18,14 @@ filter converges to zero; null adds nothing to the sparse dest_registrable
 index.
 
 Second pass, urlsV2 only: links with geo_rules or a pre_start_url get
-``dest.secondary_hosts`` (every extra destination host but the main one) so a host block
-reaches links that hide the host in a rule. Idempotent: docs already
-carrying the field are skipped, and a link whose rules add no new host
-gets an empty list so the filter converges.
+``dest.secondary_hosts`` (every extra destination host but the main one) and
+the index-aligned ``dest.secondary_registrable``, so a host block and a
+feed-domain sweep both reach links that hide the host in a rule. Idempotent:
+docs already carrying the fields are skipped, and a link whose extra
+destinations add no new host gets empty lists so the filter converges.
+
+Run it from the project environment: ``uv run python scripts/backfill_url_dest.py``.
+The inline script header below also works, but only with PyPI reachable.
 
 Usage::
 
@@ -58,7 +62,7 @@ _SECONDARY_FILTER = {
             "$or": [
                 {
                     "dest": {"$type": "object"},
-                    "dest.secondary_hosts": {"$exists": False},
+                    "dest.secondary_registrable": {"$exists": False},
                 },
                 # An unparseable long_url left dest null; its geo hosts still count.
                 {"dest": None},
@@ -111,47 +115,77 @@ def secondary_urls(doc: dict) -> list:
     return urls
 
 
+def secondary_parts(urls: list, main_host: str) -> list[dict]:
+    """Mirror of shared/url_utils._secondary_parts: one parsed destination per
+    distinct host, sorted by host."""
+    by_host: dict[str, dict] = {}
+    for parts in (parse_destination(u) for u in urls):
+        if parts is not None and parts["host"] != main_host:
+            by_host.setdefault(parts["host"], parts)
+    return [by_host[h] for h in sorted(by_host)]
+
+
 def secondary_hosts(urls: list, main_host: str) -> list[str]:
-    """Mirror of shared/url_utils.secondary_hosts."""
-    hosts = {
-        parts["host"]
-        for parts in (parse_destination(u) for u in urls)
-        if parts is not None and parts["host"] != main_host
+    return [p["host"] for p in secondary_parts(urls, main_host)]
+
+
+def secondary_fields(urls: list, main_host: str) -> dict:
+    """Both secondary lists, index-aligned, empty when nothing adds a host."""
+    parts = secondary_parts(urls, main_host)
+    return {
+        "secondary_hosts": [p["host"] for p in parts],
+        "secondary_registrable": [p["registrable_domain"] for p in parts],
     }
-    return sorted(hosts)
 
 
 def dest_for(doc: dict, url_field: str) -> dict | None:
-    """The full dest stamp for one doc: parsed parts plus secondary hosts."""
+    """The full dest stamp for one doc: parsed parts plus secondary lists."""
     parts = parse_destination(doc.get(url_field))
-    extra = secondary_hosts(secondary_urls(doc), (parts or {}).get("host", ""))
-    if parts is None and not extra:
+    extra = secondary_fields(secondary_urls(doc), (parts or {}).get("host", ""))
+    if parts is None and not extra["secondary_hosts"]:
         return None
     stamp = dict(
         parts or {"scheme": "", "host": "", "subdomain": "", "registrable_domain": ""}
     )
-    if extra:
-        stamp["secondary_hosts"] = extra
+    if extra["secondary_hosts"]:
+        stamp.update(extra)
     return stamp
 
 
 def _secondary_set(d: dict) -> dict:
-    """What the second pass writes: the list on an existing stamp, or a whole
-    stamp when dest is null. [] is the convergence marker either way."""
+    """What the second pass writes: both lists on an existing stamp, or a
+    whole stamp when dest is null. Empty lists are the convergence marker."""
     if isinstance(d.get("dest"), dict):
-        hosts = secondary_hosts(secondary_urls(d), d["dest"].get("host", ""))
-        return {"dest.secondary_hosts": hosts}
+        fields = secondary_fields(secondary_urls(d), d["dest"].get("host", ""))
+        return {f"dest.{k}": v for k, v in fields.items()}
     stamp = dest_for(d, "long_url") or dict(_EMPTY_DEST)
     stamp.setdefault("secondary_hosts", [])
+    stamp.setdefault("secondary_registrable", [])
     return {"dest": stamp}
+
+
+def _secondary_op(d: dict) -> UpdateOne:
+    # The filter re-asserts what was read, so a doc edited in between is
+    # left for the next run instead of overwritten with stale hosts.
+    flt = {
+        "_id": d["_id"],
+        "geo_rules": d.get("geo_rules"),
+        "pre_start_url": d.get("pre_start_url"),
+        "dest.secondary_registrable": {"$exists": False},
+    }
+    if isinstance(d.get("dest"), dict):
+        flt["dest.host"] = d["dest"].get("host", "")
+    else:
+        flt["dest"] = None
+    return UpdateOne(flt, {"$set": _secondary_set(d)})
 
 
 def backfill_secondary(coll, dry_run: bool) -> None:
     todo = coll.count_documents(_SECONDARY_FILTER)
-    print(f"[{coll.name}] geo or scheduled links needing secondary_hosts: {todo}")
+    print(f"[{coll.name}] geo or scheduled links needing secondary fields: {todo}")
     if todo == 0 or dry_run:
         return
-    stamped = failed = 0
+    stamped = failed = skipped = 0
     last_id = None
     while True:
         query = dict(_SECONDARY_FILTER)
@@ -168,16 +202,19 @@ def backfill_secondary(coll, dry_run: bool) -> None:
         if not batch:
             break
         last_id = batch[-1]["_id"]
-        ops = [UpdateOne({"_id": d["_id"]}, {"$set": _secondary_set(d)}) for d in batch]
+        ops = [_secondary_op(d) for d in batch]
         try:
-            coll.bulk_write(ops, ordered=False)
+            skipped += len(ops) - coll.bulk_write(ops, ordered=False).matched_count
         except BulkWriteError as exc:
-            failed += len(exc.details.get("writeErrors", []))
+            errors = exc.details.get("writeErrors", [])
+            failed += len(errors)
+            skipped += max(0, len(ops) - exc.details.get("nMatched", 0) - len(errors))
         stamped += len(batch)
     remaining = coll.count_documents(_SECONDARY_FILTER)
     print(
-        f"[{coll.name}] secondary_hosts stamped {stamped - failed}; failed: {failed}; "
-        f"remaining (expect {failed}): {remaining}"
+        f"[{coll.name}] secondary fields stamped {stamped - failed - skipped}; "
+        f"failed: {failed}; skipped (changed meanwhile): {skipped}; "
+        f"remaining (expect {failed + skipped}): {remaining}"
     )
 
 
@@ -194,6 +231,7 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         return
     done = 0
     failed = 0
+    skipped = 0
     last_id = None
     # Ride _id: the filter has no usable index, and this also carries the scan
     # past any doc whose update fails instead of dying on it forever.
@@ -209,17 +247,28 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         if not batch:
             break
         last_id = batch[-1]["_id"]
+        # The filter re-asserts what was read: a doc edited between the read
+        # and this write is left for the next run instead of overwritten.
         ops = [
-            UpdateOne({"_id": d["_id"]}, {"$set": {"dest": dest_for(d, url_field)}})
+            UpdateOne(
+                {
+                    "_id": d["_id"],
+                    url_field: d.get(url_field),
+                    "geo_rules": d.get("geo_rules"),
+                    "dest": {"$exists": False},
+                },
+                {"$set": {"dest": dest_for(d, url_field)}},
+            )
             for d in batch
         ]
         try:
-            coll.bulk_write(ops, ordered=False)
+            skipped += len(ops) - coll.bulk_write(ops, ordered=False).matched_count
         except BulkWriteError as exc:
             # v1 docs at the 16MB ceiling reject any $set: one skipped row,
             # never the migration.
             errors = exc.details.get("writeErrors", [])
             failed += len(errors)
+            skipped += max(0, len(ops) - exc.details.get("nMatched", 0) - len(errors))
             for err in errors[:10]:
                 print(
                     f"[{coll.name}] SKIPPED _id={err.get('op', {}).get('q')}: "
@@ -230,8 +279,9 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
             print(f"[{coll.name}] progress: {done}/{todo}")
     remaining = coll.count_documents(_FILTER)
     print(
-        f"[{coll.name}] stamped {done - failed}; failed: {failed}; "
-        f"remaining (expect {failed}): {remaining}"
+        f"[{coll.name}] stamped {done - failed - skipped}; failed: {failed}; "
+        f"skipped (changed meanwhile): {skipped}; "
+        f"remaining (expect {failed + skipped}): {remaining}"
     )
 
 

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -98,7 +98,7 @@ from shared.emoji_policy import (
 )
 from shared.generators import generate_emoji_alias_v2, generate_short_code_v2
 from shared.reserved_aliases import is_reserved_alias
-from shared.url_utils import extract_hostname
+from shared.url_utils import extract_hostname, link_destination_urls, parse_destination
 from shared.validators import (
     validate_alias,
     validate_blocked_url,
@@ -1028,9 +1028,22 @@ class UrlService:
         inserted_id = await self._url_repo.insert(doc)
         url_doc.id = inserted_id
 
-        # L1 accumulation: count the successful create (best-effort, the
-        # policy service never raises from here).
-        await self._url_policy.record_create(request.long_url)
+        # L1 accumulation for every destination the link routes to
+        # (best-effort, the policy service never raises from here).
+        # One record per registrable domain: the counters key on the domain,
+        # so fifty geo paths on one host must not read as a fifty-link burst.
+        counted: set[str] = set()
+        for destination in link_destination_urls(
+            request.long_url,
+            geo_rules=request.geo_rules,
+            pre_start_url=request.pre_start_url or None,
+        ):
+            parts = parse_destination(destination)
+            domain = parts["registrable_domain"] if parts else destination
+            if domain in counted:
+                continue
+            counted.add(domain)
+            await self._url_policy.record_create(destination)
 
         _url_base = request.long_url.split("?")[0]
         _log_url = f"{_url_base}?[REDACTED]" if "?" in request.long_url else _url_base

--- a/shared/url_utils.py
+++ b/shared/url_utils.py
@@ -113,14 +113,22 @@ def link_destination_urls(
     return out
 
 
+def _secondary_parts(urls: Iterable[str], exclude: str) -> list[dict]:
+    by_host: dict[str, dict] = {}
+    for parts in (parse_destination(u) for u in urls):
+        if parts is not None and parts["host"] != exclude:
+            by_host.setdefault(parts["host"], parts)
+    return [by_host[h] for h in sorted(by_host)]
+
+
 def secondary_hosts(urls: Iterable[str], *, exclude: str = "") -> list[str]:
     """Distinct parsed hosts of *urls* without *exclude*, sorted."""
-    hosts = {
-        parts["host"]
-        for parts in (parse_destination(u) for u in urls)
-        if parts is not None and parts["host"] != exclude
-    }
-    return sorted(hosts)
+    return [p["host"] for p in _secondary_parts(urls, exclude)]
+
+
+def secondary_registrables(urls: Iterable[str], *, exclude: str = "") -> list[str]:
+    """Registrable domain of each host secondary_hosts() returns, same order."""
+    return [p["registrable_domain"] for p in _secondary_parts(urls, exclude)]
 
 
 def extract_hostname(url: str | None) -> str | None:

--- a/tests/db/test_secondary_destination_sweeps.py
+++ b/tests/db/test_secondary_destination_sweeps.py
@@ -1,0 +1,113 @@
+"""The sweep aggregations run against real documents: $zip, $objectToArray
+and the pair gate are only ever exercised here, not by the unit mocks.
+Hosts use .com: a made-up TLD is its own registrable domain to tldextract."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from bson import ObjectId
+
+from repositories.url_repository import UrlRepository
+from schemas.models.base import ANONYMOUS_OWNER_ID
+from schemas.models.url import UrlDestination
+
+
+async def _insert(
+    real_db, alias: str, long_url: str, *, geo_rules=None, pre_start_url=None, dest=None
+):
+    stamp = (
+        dest
+        if dest is not None
+        else UrlDestination.for_link(
+            long_url, geo_rules=geo_rules, pre_start_url=pre_start_url
+        ).to_doc()
+    )
+    await real_db["urlsV2"].insert_one(
+        {
+            "_id": ObjectId(),
+            "alias": alias,
+            "domain": "spoo.me",
+            "owner_id": ANONYMOUS_OWNER_ID,
+            "created_at": datetime.now(timezone.utc),
+            "long_url": long_url,
+            "geo_rules": geo_rules,
+            "pre_start_url": pre_start_url,
+            "dest": stamp,
+            "status": "ACTIVE",
+            "total_clicks": 0,
+        }
+    )
+
+
+async def test_feed_sweep_reaches_hidden_hosts_and_samples_their_own_url(real_db):
+    repo = UrlRepository(real_db["urlsV2"])
+    await _insert(
+        real_db,
+        "geo1",
+        "https://clean-test.com/landing",
+        geo_rules={"IN": "https://kit.evil-feed-test.com/in"},
+    )
+    await _insert(real_db, "main1", "https://shop.evil-feed-test.com/x")
+    await _insert(
+        real_db,
+        "pre1",
+        "https://clean-test.com/other",
+        pre_start_url="https://teaser.evil-feed-test.com/soon",
+    )
+
+    hosts = dict(await repo.list_active_hosts_by_registrable("evil-feed-test.com"))
+
+    # Every host under the feed domain, each with a URL on that host.
+    assert hosts == {
+        "kit.evil-feed-test.com": "https://kit.evil-feed-test.com/in",
+        "shop.evil-feed-test.com": "https://shop.evil-feed-test.com/x",
+        "teaser.evil-feed-test.com": "https://teaser.evil-feed-test.com/soon",
+    }
+    # The clean main host is never enqueued for a domain it does not belong to.
+    assert "clean-test.com" not in hosts
+    assert dict(await repo.list_active_hosts_by_registrable("clean-test.com")) == {
+        "clean-test.com": "https://clean-test.com/landing"
+    }
+
+
+async def test_recent_screen_lists_secondary_hosts_with_their_own_url(real_db):
+    repo = UrlRepository(real_db["urlsV2"])
+    await _insert(
+        real_db,
+        "geo2",
+        "https://clean-test.com/landing",
+        geo_rules={"BR": "https://hidden-test.com/kit"},
+    )
+    since = datetime.now(timezone.utc) - timedelta(minutes=5)
+    hosts = dict(await repo.list_recent_destination_hosts(since))
+    assert hosts["clean-test.com"] == "https://clean-test.com/landing"
+    assert hosts["hidden-test.com"] == "https://hidden-test.com/kit"
+
+
+async def test_pre_registrable_stamp_is_invisible_to_the_feed_sweep_until_backfilled(
+    real_db,
+):
+    """A doc stamped by the first release (secondary_hosts only) yields no
+    (host, registrable) pairs: $zip stops at the shorter list. The
+    backfill's second pass keys on the missing field and repairs it."""
+    repo = UrlRepository(real_db["urlsV2"])
+    await _insert(
+        real_db,
+        "old1",
+        "https://clean-test.com/old",
+        geo_rules={"IN": "https://kit.evil-feed-test.com/old"},
+        dest={
+            "scheme": "https",
+            "host": "clean-test.com",
+            "subdomain": "",
+            "registrable_domain": "clean-test.com",
+            "secondary_hosts": ["kit.evil-feed-test.com"],
+        },
+    )
+    assert await repo.list_active_hosts_by_registrable("evil-feed-test.com") == []
+    # Host verdicts still reach it: the host filter does not need the registrable.
+    assert [
+        a
+        for a, _, _ in await repo.list_by_dest_host_with_urls("kit.evil-feed-test.com")
+    ] == ["old1"]

--- a/tests/unit/repositories/test_url_repository.py
+++ b/tests/unit/repositories/test_url_repository.py
@@ -470,7 +470,7 @@ class TestSweepQueries:
         col.name = "urlsV2"
         cursor = MagicMock()
         cursor.to_list = AsyncMock(
-            return_value=[{"_id": "a.evil.com", "sample_url": "https://a.evil.com/x"}]
+            return_value=[{"_id": "a.evil.com", "urls": ["https://a.evil.com/x"]}]
         )
         col.aggregate = AsyncMock(return_value=cursor)
 
@@ -478,7 +478,10 @@ class TestSweepQueries:
 
         assert result == [("a.evil.com", "https://a.evil.com/x")]
         pipeline = col.aggregate.await_args.args[0]
-        assert pipeline[0]["$match"]["dest.registrable_domain"] == "evil.com"
+        assert {"dest.registrable_domain": "evil.com"} in pipeline[0]["$match"]["$or"]
+        assert {"dest.secondary_registrable": "evil.com"} in pipeline[0]["$match"][
+            "$or"
+        ]
         assert pipeline[0]["$match"]["status"] == "ACTIVE"
 
     @pytest.mark.asyncio
@@ -491,7 +494,7 @@ class TestSweepQueries:
         col.name = "urlsV2"
         cursor = MagicMock()
         cursor.to_list = AsyncMock(
-            return_value=[{"_id": "fresh.com", "sample_url": "https://fresh.com/a"}]
+            return_value=[{"_id": "fresh.com", "urls": ["https://fresh.com/a"]}]
         )
         col.aggregate = AsyncMock(return_value=cursor)
 
@@ -855,3 +858,72 @@ class TestBlockCausesPerHost:
         assert union[0]["$ifNull"][0] == "$blocked_hosts"
         assert union[0]["$ifNull"][1]["$cond"][1] == ["$dest.host"]
         assert union[1] == ["b.example"]
+
+
+class TestFeedSweepReachesSecondaryDestinations:
+    """A geo or variant host under a feed-listed domain, whose main host is
+    elsewhere, must come out of the feed-delta fan-out as its own host."""
+
+    @pytest.mark.asyncio
+    async def test_pipeline_keeps_only_hosts_under_the_domain(self):
+        from repositories.url_repository import UrlRepository
+
+        col = make_collection()
+        col.name = "urlsV2"
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(return_value=[])
+        col.aggregate = AsyncMock(return_value=cursor)
+        await UrlRepository(col).list_active_hosts_by_registrable("evil.com")
+        pipeline = col.aggregate.await_args.args[0]
+        stages = [next(iter(st)) for st in pipeline]
+        assert stages == ["$match", "$project", "$unwind", "$match", "$group", "$limit"]
+        # Every (host, registrable) pair is unwound, then only pairs under the
+        # feed domain survive, so the clean main host never gets enqueued.
+        assert pipeline[3]["$match"] == {"pairs.1": "evil.com"}
+        assert pipeline[4]["$group"]["_id"] == {"$arrayElemAt": ["$pairs", 0]}
+        zipped = pipeline[1]["$project"]["pairs"]["$concatArrays"][1]["$zip"]["inputs"]
+        assert zipped[0] == {"$ifNull": ["$dest.secondary_hosts", []]}
+        assert zipped[1] == {"$ifNull": ["$dest.secondary_registrable", []]}
+
+
+class TestSweepSampleUrls:
+    def test_secondary_host_samples_its_own_url_not_the_main_one(self):
+        from repositories.url_repository import _host_samples
+
+        rows = [
+            {
+                "_id": "kit.evil.com",
+                "urls": ["https://clean.example/landing", "https://kit.evil.com/kit"],
+            },
+            {"_id": "clean.example", "urls": ["https://clean.example/landing"]},
+            {"_id": "orphan.example", "urls": ["https://elsewhere.example/"]},
+            {"_id": "", "urls": ["https://ignored.example/"]},
+        ]
+        assert _host_samples(rows) == [
+            ("kit.evil.com", "https://kit.evil.com/kit"),
+            ("clean.example", "https://clean.example/landing"),
+            ("orphan.example", "https://elsewhere.example/"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_recent_hosts_projects_every_url_of_the_link(self):
+        from datetime import datetime, timezone
+
+        from repositories.url_repository import UrlRepository
+
+        col = make_collection()
+        col.name = "urlsV2"
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(return_value=[])
+        col.aggregate = AsyncMock(return_value=cursor)
+        await UrlRepository(col).list_recent_destination_hosts(
+            datetime(2026, 9, 1, tzinfo=timezone.utc)
+        )
+        pipeline = col.aggregate.await_args.args[0]
+        urls = pipeline[1]["$project"]["urls"]["$concatArrays"]
+        assert urls[0] == ["$long_url"]
+        assert urls[1]["$map"]["input"] == {
+            "$objectToArray": {"$ifNull": ["$geo_rules", {}]}
+        }
+        assert urls[2]["$cond"][1] == ["$pre_start_url"]
+        assert pipeline[3]["$group"]["urls"] == {"$first": "$urls"}

--- a/tests/unit/schemas/models/test_url.py
+++ b/tests/unit/schemas/models/test_url.py
@@ -519,6 +519,26 @@ class TestUrlDestinationSecondaryHosts:
         assert geo is not None
         assert geo.to_doc()["secondary_hosts"] == ["geo.example"]
 
+    def test_secondary_registrable_is_index_aligned_with_hosts(self):
+        dest = UrlDestination.for_link(
+            "https://main.example/",
+            geo_rules={
+                "GB": "https://shop.evil.co.uk/x",
+                "IN": "https://a.evil.com/y",
+                "US": "https://b.evil.com/z",
+            },
+        )
+        assert dest is not None
+        assert dest.secondary_hosts == ["a.evil.com", "b.evil.com", "shop.evil.co.uk"]
+        assert dest.secondary_registrable == ["evil.com", "evil.com", "evil.co.uk"]
+        doc = dest.to_doc()
+        assert doc["secondary_registrable"] == ["evil.com", "evil.com", "evil.co.uk"]
+
+    def test_to_doc_omits_empty_secondary_registrable(self):
+        plain = UrlDestination.for_link("https://main.example/")
+        assert plain is not None
+        assert "secondary_registrable" not in plain.to_doc()
+
     def test_docs_predating_the_field_read_as_no_secondary_hosts(self):
         dest = UrlDestination.model_validate(
             {
@@ -529,6 +549,7 @@ class TestUrlDestinationSecondaryHosts:
             }
         )
         assert dest.secondary_hosts == []
+        assert dest.secondary_registrable == []
 
 
 class TestPreStartUrlIsADestination:
@@ -541,6 +562,7 @@ class TestPreStartUrlIsADestination:
         )
         assert dest is not None
         assert dest.secondary_hosts == ["teaser.example"]
+        assert dest.secondary_registrable == ["teaser.example"]
 
     def test_pre_start_on_the_main_host_adds_nothing(self):
         dest = UrlDestination.for_link(

--- a/tests/unit/scripts/test_backfill_url_dest.py
+++ b/tests/unit/scripts/test_backfill_url_dest.py
@@ -35,6 +35,16 @@ def test_secondary_hosts_mirror_the_shared_helper():
     assert backfill.secondary_urls({"geo_rules": None, "pre_start_url": None}) == []
 
 
+def test_secondary_fields_are_index_aligned():
+    fields = backfill.secondary_fields(
+        ["https://shop.evil.co.uk/x", "https://a.evil.com/y"], "main.example"
+    )
+    assert fields == {
+        "secondary_hosts": ["a.evil.com", "shop.evil.co.uk"],
+        "secondary_registrable": ["evil.com", "evil.co.uk"],
+    }
+
+
 def test_dest_for_includes_secondary_hosts_only_when_present():
     plain = backfill.dest_for({"long_url": "https://main.example/p"}, "long_url")
     assert plain["host"] == "main.example" and "secondary_hosts" not in plain
@@ -46,6 +56,7 @@ def test_dest_for_includes_secondary_hosts_only_when_present():
         "long_url",
     )
     assert geo["secondary_hosts"] == ["geo.example"]
+    assert geo["secondary_registrable"] == ["geo.example"]
     assert backfill.dest_for({"long_url": "nonsense"}, "long_url") is None
     scheduled = backfill.dest_for(
         {
@@ -76,16 +87,60 @@ def test_backfill_secondary_stamps_and_reports(capsys):
     cursor = MagicMock()
     cursor.sort.return_value.limit = MagicMock(side_effect=[docs, []])
     col.find = MagicMock(return_value=cursor)
+    col.bulk_write = MagicMock(return_value=MagicMock(matched_count=2))
 
     backfill.backfill_secondary(col, dry_run=False)
 
     ops = col.bulk_write.call_args.args[0]
-    sets = {op._filter["_id"]: op._doc["$set"]["dest.secondary_hosts"] for op in ops}
+    # Optimistic predicate: the write re-asserts the state it was computed from.
+    assert ops[0]._filter == {
+        "_id": 1,
+        "geo_rules": {"IN": "https://geo.example/"},
+        "pre_start_url": None,
+        "dest.host": "main.example",
+        "dest.secondary_registrable": {"$exists": False},
+    }
+    sets = {op._filter["_id"]: op._doc["$set"] for op in ops}
     # A rule that adds no new host still gets [] so the filter converges.
-    assert sets == {1: ["geo.example"], 2: []}
+    assert sets == {
+        1: {
+            "dest.secondary_hosts": ["geo.example"],
+            "dest.secondary_registrable": ["geo.example"],
+        },
+        2: {"dest.secondary_hosts": [], "dest.secondary_registrable": []},
+    }
     out = capsys.readouterr().out
-    assert "geo or scheduled links needing secondary_hosts: 2" in out
-    assert "secondary_hosts stamped 2; failed: 0; remaining (expect 0): 0" in out
+    assert "geo or scheduled links needing secondary fields: 2" in out
+    assert (
+        "secondary fields stamped 2; failed: 0; skipped (changed meanwhile): 0; "
+        "remaining (expect 0): 0"
+    ) in out
+
+
+def test_backfill_secondary_counts_docs_that_changed_under_it(capsys):
+    docs = [
+        {
+            "_id": 1,
+            "dest": {"host": "main.example"},
+            "geo_rules": {"IN": "https://geo.example/"},
+        },
+    ]
+    col = MagicMock()
+    col.name = "urlsV2"
+    col.count_documents = MagicMock(side_effect=[1, 1])
+    cursor = MagicMock()
+    cursor.sort.return_value.limit = MagicMock(side_effect=[docs, []])
+    col.find = MagicMock(return_value=cursor)
+    # The doc was edited between read and write: the predicate matched nothing.
+    col.bulk_write = MagicMock(return_value=MagicMock(matched_count=0))
+
+    backfill.backfill_secondary(col, dry_run=False)
+
+    out = capsys.readouterr().out
+    assert (
+        "stamped 0; failed: 0; skipped (changed meanwhile): 1; remaining (expect 1): 1"
+        in out
+    )
 
 
 def test_backfill_secondary_dry_run_writes_nothing(capsys):
@@ -94,7 +149,38 @@ def test_backfill_secondary_dry_run_writes_nothing(capsys):
     col.count_documents = MagicMock(return_value=5)
     backfill.backfill_secondary(col, dry_run=True)
     col.bulk_write.assert_not_called()
-    assert "needing secondary_hosts: 5" in capsys.readouterr().out
+    assert "needing secondary fields: 5" in capsys.readouterr().out
+
+
+def test_backfill_secondary_partial_bulk_failure_reconciles(capsys):
+    from pymongo.errors import BulkWriteError
+
+    docs = [
+        {
+            "_id": i,
+            "dest": {"host": "main.example"},
+            "geo_rules": {"IN": "https://geo.example/"},
+        }
+        for i in (1, 2, 3)
+    ]
+    col = MagicMock()
+    col.name = "urlsV2"
+    col.count_documents = MagicMock(side_effect=[3, 2])
+    cursor = MagicMock()
+    cursor.sort.return_value.limit = MagicMock(side_effect=[docs, []])
+    col.find = MagicMock(return_value=cursor)
+    # One op failed, one matched and wrote, one matched nothing (changed meanwhile).
+    col.bulk_write = MagicMock(
+        side_effect=BulkWriteError({"nMatched": 1, "writeErrors": [{"index": 0}]})
+    )
+
+    backfill.backfill_secondary(col, dry_run=False)
+
+    out = capsys.readouterr().out
+    assert (
+        "stamped 1; failed: 1; skipped (changed meanwhile): 1; remaining (expect 2): 2"
+        in out
+    )
 
 
 def test_secondary_pass_repairs_a_null_dest_with_valid_geo_hosts():
@@ -113,6 +199,7 @@ def test_secondary_pass_repairs_a_null_dest_with_valid_geo_hosts():
             "subdomain": "",
             "registrable_domain": "",
             "secondary_hosts": ["geo.example"],
+            "secondary_registrable": ["geo.example"],
         }
     }
     # Nothing parseable at all still converges instead of matching forever.
@@ -125,4 +212,5 @@ def test_secondary_pass_repairs_a_null_dest_with_valid_geo_hosts():
         }
     )
     assert nothing["dest"]["secondary_hosts"] == []
+    assert nothing["dest"]["secondary_registrable"] == []
     assert backfill._SECONDARY_FILTER["$and"][1]["$or"][1] == {"dest": None}

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -4108,7 +4108,6 @@ class TestSecondaryDestinationStamping:
         inserted = url_repo.insert.call_args.args[0]
         assert inserted["dest"]["host"] == "clean.example"
         assert inserted["dest"]["secondary_hosts"] == ["hidden.example"]
-        assert inserted["dest"]["secondary_registrable"] == ["hidden.example"]
 
     @pytest.mark.asyncio
     async def test_create_without_geo_rules_writes_no_secondary_field(self):
@@ -4220,3 +4219,60 @@ class TestPreStartUrlStamping:
         written = url_repo.update.call_args[0][1]["$set"]
         assert written["pre_start_url"] == "https://teaser.example/soon"
         assert written["dest"]["secondary_hosts"] == ["teaser.example"]
+
+
+class TestL1SeesSecondaryDestinations:
+    @pytest.mark.asyncio
+    async def test_create_records_every_destination_for_burst_counters(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+        svc._url_policy.record_create = AsyncMock()
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://clean.example/",
+            geo_rules={
+                "IN": "https://hidden.example/kit",
+                "US": "https://clean.example/",
+            },
+            starts_at=datetime.now(timezone.utc) + timedelta(days=1),
+            pre_start_url="https://teaser.example/soon",
+        )
+        await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        recorded = [c.args[0] for c in svc._url_policy.record_create.await_args_list]
+        # Distinct URLs, main first: the geo rule echoing long_url counts once.
+        assert recorded == [
+            "https://clean.example/",
+            "https://hidden.example/kit",
+            "https://teaser.example/soon",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_many_geo_paths_on_one_domain_count_once(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+        svc._url_policy.record_create = AsyncMock()
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        codes = ["IN", "US", "DE", "FR", "BR", "JP", "GB", "CA", "AU", "ES"]
+        req = CreateUrlRequest(
+            long_url="https://x.example/",
+            geo_rules={c: f"https://x.example/{c.lower()}" for c in codes},
+        )
+        await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        # Counters key on the registrable domain: one create is one bump.
+        assert svc._url_policy.record_create.await_count == 1

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -4108,6 +4108,7 @@ class TestSecondaryDestinationStamping:
         inserted = url_repo.insert.call_args.args[0]
         assert inserted["dest"]["host"] == "clean.example"
         assert inserted["dest"]["secondary_hosts"] == ["hidden.example"]
+        assert inserted["dest"]["secondary_registrable"] == ["hidden.example"]
 
     @pytest.mark.asyncio
     async def test_create_without_geo_rules_writes_no_secondary_field(self):

--- a/tests/unit/test_ab_testing_launch_guard.py
+++ b/tests/unit/test_ab_testing_launch_guard.py
@@ -25,6 +25,9 @@ Required before shipping them:
   2. include variant URLs in link_destination_urls callers (report intake,
      hot screening) so each variant gets its own safety event
   3. stamp existing links: scripts/backfill_url_dest.py
+  4. add the variant URLs to _ALL_URLS in repositories/url_repository.py so
+     the sweeps sample a variant host's own URL (today: long_url, geo rules,
+     pre_start_url)
 """
 
 

--- a/tests/unit/test_geo_launch_guard.py
+++ b/tests/unit/test_geo_launch_guard.py
@@ -38,3 +38,4 @@ def test_geo_targeting_stays_dark_until_enforcement_sees_it():
         "https://main.example/", geo_rules={"IN": "https://geo.example/x"}
     )
     assert stamped is not None and stamped.secondary_hosts == ["geo.example"], _WORK
+    assert stamped.secondary_registrable == ["geo.example"], _WORK


### PR DESCRIPTION
Beads ticket spoo-v3f.39. Stacked on #342 (`feat/safety-secondary-destinations`); merge that first.

## What

Two gaps the first PR left on record.

**Feed-delta sweep.** It fans out by `dest.registrable_domain`, so a geo or variant destination under a feed-listed domain whose main host sits elsewhere was never enqueued. `UrlDestination` now stamps `secondary_registrable`, index-aligned with `secondary_hosts`, at every write point and in the backfill, with a sparse index. The sweep matches either field, zips `(host, registrable)` pairs inside Mongo and keeps only pairs under the feed domain, so the clean main host is never enqueued for a domain it does not belong to. Both sweeps now sample a URL on the host they emit instead of the link's main URL, or the analyzer would screen the wrong page.

**L1 burst counters.** Create records one L1 event per distinct destination of the link, so a campaign that hides its host in geo rules crosses thresholds like any other.

Destination sources come from #342: geo rules and the scheduling `pre_start_url`; both flow through here unchanged.

The backfill docstring says to run it from the project env (`uv run python scripts/backfill_url_dest.py`); the inline script header needs PyPI.

## Proof (worktree app with safety and L1 wired to the local queue Redis)

Geo link `cqmh5Ft`: `long_url` on `clean-main-proof.com`, geo rule to `kit.evil-feed-proof.com`.

```
stored dest: {host: clean-main-proof.com, secondary_hosts: [kit.evil-feed-proof.com], secondary_registrable: [evil-feed-proof.com]}
L1 counters: l1:dom:600:evil-feed-proof.com:* = 1, l1:dom:86400:evil-feed-proof.com:* = 1 (and the same for clean-main-proof.com)
feed-delta sweep evil-feed-proof.com  -> [(kit.evil-feed-proof.com, https://kit.evil-feed-proof.com/kit)]
feed-delta sweep clean-main-proof.com -> [(clean-main-proof.com, https://clean-main-proof.com/landing)]
recent-screen listing includes (kit.evil-feed-proof.com, https://kit.evil-feed-proof.com/kit)
backfill after unsetting both fields: "geo links needing secondary fields: 2 ... stamped 2 ... remaining 0"; second run 0
index dest_secondary_registrable (sparse) created at startup
```

## Tests

`GEO_RULES_ENABLED=true uv run pytest tests/unit tests/integration` (app-token scopes file deselected): 3802 unit and integration passed, plus 3 real-Mongo cases in tests/db.


## Deploy order

`$zip` in the feed sweep stops at the shorter list, so a link stamped by #342-era code (secondary_hosts without secondary_registrable) yields no pairs until the backfill's second pass re-stamps it. Merge #342 and #343 before one release and run `uv run python scripts/backfill_url_dest.py` once after deploy. `tests/db/test_secondary_destination_sweeps.py` pins the pipeline against a real Mongo, including that truncation.
