### PR TITLE
feat(links): A/B split destinations with per-variant stats

### DIFF
--- a/config.py
+++ b/config.py
@@ -759,7 +759,7 @@ class AppSettings(BaseSettings):
     geo_rules_enabled: bool = False
     geo_rules_max_countries: int = 50
     # Dark like geo_rules until safety stamps secondary hosts; see the
-    # tripwire in tests/unit/test_ab_variants_launch_guard.py.
+    # tripwire in tests/unit/test_ab_testing_launch_guard.py.
     ab_variants_enabled: bool = False
     ab_variants_max: int = 10
     url_password_min_length: int = 8

--- a/config.py
+++ b/config.py
@@ -758,6 +758,10 @@ class AppSettings(BaseSettings):
     # tests/unit/test_geo_launch_guard.py.
     geo_rules_enabled: bool = False
     geo_rules_max_countries: int = 50
+    # Dark like geo_rules until safety stamps secondary hosts; see the
+    # tripwire in tests/unit/test_ab_variants_launch_guard.py.
+    ab_variants_enabled: bool = False
+    ab_variants_max: int = 10
     url_password_min_length: int = 8
     account_password_min_length: int = 8
     account_password_max_length: int = 128
@@ -770,6 +774,7 @@ class AppSettings(BaseSettings):
         "max_emoji_alias_length",
         "emoji_generated_alias_length",
         "geo_rules_max_countries",
+        "ab_variants_max",
         "account_erasure_batch_limit",
         "account_erasure_time_budget_seconds",
         "account_erasure_claim_lease_seconds",

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -689,6 +689,8 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         emoji_generated_alias_length=settings.emoji_generated_alias_length,
         geo_rules_max_countries=settings.geo_rules_max_countries,
         geo_rules_enabled=settings.geo_rules_enabled,
+        ab_variants_max=settings.ab_variants_max,
+        ab_variants_enabled=settings.ab_variants_enabled,
         og_writethrough=og_writethrough,
         edge_kv=edge_kv_client,
         r2_storage=r2_storage,

--- a/infrastructure/cache/url_cache.py
+++ b/infrastructure/cache/url_cache.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from infrastructure.crypto import verify_password as verify_password_hash
 from infrastructure.logging import get_logger
+from schemas.models.url import AbVariant
 from shared.datetime_utils import to_unix_timestamp, to_unix_timestamp_ceil
 
 if TYPE_CHECKING:
@@ -46,6 +47,8 @@ class UrlCacheData(BaseModel):
     geo_rules: dict[str, str] | None = None
     # v2 only; served with 302 once the link is EXPIRED.
     expired_redirect_url: str | None = None
+    # Same decoding story as geo_rules: absent on older entries → None.
+    ab_variants: list[AbVariant] | None = None
     # Custom meta-tags (v2 only; None = feature disabled on this link).
     # meta_title is the enabled-signal: LinkMetaTags.title is mandatory.
     meta_title: str | None = None
@@ -85,6 +88,7 @@ class UrlCacheData(BaseModel):
             domain=doc.domain,
             geo_rules=doc.geo_rules,
             expired_redirect_url=doc.expired_redirect_url,
+            ab_variants=doc.ab_variants,
             meta_title=doc.meta_tags.title if doc.meta_tags else None,
             meta_description=doc.meta_tags.description if doc.meta_tags else None,
             meta_image=doc.meta_tags.image if doc.meta_tags else None,

--- a/openapi.json
+++ b/openapi.json
@@ -1872,7 +1872,7 @@
           "URL Shortening"
         ],
         "summary": "Create Shortened URL",
-        "description": "Create a new shortened URL.\n\nCreate a shortened URL with optional customization including password\nprotection, expiration, click limits, and bot blocking. Authenticated\nusers may target an owned, ACTIVE custom domain via the ``domain`` field.\n\n**Emoji aliases**: ``alias`` also accepts an emoji-only short code\n(e.g. ``\ud83d\ude80\ud83d\udd25``) \u2014 1-15 fully-qualified emoji; ZWJ sequences, flags,\nkeycaps, and text-style symbols are rejected (they render or copy\ninconsistently across platforms). Set ``alias_type: \"emoji\"`` to\nauto-generate an emoji code instead of an alphanumeric one. Stored\nand returned in canonical form (variation selectors stripped).\n\n**Authentication**: Optional \u2014 higher rate limits when authenticated.\nRequired if ``domain`` is supplied.\n\n**API Key Scope**: `shorten:create` or `admin:all`\n\n**Rate Limits**:\n\n- Authenticated: 60/min, 5,000/day\n- Anonymous: 20/min, 1,000/day\n\n**Anonymous Usage Consequences**:\n\n- Lower rate limits\n- Cannot manage or view URLs later\n- Cannot use private stats\n- URLs not linked to any account\n- Cannot use custom domains\n- Cannot use geo targeting\n- Cannot use A/B variants\n- Cannot use custom meta tags",
+        "description": "Create a new shortened URL.\n\nCreate a shortened URL with optional customization including password\nprotection, expiration, click limits, and bot blocking. Authenticated\nusers may target an owned, ACTIVE custom domain via the ``domain`` field.\n\n**Emoji aliases**: ``alias`` also accepts an emoji-only short code\n(e.g. ``\ud83d\ude80\ud83d\udd25``) \u2014 1-15 fully-qualified emoji; ZWJ sequences, flags,\nkeycaps, and text-style symbols are rejected (they render or copy\ninconsistently across platforms). Set ``alias_type: \"emoji\"`` to\nauto-generate an emoji code instead of an alphanumeric one. Stored\nand returned in canonical form (variation selectors stripped).\n\n**Authentication**: Optional \u2014 higher rate limits when authenticated.\nRequired if ``domain`` is supplied.\n\n**API Key Scope**: `shorten:create` or `admin:all`\n\n**Rate Limits**:\n\n- Authenticated: 60/min, 5,000/day\n- Anonymous: 20/min, 1,000/day\n\n**Anonymous Usage Consequences**:\n\n- Lower rate limits\n- Cannot manage or view URLs later\n- Cannot use private stats\n- URLs not linked to any account\n- Cannot use custom domains\n- Cannot use geo targeting\n- Cannot use A/B variants\n- Cannot set an expired-link fallback\n- Cannot use custom meta tags",
         "operationId": "shortenUrl",
         "requestBody": {
           "content": {
@@ -2198,7 +2198,7 @@
           "Link Management"
         ],
         "summary": "List Your URLs",
-        "description": "List all URLs owned by the authenticated user.\n\nReturns a paginated list of shortened URLs with support for filtering,\nsorting, and full-text search on aliases and destination URLs.\n\n**Authentication**: Required.\n\n**API Key Scope**: `urls:manage`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Pagination**: Use `page` and `pageSize` query params. Response includes\n`hasNext` boolean and `total` count.\n\n**Sorting**: Sort by `created_at`, `last_click`, or `total_clicks` in\nascending or descending order.\n\n**Filtering**: Pass a JSON-encoded `filter` parameter with fields like\n`status`, `createdAfter`, `createdBefore`, `passwordSet`, `maxClicksSet`,\nand `search`.",
+        "description": "List all URLs owned by the authenticated user.\n\nReturns a paginated list of shortened URLs with support for filtering,\nsorting, and full-text search on aliases and destination URLs.\n\n**Authentication**: Required.\n\n**API Key Scope**: `urls:manage`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Pagination**: Use `page` and `pageSize` query params. Response includes\n`hasNext` boolean and `total` count.\n\n**Sorting**: Sort by `created_at`, `last_click`, or `total_clicks` in\nascending or descending order.\n\n**Filtering**: Pass a JSON-encoded `filter` parameter with fields like\n`status`, `createdAfter`, `createdBefore`, `passwordSet`, `maxClicksSet`,\n`search`, `tagIds`, `tagNames` and `tagsMatch`.",
         "operationId": "listUrls",
         "parameters": [
           {
@@ -2285,7 +2285,7 @@
                   "type": "null"
                 }
               ],
-              "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024",
+              "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n- **tagIds** \u2014 Only links carrying these tags, by id (array of strings)\n- **tagNames** \u2014 Same, by tag name; unknown names match nothing\n- **tagsMatch** \u2014 `\"any\"` (default) or `\"all\"`; how multiple tags combine\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n- **tagIds / tagNames**: Array of strings\n- **tagsMatch**: String \u2014 `\"any\"` or `\"all\"`\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"tagNames\": [\"launch\", \"q3\"], \"tagsMatch\": \"all\"}` \u2014 URLs tagged both launch and q3\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024",
               "examples": [
                 "{\"status\":\"ACTIVE\"}",
                 "{\"passwordSet\": true}",
@@ -2296,7 +2296,7 @@
               ],
               "title": "Filter"
             },
-            "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024"
+            "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n- **tagIds** \u2014 Only links carrying these tags, by id (array of strings)\n- **tagNames** \u2014 Same, by tag name; unknown names match nothing\n- **tagsMatch** \u2014 `\"any\"` (default) or `\"all\"`; how multiple tags combine\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n- **tagIds / tagNames**: Array of strings\n- **tagsMatch**: String \u2014 `\"any\"` or `\"all\"`\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"tagNames\": [\"launch\", \"q3\"], \"tagsMatch\": \"all\"}` \u2014 URLs tagged both launch and q3\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024"
           },
           {
             "name": "filterBy",
@@ -2621,7 +2621,7 @@
           "Link Management"
         ],
         "summary": "Update URL",
-        "description": "Update an existing URL's properties.\n\nPartially update a shortened URL. Only provided fields are modified; omitted\nfields remain unchanged. Pass `null` to remove optional settings like\n`password`, `max_clicks`, or `expire_after`.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 120/min, 2,000/day\n\n**Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,\n`max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,\n`geo_rules`, `ab_variants`, `meta_tags`\n\n**Notes**:\n\n- Setting `max_clicks` to `0` or `null` removes the click limit\n- Changing the `alias` checks availability and may fail with 409 Conflict\n- Setting `domain` moves the URL to a different tenant; caller must own\n  the target as an ACTIVE custom domain, or pass `null` to move back to\n  the system default. Alias collision is verified on the target.\n- `geo_rules` replaces the whole map; pass `null` or `{}` to remove all\n  rules\n- `ab_variants` replaces the whole list; pass `null` or `[]` to remove all\n  variants\n- The `url_id` is the MongoDB ObjectId, not the alias",
+        "description": "Update an existing URL's properties.\n\nPartially update a shortened URL. Only provided fields are modified; omitted\nfields remain unchanged. Pass `null` to remove optional settings like\n`password`, `max_clicks`, or `expire_after`.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 120/min, 2,000/day\n\n**Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,\n`max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,\n`geo_rules`, `ab_variants`, `expired_redirect_url`, `meta_tags`\n\n**Notes**:\n\n- Setting `max_clicks` to `0` or `null` removes the click limit\n- Changing the `alias` checks availability and may fail with 409 Conflict\n- Setting `domain` moves the URL to a different tenant; caller must own\n  the target as an ACTIVE custom domain, or pass `null` to move back to\n  the system default. Alias collision is verified on the target.\n- `geo_rules` replaces the whole map; pass `null` or `{}` to remove all\n  rules\n- `ab_variants` replaces the whole list; pass `null` or `[]` to remove all\n  variants\n- `expired_redirect_url` is where visitors land once the link has expired;\n  pass `null` to go back to the expired page\n- The `url_id` is the MongoDB ObjectId, not the alias",
         "operationId": "updateUrl",
         "parameters": [
           {
@@ -3311,6 +3311,464 @@
         }
       }
     },
+    "/api/v1/urls/bulk/tags": {
+      "post": {
+        "tags": [
+          "Link Management"
+        ],
+        "summary": "Bulk Tag URLs",
+        "description": "Add and remove tags (by tag id) on up to 100 URLs you own in one request.\n\nPer item the result is the link's current tags minus `remove`, plus\n`add` (kept once, order preserved). A link that already reads that\nway is a success no-op. Every id in `add` must be one of your tags\n(`GET /tags`); an unknown one rejects the whole request before any\nitem is touched.\n\n**Per-item verdicts** (`error_code`): `not_found` \u2014 no such URL in\nyour account; `forbidden` \u2014 the URL is admin-blocked;\n`validation_error` \u2014 the result would exceed 10 tags on that link.\n\n**Retry semantics**: re-sending the batch is safe \u2014 items already\ncarrying the result report success no-ops.\n\n**Rate Limits**: 60/min, 200/day \u2014 counted per request, not per id.",
+        "operationId": "bulkTagUrls",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkTagUrlsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkUrlOperationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request \u2014 invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 insufficient permissions or scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tags": {
+      "get": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "List Your Tags",
+        "description": "Every tag in your account with the number of links carrying it,\noldest first.\n\n**API Key Scope**: `urls:manage`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day",
+        "operationId": "listTags",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request \u2014 invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 insufficient permissions or scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Create a Tag",
+        "description": "Create a tag. Names are lowercased and trimmed; a name you already\nhave answers `409 conflict`. Omit `color` to get the least-used palette\ncolour in your account; omit `icon` for the generic tag glyph. At most\n500 tags per account.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 30/min",
+        "operationId": "createTag",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request \u2014 invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 insufficient permissions or scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tags/{tag_id}": {
+      "patch": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Rename or Recolour a Tag",
+        "description": "Change the name, colour or icon. Links keep pointing at the tag\nby id, so a rename shows up everywhere at once. Renaming onto a name you\nalready have answers `409 conflict`.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 30/min",
+        "operationId": "updateTag",
+        "parameters": [
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Tag id (MongoDB ObjectId), as returned by GET /tags.",
+              "examples": [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ],
+              "title": "Tag Id"
+            },
+            "description": "Tag id (MongoDB ObjectId), as returned by GET /tags."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTagRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request \u2014 invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 insufficient permissions or scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Delete a Tag",
+        "description": "Delete the tag and remove it from every link that carried it. The\nlinks themselves are untouched otherwise.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 10/min. Deleting fans out an update over every link\nyou own, so it carries the same budget as bulk delete.",
+        "operationId": "deleteTag",
+        "parameters": [
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Tag id (MongoDB ObjectId), as returned by GET /tags.",
+              "examples": [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ],
+              "title": "Tag Id"
+            },
+            "description": "Tag id (MongoDB ObjectId), as returned by GET /tags."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request \u2014 invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 insufficient permissions or scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/urls/claim": {
       "post": {
         "tags": [
@@ -3588,7 +4046,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -3596,7 +4054,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -3652,14 +4110,14 @@
                   "type": "null"
                 }
               ],
-              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
+              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
               "examples": [
                 "{\"browser\":[\"Chrome\",\"Firefox\"]}",
                 "{\"country\":[\"United States\",\"Canada\"],\"browser\":[\"Chrome\"]}"
               ],
               "title": "Filters"
             },
-            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
+            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
           },
           {
             "name": "browser",
@@ -3925,6 +4383,50 @@
               "title": "Url Id"
             },
             "description": "Comma-separated URL ids (MongoDB ObjectIds) to filter stats to specific URLs you own. Slices your own aggregate \u2014 ids you do not own simply match nothing.\n\nFor statistics on a single link, prefer `GET /api/v1/stats/links/{url_id}`."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 500
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`.",
+              "examples": [
+                "launch,q3"
+              ],
+              "title": "Tag"
+            },
+            "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`."
+          },
+          {
+            "name": "tag_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 1000
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only.",
+              "examples": [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ],
+              "title": "Tag Id"
+            },
+            "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only."
           }
         ],
         "responses": {
@@ -4079,7 +4581,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -4087,7 +4589,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -4873,7 +5375,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -4881,7 +5383,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -4937,14 +5439,14 @@
                   "type": "null"
                 }
               ],
-              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
+              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
               "examples": [
                 "{\"browser\":[\"Chrome\",\"Firefox\"]}",
                 "{\"country\":[\"United States\",\"Canada\"],\"browser\":[\"Chrome\"]}"
               ],
               "title": "Filters"
             },
-            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
+            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
           },
           {
             "name": "browser",
@@ -5210,6 +5712,50 @@
               "title": "Url Id"
             },
             "description": "Comma-separated URL ids (MongoDB ObjectIds) to filter stats to specific URLs you own. Slices your own aggregate \u2014 ids you do not own simply match nothing.\n\nFor statistics on a single link, prefer `GET /api/v1/stats/links/{url_id}`."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 500
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`.",
+              "examples": [
+                "launch,q3"
+              ],
+              "title": "Tag"
+            },
+            "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`."
+          },
+          {
+            "name": "tag_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 1000
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only.",
+              "examples": [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ],
+              "title": "Tag Id"
+            },
+            "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only."
           }
         ],
         "responses": {
@@ -5412,7 +5958,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -5420,7 +5966,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`. The index is positional: editing `ab_variants` re-keys past clicks to whatever now sits at that index\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -10140,6 +10686,59 @@
         "title": "BulkOperationSummary",
         "description": "Counts derived from the result rows."
       },
+      "BulkTagUrlsRequest": {
+        "properties": {
+          "ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Ids",
+            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
+            "examples": [
+              [
+                "665f0c2f9e7a4b1d2c3d4e5f",
+                "665f0c2f9e7a4b1d2c3d4e60"
+              ]
+            ]
+          },
+          "add": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 10,
+            "title": "Add",
+            "description": "Tag ids to add to every id (at most 10); every one must be a tag you own. Tags a link already carries are kept once.",
+            "examples": [
+              [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ]
+            ]
+          },
+          "remove": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove",
+            "description": "Tag ids to remove from every id. Tags a link does not carry are ignored.",
+            "examples": [
+              [
+                "665f0c2f9e7a4b1d2c3d4e60"
+              ]
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "ids"
+        ],
+        "title": "BulkTagUrlsRequest",
+        "description": "Request body for bulk tag / untag, by tag id.\n\nAt least one of ``add`` or ``remove`` must name a tag, and no tag may be\nin both."
+      },
       "BulkUpdateExpiryRequest": {
         "properties": {
           "ids": {
@@ -10658,6 +11257,46 @@
         "title": "CreateReportsRequest",
         "description": "Request body for POST /api/v1/reports.\n\n``items`` size is validated in the service (anonymous \u2264 25,\nauthenticated \u2264 100; empty \u2192 400) because the cap depends on the\ncaller's auth state."
       },
+      "CreateTagRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Name",
+            "description": "Tag name, at most 32 characters. Lowercased and trimmed on write; letters, digits, spaces, `-`, `_` and `.` only. Unique per account.",
+            "examples": [
+              "launch"
+            ]
+          },
+          "color": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TagColor"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "One of the palette keys. Omit on create to get the least-used colour in your account.",
+            "examples": [
+              "violet"
+            ]
+          },
+          "icon": {
+            "$ref": "#/components/schemas/TagIcon",
+            "description": "Icon key from the curated set (lucide names). Defaults to `tag`.",
+            "default": "tag",
+            "examples": [
+              "rocket"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CreateTagRequest"
+      },
       "CreateUrlRequest": {
         "properties": {
           "long_url": {
@@ -10762,6 +11401,42 @@
               1735689599
             ]
           },
+          "starts_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starts At",
+            "description": "Go-live time. The link is not live before this moment. ISO 8601 string or Unix epoch seconds; must be in the future and before `expire_after`. Requires authentication.",
+            "examples": [
+              "2026-09-10T18:00:00+05:30",
+              1789500000
+            ]
+          },
+          "pre_start_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 8192
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Start Url",
+            "description": "Where visitors are sent before `starts_at`. Omit for the not-yet-live page. No effect without `starts_at`.",
+            "examples": [
+              "https://example.com/coming-soon"
+            ]
+          },
           "private_stats": {
             "anyOf": [
               {
@@ -10809,6 +11484,42 @@
                 "IN": "https://example.in/",
                 "US": "https://example.com/us"
               }
+            ]
+          },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 8192
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Where visitors land once the link has expired, by time or by click limit, instead of the expired page. Validated like a destination. Requires authentication.",
+            "examples": [
+              "https://example.com/offer-ended"
+            ]
+          },
+          "tag_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Ids",
+            "description": "Ids of tags from `GET /api/v1/tags`, at most 10 per link. Every id must be one of your tags (400 otherwise). On PATCH the list replaces the stored one; `null` or `[]` clears it.",
+            "examples": [
+              [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ]
             ]
           },
           "ab_variants": {
@@ -12732,6 +13443,40 @@
         "title": "PreviewGeoDestination",
         "description": "One geo-rule destination group.\n\n``countries`` are ISO 3166-1 alpha-2 codes, sorted ascending \u2014 every\nrule is listed, nothing summarized (anti-cloaking transparency)."
       },
+      "PreviewVariantDestination": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "domain": {
+            "type": "string",
+            "title": "Domain"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "is_https": {
+            "type": "boolean",
+            "title": "Is Https"
+          },
+          "weight": {
+            "type": "integer",
+            "title": "Weight"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "domain",
+          "path",
+          "is_https",
+          "weight"
+        ],
+        "title": "PreviewVariantDestination",
+        "description": "One A/B variant destination with its traffic share in percent."
+      },
       "ProfilePictureMessageResponse": {
         "properties": {
           "message": {
@@ -12795,6 +13540,17 @@
             ],
             "title": "Long Url"
           },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url"
+          },
           "created_at": {
             "anyOf": [
               {
@@ -12813,7 +13569,8 @@
               "active",
               "inactive",
               "expired",
-              "blocked"
+              "blocked",
+              "scheduled"
             ],
             "title": "Status"
           },
@@ -12872,7 +13629,8 @@
               "active",
               "inactive",
               "expired",
-              "blocked"
+              "blocked",
+              "scheduled"
             ],
             "title": "Status"
           },
@@ -12886,6 +13644,17 @@
               }
             ],
             "title": "Created At"
+          },
+          "starts_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starts At"
           },
           "password_protected": {
             "type": "boolean",
@@ -12914,6 +13683,30 @@
               }
             ],
             "title": "Geo Destinations"
+          },
+          "variant_destinations": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PreviewVariantDestination"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variant Destinations"
+          },
+          "expired_destination": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PreviewDestination"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -12928,7 +13721,7 @@
           "geo_destinations"
         ],
         "title": "PublicPreviewResponse",
-        "description": "Response body for the public link preview endpoint.\n\n``destination`` and ``geo_destinations`` are non-null only while the\nlink is active and not password-protected \u2014 the preview never reveals\na destination the redirect would refuse to serve."
+        "description": "Response body for the public link preview endpoint.\n\n``destination``, ``geo_destinations`` and ``variant_destinations`` are\nnon-null only while the link is active and not password-protected \u2014 the\npreview never reveals a destination the redirect would refuse to serve.\nThe rule runs both ways: ``expired_destination`` names where an expired\nlink still sends every visitor when its owner set a fallback, so the\npreview never shows LESS than the redirect serves either."
       },
       "PublicStatsBody": {
         "properties": {
@@ -13613,6 +14406,253 @@
         "title": "StatsTimeRange",
         "description": "Time range metadata inside StatsResponse."
       },
+      "TagColor": {
+        "type": "string",
+        "enum": [
+          "gray",
+          "red",
+          "orange",
+          "amber",
+          "green",
+          "teal",
+          "blue",
+          "violet",
+          "pink"
+        ],
+        "title": "TagColor",
+        "description": "Fixed palette; the dashboard maps each key to a muted dot colour."
+      },
+      "TagDeleteResponse": {
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted",
+            "default": true
+          },
+          "links_updated": {
+            "type": "integer",
+            "title": "Links Updated",
+            "description": "Links the tag was removed from."
+          }
+        },
+        "type": "object",
+        "required": [
+          "links_updated"
+        ],
+        "title": "TagDeleteResponse"
+      },
+      "TagIcon": {
+        "type": "string",
+        "enum": [
+          "banknote",
+          "bar-chart-3",
+          "beaker",
+          "bell",
+          "bird",
+          "book",
+          "bookmark",
+          "box",
+          "briefcase",
+          "bug",
+          "building",
+          "calendar",
+          "camera",
+          "car",
+          "cat",
+          "clock",
+          "cloud",
+          "code",
+          "coffee",
+          "compass",
+          "credit-card",
+          "crown",
+          "dog",
+          "file-text",
+          "fish",
+          "flag",
+          "flame",
+          "flask-conical",
+          "folder",
+          "gamepad-2",
+          "gem",
+          "ghost",
+          "gift",
+          "globe",
+          "graduation-cap",
+          "handshake",
+          "hash",
+          "heart",
+          "home",
+          "hourglass",
+          "image",
+          "key",
+          "layers",
+          "leaf",
+          "lightbulb",
+          "link",
+          "lock",
+          "mail",
+          "map-pin",
+          "megaphone",
+          "message-square",
+          "mic",
+          "moon",
+          "music",
+          "newspaper",
+          "package",
+          "pen-line",
+          "phone",
+          "pie-chart",
+          "pizza",
+          "plane",
+          "puzzle",
+          "receipt",
+          "rocket",
+          "send",
+          "settings",
+          "share-2",
+          "shield",
+          "shopping-cart",
+          "smile",
+          "sparkles",
+          "star",
+          "store",
+          "sun",
+          "tag",
+          "target",
+          "terminal",
+          "timer",
+          "trending-up",
+          "trophy",
+          "umbrella",
+          "user",
+          "users",
+          "video",
+          "wallet",
+          "wrench",
+          "zap"
+        ],
+        "title": "TagIcon"
+      },
+      "TagListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TagResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "TagListResponse"
+      },
+      "TagRef": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "examples": [
+              "665f0c2f9e7a4b1d2c3d4e5f"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "examples": [
+              "launch"
+            ]
+          },
+          "color": {
+            "$ref": "#/components/schemas/TagColor",
+            "examples": [
+              "violet"
+            ]
+          },
+          "icon": {
+            "$ref": "#/components/schemas/TagIcon",
+            "examples": [
+              "rocket"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "color",
+          "icon"
+        ],
+        "title": "TagRef",
+        "description": "A tag as it appears on a link: enough to render, no counts."
+      },
+      "TagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "examples": [
+              "665f0c2f9e7a4b1d2c3d4e5f"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "examples": [
+              "launch"
+            ]
+          },
+          "color": {
+            "$ref": "#/components/schemas/TagColor",
+            "examples": [
+              "violet"
+            ]
+          },
+          "icon": {
+            "$ref": "#/components/schemas/TagIcon",
+            "examples": [
+              "rocket"
+            ]
+          },
+          "link_count": {
+            "type": "integer",
+            "title": "Link Count",
+            "description": "Links carrying the tag.",
+            "examples": [
+              14
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "color",
+          "icon",
+          "link_count",
+          "created_at"
+        ],
+        "title": "TagResponse",
+        "description": "A tag on its own endpoints, with its link count."
+      },
       "TestWebhookRequest": {
         "properties": {
           "event_type": {
@@ -13751,6 +14791,42 @@
         "title": "UpdateProfileRequest",
         "description": "Request body for PATCH /auth/me.\n\n``user_name`` is required but nullable: an explicit ``null`` clears\nthe display name (an accidental ``{}`` must not). Bounds mirror\nRegisterRequest \u2014 the two write paths for the same field."
       },
+      "UpdateTagRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Tag name, at most 32 characters. Lowercased and trimmed on write; letters, digits, spaces, `-`, `_` and `.` only. Unique per account."
+          },
+          "color": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TagColor"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "One of the palette keys. Omit on create to get the least-used colour in your account."
+          },
+          "icon": {
+            "$ref": "#/components/schemas/TagIcon",
+            "title": "Icon",
+            "description": "Icon key from the curated set (lucide names). Defaults to `tag`."
+          }
+        },
+        "type": "object",
+        "title": "UpdateTagRequest",
+        "description": "Rename, recolour or change the icon. Omitted fields are left as they are."
+      },
       "UpdateUrlRequest": {
         "properties": {
           "long_url": {
@@ -13852,6 +14928,42 @@
               1735689599
             ]
           },
+          "starts_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starts At",
+            "description": "Go-live time. ISO 8601 string or Unix epoch seconds; must be in the future and before `expire_after`. Pass `null` to make the link live now.",
+            "examples": [
+              "2026-09-10T18:00:00+05:30",
+              1789500000
+            ]
+          },
+          "pre_start_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 8192
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Start Url",
+            "description": "Where visitors are sent before `starts_at`. Pass `null` for the not-yet-live page.",
+            "examples": [
+              "https://example.com/coming-soon"
+            ]
+          },
           "private_stats": {
             "anyOf": [
               {
@@ -13918,6 +15030,42 @@
                 "IN": "https://example.in/",
                 "US": "https://example.com/us"
               }
+            ]
+          },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 8192
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Where visitors land once the link has expired, by time or by click limit, instead of the expired page. Validated like a destination. Pass `null` or empty to remove; omit to keep.",
+            "examples": [
+              "https://example.com/offer-ended"
+            ]
+          },
+          "tag_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Ids",
+            "description": "Ids of tags from `GET /api/v1/tags`, at most 10 per link. Every id must be one of your tags (400 otherwise). On PATCH the list replaces the stored one; `null` or `[]` clears it.",
+            "examples": [
+              [
+                "665f0c2f9e7a4b1d2c3d4e5f"
+              ]
             ]
           },
           "ab_variants": {
@@ -14048,6 +15196,36 @@
               1735689599
             ]
           },
+          "starts_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starts At",
+            "description": "Go-live time as Unix timestamp, or null when live now.",
+            "examples": [
+              1789500000
+            ]
+          },
+          "pre_start_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Start Url",
+            "description": "Where visitors go before `starts_at`, or null for the not-yet-live page.",
+            "examples": [
+              "https://example.com/coming-soon"
+            ]
+          },
           "block_bots": {
             "anyOf": [
               {
@@ -14106,6 +15284,29 @@
                 "IN": "https://example.in/"
               }
             ]
+          },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Destination served once the link has expired, or null.",
+            "examples": [
+              "https://example.com/offer-ended"
+            ]
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "The link's tags (id, name, colour), in the link's order."
           },
           "ab_variants": {
             "anyOf": [
@@ -14340,6 +15541,28 @@
             ],
             "title": "Expire After"
           },
+          "starts_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starts At"
+          },
+          "pre_start_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Start Url"
+          },
           "max_clicks": {
             "anyOf": [
               {
@@ -14424,6 +15647,24 @@
               }
             ],
             "title": "Geo Rules"
+          },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
           },
           "ab_variants": {
             "anyOf": [
@@ -14602,6 +15843,29 @@
               }
             ]
           },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Destination served once the link has expired, or null.",
+            "examples": [
+              "https://example.com/offer-ended"
+            ]
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "The link's tags (id, name, colour), in the link's order."
+          },
           "ab_variants": {
             "anyOf": [
               {
@@ -14667,7 +15931,8 @@
           "ACTIVE",
           "INACTIVE",
           "EXPIRED",
-          "BLOCKED"
+          "BLOCKED",
+          "SCHEDULED"
         ],
         "title": "UrlStatus",
         "description": "Status values for v2 URLs."

--- a/openapi.json
+++ b/openapi.json
@@ -1872,7 +1872,7 @@
           "URL Shortening"
         ],
         "summary": "Create Shortened URL",
-        "description": "Create a new shortened URL.\n\nCreate a shortened URL with optional customization including password\nprotection, expiration, click limits, and bot blocking. Authenticated\nusers may target an owned, ACTIVE custom domain via the ``domain`` field.\n\n**Emoji aliases**: ``alias`` also accepts an emoji-only short code\n(e.g. ``\ud83d\ude80\ud83d\udd25``) \u2014 1-15 fully-qualified emoji; ZWJ sequences, flags,\nkeycaps, and text-style symbols are rejected (they render or copy\ninconsistently across platforms). Set ``alias_type: \"emoji\"`` to\nauto-generate an emoji code instead of an alphanumeric one. Stored\nand returned in canonical form (variation selectors stripped).\n\n**Authentication**: Optional \u2014 higher rate limits when authenticated.\nRequired if ``domain`` is supplied.\n\n**API Key Scope**: `shorten:create` or `admin:all`\n\n**Rate Limits**:\n\n- Authenticated: 60/min, 5,000/day\n- Anonymous: 20/min, 1,000/day\n\n**Anonymous Usage Consequences**:\n\n- Lower rate limits\n- Cannot manage or view URLs later\n- Cannot use private stats\n- URLs not linked to any account\n- Cannot use custom domains\n- Cannot use geo targeting\n- Cannot set an expired-link fallback\n- Cannot use custom meta tags",
+        "description": "Create a new shortened URL.\n\nCreate a shortened URL with optional customization including password\nprotection, expiration, click limits, and bot blocking. Authenticated\nusers may target an owned, ACTIVE custom domain via the ``domain`` field.\n\n**Emoji aliases**: ``alias`` also accepts an emoji-only short code\n(e.g. ``\ud83d\ude80\ud83d\udd25``) \u2014 1-15 fully-qualified emoji; ZWJ sequences, flags,\nkeycaps, and text-style symbols are rejected (they render or copy\ninconsistently across platforms). Set ``alias_type: \"emoji\"`` to\nauto-generate an emoji code instead of an alphanumeric one. Stored\nand returned in canonical form (variation selectors stripped).\n\n**Authentication**: Optional \u2014 higher rate limits when authenticated.\nRequired if ``domain`` is supplied.\n\n**API Key Scope**: `shorten:create` or `admin:all`\n\n**Rate Limits**:\n\n- Authenticated: 60/min, 5,000/day\n- Anonymous: 20/min, 1,000/day\n\n**Anonymous Usage Consequences**:\n\n- Lower rate limits\n- Cannot manage or view URLs later\n- Cannot use private stats\n- URLs not linked to any account\n- Cannot use custom domains\n- Cannot use geo targeting\n- Cannot use A/B variants\n- Cannot use custom meta tags",
         "operationId": "shortenUrl",
         "requestBody": {
           "content": {
@@ -2198,7 +2198,7 @@
           "Link Management"
         ],
         "summary": "List Your URLs",
-        "description": "List all URLs owned by the authenticated user.\n\nReturns a paginated list of shortened URLs with support for filtering,\nsorting, and full-text search on aliases and destination URLs.\n\n**Authentication**: Required.\n\n**API Key Scope**: `urls:manage`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Pagination**: Use `page` and `pageSize` query params. Response includes\n`hasNext` boolean and `total` count.\n\n**Sorting**: Sort by `created_at`, `last_click`, or `total_clicks` in\nascending or descending order.\n\n**Filtering**: Pass a JSON-encoded `filter` parameter with fields like\n`status`, `createdAfter`, `createdBefore`, `passwordSet`, `maxClicksSet`,\n`search`, `tagIds`, `tagNames` and `tagsMatch`.",
+        "description": "List all URLs owned by the authenticated user.\n\nReturns a paginated list of shortened URLs with support for filtering,\nsorting, and full-text search on aliases and destination URLs.\n\n**Authentication**: Required.\n\n**API Key Scope**: `urls:manage`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Pagination**: Use `page` and `pageSize` query params. Response includes\n`hasNext` boolean and `total` count.\n\n**Sorting**: Sort by `created_at`, `last_click`, or `total_clicks` in\nascending or descending order.\n\n**Filtering**: Pass a JSON-encoded `filter` parameter with fields like\n`status`, `createdAfter`, `createdBefore`, `passwordSet`, `maxClicksSet`,\nand `search`.",
         "operationId": "listUrls",
         "parameters": [
           {
@@ -2285,7 +2285,7 @@
                   "type": "null"
                 }
               ],
-              "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n- **tagIds** \u2014 Only links carrying these tags, by id (array of strings)\n- **tagNames** \u2014 Same, by tag name; unknown names match nothing\n- **tagsMatch** \u2014 `\"any\"` (default) or `\"all\"`; how multiple tags combine\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n- **tagIds / tagNames**: Array of strings\n- **tagsMatch**: String \u2014 `\"any\"` or `\"all\"`\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"tagNames\": [\"launch\", \"q3\"], \"tagsMatch\": \"all\"}` \u2014 URLs tagged both launch and q3\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024",
+              "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024",
               "examples": [
                 "{\"status\":\"ACTIVE\"}",
                 "{\"passwordSet\": true}",
@@ -2296,7 +2296,7 @@
               ],
               "title": "Filter"
             },
-            "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n- **tagIds** \u2014 Only links carrying these tags, by id (array of strings)\n- **tagNames** \u2014 Same, by tag name; unknown names match nothing\n- **tagsMatch** \u2014 `\"any\"` (default) or `\"all\"`; how multiple tags combine\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n- **tagIds / tagNames**: Array of strings\n- **tagsMatch**: String \u2014 `\"any\"` or `\"all\"`\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"tagNames\": [\"launch\", \"q3\"], \"tagsMatch\": \"all\"}` \u2014 URLs tagged both launch and q3\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024"
+            "description": "JSON string containing filter criteria for URLs. Format: `{\"field\": value}`\n\n**Available filter fields:**\n\n- **status** \u2014 Filter by URL status (`\"ACTIVE\"` or `\"INACTIVE\"`)\n- **createdAfter** \u2014 Filter URLs created after this date (ISO 8601 datetime or Unix timestamp)\n- **createdBefore** \u2014 Filter URLs created before this date (ISO 8601 datetime or Unix timestamp)\n- **passwordSet** \u2014 Filter by password protection (boolean: `true`/`false`)\n- **maxClicksSet** \u2014 Filter by click limit presence (boolean: `true`/`false`)\n- **search** \u2014 Search in alias or long_url (case-insensitive string)\n\n**Value formats:**\n\n- **status**: String \u2014 `\"ACTIVE\"` or `\"INACTIVE\"` (case-sensitive)\n- **createdAfter / createdBefore**: ISO 8601 datetime string (e.g., `\"2024-01-01T00:00:00Z\"`) or Unix timestamp (e.g., `1704067200`)\n- **passwordSet / maxClicksSet**: Boolean \u2014 `true` or `false`\n- **search**: String \u2014 case-insensitive search term\n\n**Examples:**\n\n- `{\"status\": \"ACTIVE\"}` \u2014 Only active URLs\n- `{\"passwordSet\": true}` \u2014 Only password-protected URLs\n- `{\"createdAfter\": \"2024-01-01T00:00:00Z\"}` \u2014 URLs created after Jan 1, 2024\n- `{\"status\": \"ACTIVE\", \"maxClicksSet\": true}` \u2014 Active URLs with click limits\n- `{\"search\": \"example\"}` \u2014 URLs containing \"example\" in alias or long_url\n- `{\"createdAfter\": \"2024-01-01\", \"createdBefore\": \"2024-12-31\", \"status\": \"ACTIVE\"}` \u2014 Active URLs from 2024"
           },
           {
             "name": "filterBy",
@@ -2621,7 +2621,7 @@
           "Link Management"
         ],
         "summary": "Update URL",
-        "description": "Update an existing URL's properties.\n\nPartially update a shortened URL. Only provided fields are modified; omitted\nfields remain unchanged. Pass `null` to remove optional settings like\n`password`, `max_clicks`, or `expire_after`.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 120/min, 2,000/day\n\n**Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,\n`max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,\n`geo_rules`, `expired_redirect_url`, `meta_tags`\n\n**Notes**:\n\n- Setting `max_clicks` to `0` or `null` removes the click limit\n- Changing the `alias` checks availability and may fail with 409 Conflict\n- Setting `domain` moves the URL to a different tenant; caller must own\n  the target as an ACTIVE custom domain, or pass `null` to move back to\n  the system default. Alias collision is verified on the target.\n- `geo_rules` replaces the whole map; pass `null` or `{}` to remove all\n  rules\n- `expired_redirect_url` is where visitors land once the link has expired;\n  pass `null` to go back to the expired page\n- The `url_id` is the MongoDB ObjectId, not the alias",
+        "description": "Update an existing URL's properties.\n\nPartially update a shortened URL. Only provided fields are modified; omitted\nfields remain unchanged. Pass `null` to remove optional settings like\n`password`, `max_clicks`, or `expire_after`.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 120/min, 2,000/day\n\n**Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,\n`max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,\n`geo_rules`, `ab_variants`, `meta_tags`\n\n**Notes**:\n\n- Setting `max_clicks` to `0` or `null` removes the click limit\n- Changing the `alias` checks availability and may fail with 409 Conflict\n- Setting `domain` moves the URL to a different tenant; caller must own\n  the target as an ACTIVE custom domain, or pass `null` to move back to\n  the system default. Alias collision is verified on the target.\n- `geo_rules` replaces the whole map; pass `null` or `{}` to remove all\n  rules\n- `ab_variants` replaces the whole list; pass `null` or `[]` to remove all\n  variants\n- The `url_id` is the MongoDB ObjectId, not the alias",
         "operationId": "updateUrl",
         "parameters": [
           {
@@ -3311,464 +3311,6 @@
         }
       }
     },
-    "/api/v1/urls/bulk/tags": {
-      "post": {
-        "tags": [
-          "Link Management"
-        ],
-        "summary": "Bulk Tag URLs",
-        "description": "Add and remove tags (by tag id) on up to 100 URLs you own in one request.\n\nPer item the result is the link's current tags minus `remove`, plus\n`add` (kept once, order preserved). A link that already reads that\nway is a success no-op. Every id in `add` must be one of your tags\n(`GET /tags`); an unknown one rejects the whole request before any\nitem is touched.\n\n**Per-item verdicts** (`error_code`): `not_found` \u2014 no such URL in\nyour account; `forbidden` \u2014 the URL is admin-blocked;\n`validation_error` \u2014 the result would exceed 10 tags on that link.\n\n**Retry semantics**: re-sending the batch is safe \u2014 items already\ncarrying the result report success no-ops.\n\n**Rate Limits**: 60/min, 200/day \u2014 counted per request, not per id.",
-        "operationId": "bulkTagUrls",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkTagUrlsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkUrlOperationResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request \u2014 invalid parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized \u2014 missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden \u2014 insufficient permissions or scope",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/tags": {
-      "get": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "List Your Tags",
-        "description": "Every tag in your account with the number of links carrying it,\noldest first.\n\n**API Key Scope**: `urls:manage`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day",
-        "operationId": "listTags",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagListResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request \u2014 invalid parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized \u2014 missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden \u2014 insufficient permissions or scope",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Create a Tag",
-        "description": "Create a tag. Names are lowercased and trimmed; a name you already\nhave answers `409 conflict`. Omit `color` to get the least-used palette\ncolour in your account; omit `icon` for the generic tag glyph. At most\n500 tags per account.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 30/min",
-        "operationId": "createTag",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateTagRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request \u2014 invalid parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized \u2014 missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden \u2014 insufficient permissions or scope",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/tags/{tag_id}": {
-      "patch": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Rename or Recolour a Tag",
-        "description": "Change the name, colour or icon. Links keep pointing at the tag\nby id, so a rename shows up everywhere at once. Renaming onto a name you\nalready have answers `409 conflict`.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 30/min",
-        "operationId": "updateTag",
-        "parameters": [
-          {
-            "name": "tag_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Tag id (MongoDB ObjectId), as returned by GET /tags.",
-              "examples": [
-                "665f0c2f9e7a4b1d2c3d4e5f"
-              ],
-              "title": "Tag Id"
-            },
-            "description": "Tag id (MongoDB ObjectId), as returned by GET /tags."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTagRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request \u2014 invalid parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized \u2014 missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden \u2014 insufficient permissions or scope",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Delete a Tag",
-        "description": "Delete the tag and remove it from every link that carried it. The\nlinks themselves are untouched otherwise.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 10/min. Deleting fans out an update over every link\nyou own, so it carries the same budget as bulk delete.",
-        "operationId": "deleteTag",
-        "parameters": [
-          {
-            "name": "tag_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Tag id (MongoDB ObjectId), as returned by GET /tags.",
-              "examples": [
-                "665f0c2f9e7a4b1d2c3d4e5f"
-              ],
-              "title": "Tag Id"
-            },
-            "description": "Tag id (MongoDB ObjectId), as returned by GET /tags."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagDeleteResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request \u2014 invalid parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized \u2014 missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden \u2014 insufficient permissions or scope",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/urls/claim": {
       "post": {
         "tags": [
@@ -3985,7 +3527,7 @@
           "Statistics"
         ],
         "summary": "URL Statistics",
-        "description": "Get aggregated click statistics across all URLs you own.\n\nRetrieve click analytics with flexible grouping, filtering, and\ntime-range options.\n\n**Authentication**: Required.\n\n**API Key Scope**: `stats:read`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,\n`city`, `referrer`, `short_code`, `utm_source`, `utm_medium`,\n`utm_campaign`\n\n**Metrics**: `clicks`, `unique_clicks`\n\n**Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,\n`referrer`, `short_code`, `url_id`, or the `utm_*` tags using query\nparams or a JSON `filters` object. Filters slice your own aggregate \u2014\n`url_id` values you do not own simply match nothing. For statistics on\na single link, prefer `GET /stats/links/{url_id}`.",
+        "description": "Get aggregated click statistics across all URLs you own.\n\nRetrieve click analytics with flexible grouping, filtering, and\ntime-range options.\n\n**Authentication**: Required.\n\n**API Key Scope**: `stats:read`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,\n`city`, `referrer`, `short_code`, `utm_source`, `utm_medium`,\n`utm_campaign`, `variant`\n\n**Metrics**: `clicks`, `unique_clicks`\n\n**Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,\n`referrer`, `short_code`, `url_id`, `variant`, or the `utm_*` tags using\nquery params or a JSON `filters` object. Filters slice your own aggregate \u2014\n`url_id` values you do not own simply match nothing. For statistics on\na single link, prefer `GET /stats/links/{url_id}`.",
         "operationId": "getStats",
         "parameters": [
           {
@@ -4046,7 +3588,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -4054,7 +3596,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -4110,14 +3652,14 @@
                   "type": "null"
                 }
               ],
-              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
+              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
               "examples": [
                 "{\"browser\":[\"Chrome\",\"Firefox\"]}",
                 "{\"country\":[\"United States\",\"Canada\"],\"browser\":[\"Chrome\"]}"
               ],
               "title": "Filters"
             },
-            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
+            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
           },
           {
             "name": "browser",
@@ -4318,6 +3860,29 @@
             "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated campaign tag values. Alternative to using the `filters` JSON parameter.\n\n**Important:** Values are case-sensitive. `(none)` matches clicks with no tag.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
           },
           {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined.",
+              "examples": [
+                "0,1",
+                "(default)"
+              ],
+              "title": "Variant"
+            },
+            "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
+          },
+          {
             "name": "short_code",
             "in": "query",
             "required": false,
@@ -4360,50 +3925,6 @@
               "title": "Url Id"
             },
             "description": "Comma-separated URL ids (MongoDB ObjectIds) to filter stats to specific URLs you own. Slices your own aggregate \u2014 ids you do not own simply match nothing.\n\nFor statistics on a single link, prefer `GET /api/v1/stats/links/{url_id}`."
-          },
-          {
-            "name": "tag",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "maxLength": 500
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`.",
-              "examples": [
-                "launch,q3"
-              ],
-              "title": "Tag"
-            },
-            "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`."
-          },
-          {
-            "name": "tag_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "maxLength": 1000
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only.",
-              "examples": [
-                "665f0c2f9e7a4b1d2c3d4e5f"
-              ],
-              "title": "Tag Id"
-            },
-            "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only."
           }
         ],
         "responses": {
@@ -4486,7 +4007,7 @@
           "Statistics"
         ],
         "summary": "Link Statistics",
-        "description": "Get click statistics for a single URL you own.\n\nThe same aggregated analytics as `GET /stats`, pre-scoped to one link \u2014\nthe response additionally echoes the link's `url_id` and `alias`.\nCustom-domain links are safe here: clicks are matched by URL id, so a\nsame-alias link on another domain can never bleed in.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `stats:read`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,\n`city`, `referrer`, `utm_source`, `utm_medium`, `utm_campaign`\n\n**Metrics**: `clicks`, `unique_clicks`\n\n**Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,\n`referrer`, or the `utm_*` tags using query params or a JSON `filters`\nobject. Link-identity filters (`short_code`, `url_id`) do not exist\nhere \u2014 the path already selects the link.\n\n**Errors**:\n\n- `400` \u2014 malformed id (not a valid ObjectId)\n- `404` \u2014 no URL with that id in your account. A URL owned by someone\n  else answers identically; this endpoint never confirms foreign ids.",
+        "description": "Get click statistics for a single URL you own.\n\nThe same aggregated analytics as `GET /stats`, pre-scoped to one link \u2014\nthe response additionally echoes the link's `url_id` and `alias`.\nCustom-domain links are safe here: clicks are matched by URL id, so a\nsame-alias link on another domain can never bleed in.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `stats:read`, `urls:read`, or `admin:all`\n\n**Rate Limits**: 60/min, 5,000/day\n\n**Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,\n`city`, `referrer`, `utm_source`, `utm_medium`, `utm_campaign`, `variant`\n\n**Metrics**: `clicks`, `unique_clicks`\n\n**Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,\n`referrer`, `variant`, or the `utm_*` tags using query params or a JSON\n`filters` object. Link-identity filters (`short_code`, `url_id`) do not exist\nhere \u2014 the path already selects the link.\n\n**Errors**:\n\n- `400` \u2014 malformed id (not a valid ObjectId)\n- `404` \u2014 no URL with that id in your account. A URL owned by someone\n  else answers identically; this endpoint never confirms foreign ids.",
         "operationId": "getLinkStats",
         "parameters": [
           {
@@ -4558,7 +4079,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -4566,7 +4087,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -4622,14 +4143,14 @@
                   "type": "null"
                 }
               ],
-              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
+              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
               "examples": [
                 "{\"browser\":[\"Chrome\",\"Firefox\"]}",
                 "{\"country\":[\"United States\",\"Canada\"],\"browser\":[\"Chrome\"]}"
               ],
               "title": "Filters"
             },
-            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
+            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
           },
           {
             "name": "browser",
@@ -4828,6 +4349,29 @@
               "title": "Utm Campaign"
             },
             "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated campaign tag values. Alternative to using the `filters` JSON parameter.\n\n**Important:** Values are case-sensitive. `(none)` matches clicks with no tag.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
+          },
+          {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined.",
+              "examples": [
+                "0,1",
+                "(default)"
+              ],
+              "title": "Variant"
+            },
+            "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
           }
         ],
         "responses": {
@@ -5329,7 +4873,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -5337,7 +4881,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `short_code` \u2014 group by URL alias\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -5393,14 +4937,14 @@
                   "type": "null"
                 }
               ],
-              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
+              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
               "examples": [
                 "{\"browser\":[\"Chrome\",\"Firefox\"]}",
                 "{\"country\":[\"United States\",\"Canada\"],\"browser\":[\"Chrome\"]}"
               ],
               "title": "Filters"
             },
-            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `tag` / `tag_id` \u2014 Filter by link tag (name or id); clicks on your links carrying any listed tag\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
+            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `short_code` \u2014 Filter by URL alias (e.g., mylink, promo2024)\n- `url_id` \u2014 Filter by URL id (MongoDB ObjectId); ids you do not own match nothing\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n- `{\"short_code\": [\"link1\", \"link2\"]}` \u2014 Stats for specific URLs\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
           },
           {
             "name": "browser",
@@ -5601,6 +5145,29 @@
             "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated campaign tag values. Alternative to using the `filters` JSON parameter.\n\n**Important:** Values are case-sensitive. `(none)` matches clicks with no tag.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
           },
           {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined.",
+              "examples": [
+                "0,1",
+                "(default)"
+              ],
+              "title": "Variant"
+            },
+            "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
+          },
+          {
             "name": "short_code",
             "in": "query",
             "required": false,
@@ -5643,50 +5210,6 @@
               "title": "Url Id"
             },
             "description": "Comma-separated URL ids (MongoDB ObjectIds) to filter stats to specific URLs you own. Slices your own aggregate \u2014 ids you do not own simply match nothing.\n\nFor statistics on a single link, prefer `GET /api/v1/stats/links/{url_id}`."
-          },
-          {
-            "name": "tag",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "maxLength": 500
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`.",
-              "examples": [
-                "launch,q3"
-              ],
-              "title": "Tag"
-            },
-            "description": "Comma-separated tag names. Scopes the aggregate to clicks on your links carrying at least one of them (resolved to link ids at query time, so a tag added today covers the link's whole click history). Filter only: `tag` is not a `group_by` dimension. See also `tag_id`."
-          },
-          {
-            "name": "tag_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "maxLength": 1000
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only.",
-              "examples": [
-                "665f0c2f9e7a4b1d2c3d4e5f"
-              ],
-              "title": "Tag Id"
-            },
-            "description": "Comma-separated tag ids (from `GET /api/v1/tags`). Same scope as `tag`, by id. Filter only."
           }
         ],
         "responses": {
@@ -5889,7 +5412,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
+              "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser.",
               "examples": [
                 "time,browser",
                 "country",
@@ -5897,7 +5420,7 @@
               ],
               "title": "Group By"
             },
-            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
+            "description": "Comma-separated grouping dimensions for the statistics breakdown. Defaults to `time` if omitted.\n\n**Available dimensions:**\n\n- `time` \u2014 group by time buckets (day/week/month, auto-selected based on range)\n- `browser` \u2014 group by browser name (e.g., Chrome, Firefox, Safari)\n- `os` \u2014 group by operating system (e.g., Windows, macOS, Linux)\n- `device` \u2014 group by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 group by country\n- `city` \u2014 group by city\n- `referrer` \u2014 group by referrer URL\n- `utm_source` \u2014 group by the `utm_source` tag on the short link (untagged clicks appear as `(none)`)\n- `utm_medium` \u2014 group by the `utm_medium` tag\n- `utm_campaign` \u2014 group by the `utm_campaign` tag\n- `variant` \u2014 group by the A/B variant served, as its index into `ab_variants` (`0`, `1`, ...); clicks sent to the default destination appear as `(default)`\n\nMultiple dimensions can be combined: `time,browser` returns time series broken down by browser."
           },
           {
             "name": "metrics",
@@ -5953,14 +5476,14 @@
                   "type": "null"
                 }
               ],
-              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
+              "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below).",
               "examples": [
                 "{\"browser\":[\"Chrome\",\"Firefox\"]}",
                 "{\"country\":[\"United States\",\"Canada\"],\"browser\":[\"Chrome\"]}"
               ],
               "title": "Filters"
             },
-            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
+            "description": "**Method 1: JSON Filters Object**\n\nJSON string containing dimension filters. Format: `{\"dimension\": [\"value1\", \"value2\"]}`\n\n**Available filter dimensions:**\n\n- `browser` \u2014 Filter by browser name (e.g., Chrome, Firefox, Safari, Edge)\n- `os` \u2014 Filter by operating system (e.g., Windows, macOS, Linux, iOS, Android)\n- `device` \u2014 Filter by device type (`mobile`, `tablet`, `desktop`, `unknown`)\n- `country` \u2014 Filter by country name (e.g., United States, Canada, Germany)\n- `city` \u2014 Filter by city name (e.g., New York, London, Mumbai)\n- `referrer` \u2014 Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n- `utm_source` / `utm_medium` / `utm_campaign` \u2014 Filter by campaign tags; `(none)` matches untagged clicks\n- `variant` \u2014 Filter by A/B variant index (`0`, `1`, ...); `(default)` matches clicks sent to the default destination\n\n**Value format:** Array of strings for each dimension.\n\n**Important:** Filter values are case-sensitive. Use exact capitalization as stored in the database.\n\n**Examples:**\n\n- `{\"browser\": [\"Chrome\", \"Firefox\"]}` \u2014 Chrome OR Firefox clicks\n- `{\"country\": [\"United States\", \"Canada\"], \"browser\": [\"Chrome\"]}` \u2014 US/CA clicks from Chrome\n\n**Alternative:** You can also pass filters as individual query parameters (see `browser`, `os`, `country`, `city`, `referrer` parameters below)."
           },
           {
             "name": "browser",
@@ -6159,6 +5682,29 @@
               "title": "Utm Campaign"
             },
             "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated campaign tag values. Alternative to using the `filters` JSON parameter.\n\n**Important:** Values are case-sensitive. `(none)` matches clicks with no tag.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
+          },
+          {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined.",
+              "examples": [
+                "0,1",
+                "(default)"
+              ],
+              "title": "Variant"
+            },
+            "description": "**Method 2: Individual Filter Parameter**\n\nComma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches clicks sent to the default destination, including every click on a link without variants.\n\n**Note:** Both `filters` JSON and individual parameters can be combined."
           }
         ],
         "responses": {
@@ -9849,6 +9395,58 @@
   },
   "components": {
     "schemas": {
+      "AbVariantRequest": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "maxLength": 8192,
+            "minLength": 1,
+            "title": "Url",
+            "description": "Destination URL for this variant.",
+            "examples": [
+              "https://example.com/b"
+            ]
+          },
+          "weight": {
+            "type": "integer",
+            "maximum": 100.0,
+            "minimum": 1.0,
+            "title": "Weight",
+            "description": "Percentage of visitors sent to this variant (1-100).",
+            "examples": [
+              40
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "weight"
+        ],
+        "title": "AbVariantRequest",
+        "description": "One A/B split destination as sent on create/update."
+      },
+      "AbVariantResponse": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "Variant destination URL."
+          },
+          "weight": {
+            "type": "integer",
+            "title": "Weight",
+            "description": "Percentage of visitors sent here."
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "weight"
+        ],
+        "title": "AbVariantResponse",
+        "description": "One A/B split destination."
+      },
       "AccountDeletionResponse": {
         "properties": {
           "purge_after": {
@@ -10542,59 +10140,6 @@
         "title": "BulkOperationSummary",
         "description": "Counts derived from the result rows."
       },
-      "BulkTagUrlsRequest": {
-        "properties": {
-          "ids": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "maxItems": 100,
-            "minItems": 1,
-            "title": "Ids",
-            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
-            "examples": [
-              [
-                "665f0c2f9e7a4b1d2c3d4e5f",
-                "665f0c2f9e7a4b1d2c3d4e60"
-              ]
-            ]
-          },
-          "add": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "maxItems": 10,
-            "title": "Add",
-            "description": "Tag ids to add to every id (at most 10); every one must be a tag you own. Tags a link already carries are kept once.",
-            "examples": [
-              [
-                "665f0c2f9e7a4b1d2c3d4e5f"
-              ]
-            ]
-          },
-          "remove": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Remove",
-            "description": "Tag ids to remove from every id. Tags a link does not carry are ignored.",
-            "examples": [
-              [
-                "665f0c2f9e7a4b1d2c3d4e60"
-              ]
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "ids"
-        ],
-        "title": "BulkTagUrlsRequest",
-        "description": "Request body for bulk tag / untag, by tag id.\n\nAt least one of ``add`` or ``remove`` must name a tag, and no tag may be\nin both."
-      },
       "BulkUpdateExpiryRequest": {
         "properties": {
           "ids": {
@@ -11113,46 +10658,6 @@
         "title": "CreateReportsRequest",
         "description": "Request body for POST /api/v1/reports.\n\n``items`` size is validated in the service (anonymous \u2264 25,\nauthenticated \u2264 100; empty \u2192 400) because the cap depends on the\ncaller's auth state."
       },
-      "CreateTagRequest": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 64,
-            "title": "Name",
-            "description": "Tag name, at most 32 characters. Lowercased and trimmed on write; letters, digits, spaces, `-`, `_` and `.` only. Unique per account.",
-            "examples": [
-              "launch"
-            ]
-          },
-          "color": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TagColor"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "One of the palette keys. Omit on create to get the least-used colour in your account.",
-            "examples": [
-              "violet"
-            ]
-          },
-          "icon": {
-            "$ref": "#/components/schemas/TagIcon",
-            "description": "Icon key from the curated set (lucide names). Defaults to `tag`.",
-            "default": "tag",
-            "examples": [
-              "rocket"
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "CreateTagRequest"
-      },
       "CreateUrlRequest": {
         "properties": {
           "long_url": {
@@ -11257,42 +10762,6 @@
               1735689599
             ]
           },
-          "starts_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Starts At",
-            "description": "Go-live time. The link is not live before this moment. ISO 8601 string or Unix epoch seconds; must be in the future and before `expire_after`. Requires authentication.",
-            "examples": [
-              "2026-09-10T18:00:00+05:30",
-              1789500000
-            ]
-          },
-          "pre_start_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 8192
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pre Start Url",
-            "description": "Where visitors are sent before `starts_at`. Omit for the not-yet-live page. No effect without `starts_at`.",
-            "examples": [
-              "https://example.com/coming-soon"
-            ]
-          },
           "private_stats": {
             "anyOf": [
               {
@@ -11342,27 +10811,11 @@
               }
             ]
           },
-          "expired_redirect_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 8192
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expired Redirect Url",
-            "description": "Where visitors land once the link has expired, by time or by click limit, instead of the expired page. Validated like a destination. Requires authentication.",
-            "examples": [
-              "https://example.com/offer-ended"
-            ]
-          },
-          "tag_ids": {
+          "ab_variants": {
             "anyOf": [
               {
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/AbVariantRequest"
                 },
                 "type": "array"
               },
@@ -11370,11 +10823,14 @@
                 "type": "null"
               }
             ],
-            "title": "Tag Ids",
-            "description": "Ids of tags from `GET /api/v1/tags`, at most 10 per link. Every id must be one of your tags (400 otherwise). On PATCH the list replaces the stored one; `null` or `[]` clears it.",
+            "title": "Ab Variants",
+            "description": "Weighted split destinations: each entry is `{url, weight}` where `weight` is the percentage of visitors sent there (integers, summing to at most 100). The default destination (`url`) receives the remainder. Requires authentication.",
             "examples": [
               [
-                "665f0c2f9e7a4b1d2c3d4e5f"
+                {
+                  "url": "https://example.com/b",
+                  "weight": 40
+                }
               ]
             ]
           },
@@ -13339,17 +12795,6 @@
             ],
             "title": "Long Url"
           },
-          "expired_redirect_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expired Redirect Url"
-          },
           "created_at": {
             "anyOf": [
               {
@@ -13368,8 +12813,7 @@
               "active",
               "inactive",
               "expired",
-              "blocked",
-              "scheduled"
+              "blocked"
             ],
             "title": "Status"
           },
@@ -13428,8 +12872,7 @@
               "active",
               "inactive",
               "expired",
-              "blocked",
-              "scheduled"
+              "blocked"
             ],
             "title": "Status"
           },
@@ -13443,17 +12886,6 @@
               }
             ],
             "title": "Created At"
-          },
-          "starts_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Starts At"
           },
           "password_protected": {
             "type": "boolean",
@@ -13482,16 +12914,6 @@
               }
             ],
             "title": "Geo Destinations"
-          },
-          "expired_destination": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PreviewDestination"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "type": "object",
@@ -13506,7 +12928,7 @@
           "geo_destinations"
         ],
         "title": "PublicPreviewResponse",
-        "description": "Response body for the public link preview endpoint.\n\n``destination`` and ``geo_destinations`` are non-null only while the\nlink is active and not password-protected \u2014 the preview never reveals\na destination the redirect would refuse to serve. The rule runs both\nways: ``expired_destination`` names where an expired link still sends\nevery visitor when its owner set a fallback, so the preview never shows\nLESS than the redirect serves either."
+        "description": "Response body for the public link preview endpoint.\n\n``destination`` and ``geo_destinations`` are non-null only while the\nlink is active and not password-protected \u2014 the preview never reveals\na destination the redirect would refuse to serve."
       },
       "PublicStatsBody": {
         "properties": {
@@ -14191,253 +13613,6 @@
         "title": "StatsTimeRange",
         "description": "Time range metadata inside StatsResponse."
       },
-      "TagColor": {
-        "type": "string",
-        "enum": [
-          "gray",
-          "red",
-          "orange",
-          "amber",
-          "green",
-          "teal",
-          "blue",
-          "violet",
-          "pink"
-        ],
-        "title": "TagColor",
-        "description": "Fixed palette; the dashboard maps each key to a muted dot colour."
-      },
-      "TagDeleteResponse": {
-        "properties": {
-          "deleted": {
-            "type": "boolean",
-            "title": "Deleted",
-            "default": true
-          },
-          "links_updated": {
-            "type": "integer",
-            "title": "Links Updated",
-            "description": "Links the tag was removed from."
-          }
-        },
-        "type": "object",
-        "required": [
-          "links_updated"
-        ],
-        "title": "TagDeleteResponse"
-      },
-      "TagIcon": {
-        "type": "string",
-        "enum": [
-          "banknote",
-          "bar-chart-3",
-          "beaker",
-          "bell",
-          "bird",
-          "book",
-          "bookmark",
-          "box",
-          "briefcase",
-          "bug",
-          "building",
-          "calendar",
-          "camera",
-          "car",
-          "cat",
-          "clock",
-          "cloud",
-          "code",
-          "coffee",
-          "compass",
-          "credit-card",
-          "crown",
-          "dog",
-          "file-text",
-          "fish",
-          "flag",
-          "flame",
-          "flask-conical",
-          "folder",
-          "gamepad-2",
-          "gem",
-          "ghost",
-          "gift",
-          "globe",
-          "graduation-cap",
-          "handshake",
-          "hash",
-          "heart",
-          "home",
-          "hourglass",
-          "image",
-          "key",
-          "layers",
-          "leaf",
-          "lightbulb",
-          "link",
-          "lock",
-          "mail",
-          "map-pin",
-          "megaphone",
-          "message-square",
-          "mic",
-          "moon",
-          "music",
-          "newspaper",
-          "package",
-          "pen-line",
-          "phone",
-          "pie-chart",
-          "pizza",
-          "plane",
-          "puzzle",
-          "receipt",
-          "rocket",
-          "send",
-          "settings",
-          "share-2",
-          "shield",
-          "shopping-cart",
-          "smile",
-          "sparkles",
-          "star",
-          "store",
-          "sun",
-          "tag",
-          "target",
-          "terminal",
-          "timer",
-          "trending-up",
-          "trophy",
-          "umbrella",
-          "user",
-          "users",
-          "video",
-          "wallet",
-          "wrench",
-          "zap"
-        ],
-        "title": "TagIcon"
-      },
-      "TagListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/TagResponse"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "TagListResponse"
-      },
-      "TagRef": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id",
-            "examples": [
-              "665f0c2f9e7a4b1d2c3d4e5f"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "examples": [
-              "launch"
-            ]
-          },
-          "color": {
-            "$ref": "#/components/schemas/TagColor",
-            "examples": [
-              "violet"
-            ]
-          },
-          "icon": {
-            "$ref": "#/components/schemas/TagIcon",
-            "examples": [
-              "rocket"
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "color",
-          "icon"
-        ],
-        "title": "TagRef",
-        "description": "A tag as it appears on a link: enough to render, no counts."
-      },
-      "TagResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id",
-            "examples": [
-              "665f0c2f9e7a4b1d2c3d4e5f"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "examples": [
-              "launch"
-            ]
-          },
-          "color": {
-            "$ref": "#/components/schemas/TagColor",
-            "examples": [
-              "violet"
-            ]
-          },
-          "icon": {
-            "$ref": "#/components/schemas/TagIcon",
-            "examples": [
-              "rocket"
-            ]
-          },
-          "link_count": {
-            "type": "integer",
-            "title": "Link Count",
-            "description": "Links carrying the tag.",
-            "examples": [
-              14
-            ]
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "color",
-          "icon",
-          "link_count",
-          "created_at"
-        ],
-        "title": "TagResponse",
-        "description": "A tag on its own endpoints, with its link count."
-      },
       "TestWebhookRequest": {
         "properties": {
           "event_type": {
@@ -14576,42 +13751,6 @@
         "title": "UpdateProfileRequest",
         "description": "Request body for PATCH /auth/me.\n\n``user_name`` is required but nullable: an explicit ``null`` clears\nthe display name (an accidental ``{}`` must not). Bounds mirror\nRegisterRequest \u2014 the two write paths for the same field."
       },
-      "UpdateTagRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Tag name, at most 32 characters. Lowercased and trimmed on write; letters, digits, spaces, `-`, `_` and `.` only. Unique per account."
-          },
-          "color": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TagColor"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "One of the palette keys. Omit on create to get the least-used colour in your account."
-          },
-          "icon": {
-            "$ref": "#/components/schemas/TagIcon",
-            "title": "Icon",
-            "description": "Icon key from the curated set (lucide names). Defaults to `tag`."
-          }
-        },
-        "type": "object",
-        "title": "UpdateTagRequest",
-        "description": "Rename, recolour or change the icon. Omitted fields are left as they are."
-      },
       "UpdateUrlRequest": {
         "properties": {
           "long_url": {
@@ -14713,42 +13852,6 @@
               1735689599
             ]
           },
-          "starts_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Starts At",
-            "description": "Go-live time. ISO 8601 string or Unix epoch seconds; must be in the future and before `expire_after`. Pass `null` to make the link live now.",
-            "examples": [
-              "2026-09-10T18:00:00+05:30",
-              1789500000
-            ]
-          },
-          "pre_start_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 8192
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pre Start Url",
-            "description": "Where visitors are sent before `starts_at`. Pass `null` for the not-yet-live page.",
-            "examples": [
-              "https://example.com/coming-soon"
-            ]
-          },
           "private_stats": {
             "anyOf": [
               {
@@ -14817,27 +13920,11 @@
               }
             ]
           },
-          "expired_redirect_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 8192
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expired Redirect Url",
-            "description": "Where visitors land once the link has expired, by time or by click limit, instead of the expired page. Validated like a destination. Pass `null` or empty to remove; omit to keep.",
-            "examples": [
-              "https://example.com/offer-ended"
-            ]
-          },
-          "tag_ids": {
+          "ab_variants": {
             "anyOf": [
               {
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/AbVariantRequest"
                 },
                 "type": "array"
               },
@@ -14845,11 +13932,14 @@
                 "type": "null"
               }
             ],
-            "title": "Tag Ids",
-            "description": "Ids of tags from `GET /api/v1/tags`, at most 10 per link. Every id must be one of your tags (400 otherwise). On PATCH the list replaces the stored one; `null` or `[]` clears it.",
+            "title": "Ab Variants",
+            "description": "Weighted split destinations: each entry is `{url, weight}` where `weight` is the percentage of visitors sent there (integers, summing to at most 100). The default destination (`url`) receives the remainder. Requires authentication. The list replaces any existing variants in full. Pass `null` or `[]` to remove all variants; omit to keep them unchanged.",
             "examples": [
               [
-                "665f0c2f9e7a4b1d2c3d4e5f"
+                {
+                  "url": "https://example.com/b",
+                  "weight": 40
+                }
               ]
             ]
           },
@@ -14958,36 +14048,6 @@
               1735689599
             ]
           },
-          "starts_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Starts At",
-            "description": "Go-live time as Unix timestamp, or null when live now.",
-            "examples": [
-              1789500000
-            ]
-          },
-          "pre_start_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pre Start Url",
-            "description": "Where visitors go before `starts_at`, or null for the not-yet-live page.",
-            "examples": [
-              "https://example.com/coming-soon"
-            ]
-          },
           "block_bots": {
             "anyOf": [
               {
@@ -15047,28 +14107,28 @@
               }
             ]
           },
-          "expired_redirect_url": {
+          "ab_variants": {
             "anyOf": [
               {
-                "type": "string"
+                "items": {
+                  "$ref": "#/components/schemas/AbVariantResponse"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Expired Redirect Url",
-            "description": "Destination served once the link has expired, or null.",
+            "title": "Ab Variants",
+            "description": "Weighted split destinations ({url, weight} entries; the default destination takes the remaining share), or null.",
             "examples": [
-              "https://example.com/offer-ended"
+              [
+                {
+                  "url": "https://example.com/b",
+                  "weight": 40
+                }
+              ]
             ]
-          },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagRef"
-            },
-            "type": "array",
-            "title": "Tags",
-            "description": "The link's tags (id, name, colour), in the link's order."
           },
           "updated_at": {
             "type": "integer",
@@ -15280,28 +14340,6 @@
             ],
             "title": "Expire After"
           },
-          "starts_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Starts At"
-          },
-          "pre_start_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pre Start Url"
-          },
           "max_clicks": {
             "anyOf": [
               {
@@ -15387,23 +14425,19 @@
             ],
             "title": "Geo Rules"
           },
-          "expired_redirect_url": {
+          "ab_variants": {
             "anyOf": [
               {
-                "type": "string"
+                "items": {
+                  "$ref": "#/components/schemas/AbVariantResponse"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Expired Redirect Url"
-          },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagRef"
-            },
-            "type": "array",
-            "title": "Tags"
+            "title": "Ab Variants"
           },
           "meta_tags": {
             "anyOf": [
@@ -15568,28 +14602,28 @@
               }
             ]
           },
-          "expired_redirect_url": {
+          "ab_variants": {
             "anyOf": [
               {
-                "type": "string"
+                "items": {
+                  "$ref": "#/components/schemas/AbVariantResponse"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Expired Redirect Url",
-            "description": "Destination served once the link has expired, or null.",
+            "title": "Ab Variants",
+            "description": "Weighted split destinations ({url, weight} entries; the default destination takes the remaining share), or null.",
             "examples": [
-              "https://example.com/offer-ended"
+              [
+                {
+                  "url": "https://example.com/b",
+                  "weight": 40
+                }
+              ]
             ]
-          },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagRef"
-            },
-            "type": "array",
-            "title": "Tags",
-            "description": "The link's tags (id, name, colour), in the link's order."
           },
           "meta_tags": {
             "anyOf": [
@@ -15633,8 +14667,7 @@
           "ACTIVE",
           "INACTIVE",
           "EXPIRED",
-          "BLOCKED",
-          "SCHEDULED"
+          "BLOCKED"
         ],
         "title": "UrlStatus",
         "description": "Status values for v2 URLs."

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -44,6 +44,13 @@ _ALL_URLS = {
                 "in": "$$rule.v",
             }
         },
+        {
+            "$map": {
+                "input": {"$ifNull": ["$ab_variants", []]},
+                "as": "v",
+                "in": "$$v.url",
+            }
+        },
         *(
             {"$cond": [{"$eq": [{"$type": f"${field}"}, "string"]}, [f"${field}"], []]}
             for field in SINGLE_DESTINATION_FIELDS

--- a/routes/api_v1/management.py
+++ b/routes/api_v1/management.py
@@ -38,6 +38,7 @@ from schemas.dto.responses.url import (
     UpdateUrlResponse,
 )
 from services.feature_flag_service import (
+    AB_TESTING_FLAG,
     EXPIRED_FALLBACK_FLAG,
     GEO_TARGETING_FLAG,
     LINK_SCHEDULING_FLAG,
@@ -127,7 +128,7 @@ async def update_url_v1(
 
     **Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,
     `max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,
-    `geo_rules`, `expired_redirect_url`, `meta_tags`
+    `geo_rules`, `ab_variants`, `expired_redirect_url`, `meta_tags`
 
     **Notes**:
 
@@ -138,6 +139,8 @@ async def update_url_v1(
       the system default. Alias collision is verified on the target.
     - `geo_rules` replaces the whole map; pass `null` or `{}` to remove all
       rules
+    - `ab_variants` replaces the whole list; pass `null` or `[]` to remove all
+      variants
     - `expired_redirect_url` is where visitors land once the link has expired;
       pass `null` to go back to the expired page
     - The `url_id` is the MongoDB ObjectId, not the alias
@@ -147,6 +150,8 @@ async def update_url_v1(
     # de-allowlisted owners can remove their rules during rollback.
     if "geo_rules" in body.model_fields_set and body.geo_rules:
         await flag_svc.require(GEO_TARGETING_FLAG, user)
+    if "ab_variants" in body.model_fields_set and body.ab_variants:
+        await flag_svc.require(AB_TESTING_FLAG, user)
     if "expired_redirect_url" in body.model_fields_set and body.expired_redirect_url:
         await flag_svc.require(EXPIRED_FALLBACK_FLAG, user)
     # Same deal for meta_tags: setting/replacing is flag-gated, clearing

--- a/routes/api_v1/shorten.py
+++ b/routes/api_v1/shorten.py
@@ -31,6 +31,7 @@ from middleware.rate_limiter import Limits, dynamic_limit, limiter
 from schemas.dto.requests.url import AliasCheckQuery, CreateUrlRequest
 from schemas.dto.responses.url import AliasCheckResponse, UrlResponse
 from services.feature_flag_service import (
+    AB_TESTING_FLAG,
     EXPIRED_FALLBACK_FLAG,
     GEO_TARGETING_FLAG,
     LINK_SCHEDULING_FLAG,
@@ -95,6 +96,7 @@ async def shorten_v1(
     - URLs not linked to any account
     - Cannot use custom domains
     - Cannot use geo targeting
+    - Cannot use A/B variants
     - Cannot set an expired-link fallback
     - Cannot use custom meta tags
     """
@@ -105,6 +107,11 @@ async def shorten_v1(
         if user is None:
             raise AuthenticationError("Authentication required to set geo_rules")
         await flag_svc.require(GEO_TARGETING_FLAG, user)
+
+    if body.ab_variants:
+        if user is None:
+            raise AuthenticationError("Authentication required to set ab_variants")
+        await flag_svc.require(AB_TESTING_FLAG, user)
 
     if body.expired_redirect_url:
         if user is None:

--- a/routes/api_v1/stats.py
+++ b/routes/api_v1/stats.py
@@ -60,13 +60,13 @@ async def stats_v1(
 
     **Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,
     `city`, `referrer`, `short_code`, `utm_source`, `utm_medium`,
-    `utm_campaign`
+    `utm_campaign`, `variant`
 
     **Metrics**: `clicks`, `unique_clicks`
 
     **Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,
-    `referrer`, `short_code`, `url_id`, or the `utm_*` tags using query
-    params or a JSON `filters` object. Filters slice your own aggregate —
+    `referrer`, `short_code`, `url_id`, `variant`, or the `utm_*` tags using
+    query params or a JSON `filters` object. Filters slice your own aggregate —
     `url_id` values you do not own simply match nothing. For statistics on
     a single link, prefer `GET /stats/links/{url_id}`.
     """
@@ -106,13 +106,13 @@ async def link_stats_v1(
     **Rate Limits**: 60/min, 5,000/day
 
     **Grouping Dimensions**: `time`, `browser`, `os`, `device`, `country`,
-    `city`, `referrer`, `utm_source`, `utm_medium`, `utm_campaign`
+    `city`, `referrer`, `utm_source`, `utm_medium`, `utm_campaign`, `variant`
 
     **Metrics**: `clicks`, `unique_clicks`
 
     **Filtering**: Filter by `browser`, `os`, `device`, `country`, `city`,
-    `referrer`, or the `utm_*` tags using query params or a JSON `filters`
-    object. Link-identity filters (`short_code`, `url_id`) do not exist
+    `referrer`, `variant`, or the `utm_*` tags using query params or a JSON
+    `filters` object. Link-identity filters (`short_code`, `url_id`) do not exist
     here — the path already selects the link.
 
     **Errors**:

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -501,6 +501,7 @@ async def preview_url(
                         "long_url": v2.long_url,
                         "password": v2.password,
                         "geo_rules": v2.geo_rules,
+                        "ab_variants": [v.model_dump() for v in v2.ab_variants or []],
                         "meta_tags": v2.meta_tags.model_dump()
                         if v2.meta_tags
                         else None,
@@ -524,6 +525,7 @@ async def preview_url(
                     "long_url": v2.long_url,
                     "password": v2.password,
                     "geo_rules": v2.geo_rules,
+                    "ab_variants": [v.model_dump() for v in v2.ab_variants or []],
                     "meta_tags": v2.meta_tags.model_dump() if v2.meta_tags else None,
                     "blocked": v2.effective_status is UrlStatus.BLOCKED,
                     "scheduled": v2.effective_status is UrlStatus.SCHEDULED,
@@ -619,6 +621,11 @@ async def preview_url(
             {"countries": sorted(codes), **split_destination(dest)}
             for dest, codes in grouped.items()
         ]
+    # Same rule for A/B variants: every destination a visitor might land on.
+    variant_destinations = [
+        {"weight": v["weight"], **split_destination(v["url"])}
+        for v in url_data.get("ab_variants") or []
+    ] or None
 
     return templates.TemplateResponse(
         request,
@@ -631,6 +638,7 @@ async def preview_url(
             "path": default_dest["path"],
             "is_https": default_dest["is_https"],
             "geo_destinations": geo_destinations,
+            "variant_destinations": variant_destinations,
             # An expired link with a fallback still sends everyone there.
             "expired_destination": (
                 split_destination(url_data["expired_fallback"])

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -8,6 +8,7 @@ POST /<short_code>/password → password form submission
 from __future__ import annotations
 
 import time
+from random import randrange
 from urllib.parse import unquote
 
 from fastapi import APIRouter, Request
@@ -32,6 +33,7 @@ from schemas.models.url import SchemaVersion
 from services.click.bot_detection import should_block_bot, wants_preview
 from services.click.events import ClickEvent
 from services.meta_preview import build_preview_context
+from shared.ab_variants import pick_variant
 from shared.ip_utils import get_client_ip
 from shared.url_utils import extract_hostname
 
@@ -265,6 +267,14 @@ async def redirect_url(
             destination = url_data.geo_rules[resolved_country]
             geo_matched = True
 
+    # 3b. A/B split — only the default destination is split; a matched geo
+    #     rule already decided. Stateless per request, no sticky assignment.
+    variant_index: int | None = None
+    if url_data.ab_variants and not geo_matched:
+        variant_index = pick_variant(url_data.ab_variants, randrange(100))
+        if variant_index is not None:
+            destination = url_data.ab_variants[variant_index].url
+
     # 4. Pre-emit bot block — the DECISION must run before the redirect is
     #    served (click processing may happen out-of-band); bot metadata
     #    RECORDING stays in the click pipeline.
@@ -297,6 +307,7 @@ async def redirect_url(
             cf_city=cf_city,
             resolved_country=resolved_country,
             geo_matched=geo_matched,
+            variant_index=variant_index,
             # Raw capture only — ClickEvent sanitises and bounds these
             # structurally, same as the password-hash strip.
             utm_source=request.query_params.get("utm_source"),
@@ -340,12 +351,13 @@ async def redirect_url(
             geo_targeted=bool(url_data.geo_rules),
             resolved_country=resolved_country,
             geo_matched=geo_matched,
+            variant_index=variant_index,
             slow=total_ms > 100,
         )
     resp = RedirectResponse(destination, status_code=302)
     resp.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
-    if url_data.geo_rules:
-        # Response varies by visitor country — no intermediary may cache it
+    if url_data.geo_rules or url_data.ab_variants:
+        # Response varies per visitor — no intermediary may cache it
         resp.headers["Cache-Control"] = "no-store"
     return resp
 

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -62,7 +62,10 @@ STATS_GROUP_BY_DESC = (
     "- `utm_source` — group by the `utm_source` tag on the short link "
     "(untagged clicks appear as `(none)`)\n"
     "- `utm_medium` — group by the `utm_medium` tag\n"
-    "- `utm_campaign` — group by the `utm_campaign` tag\n\n"
+    "- `utm_campaign` — group by the `utm_campaign` tag\n"
+    "- `variant` — group by the A/B variant served, as its index into "
+    "`ab_variants` (`0`, `1`, ...); clicks sent to the default destination "
+    "appear as `(default)`\n\n"
     "Multiple dimensions can be combined: `time,browser` returns time series "
     "broken down by browser."
 )
@@ -97,7 +100,9 @@ STATS_FILTERS_DESC = (
     "- `tag` / `tag_id` — Filter by link tag (name or id); clicks on your links "
     "carrying any listed tag\n"
     "- `utm_source` / `utm_medium` / `utm_campaign` — Filter by campaign tags; "
-    "`(none)` matches untagged clicks\n\n"
+    "`(none)` matches untagged clicks\n"
+    "- `variant` — Filter by A/B variant index (`0`, `1`, ...); "
+    "`(default)` matches clicks sent to the default destination\n\n"
     "**Value format:** Array of strings for each dimension.\n\n"
     "**Important:** Filter values are case-sensitive. Use exact capitalization "
     "as stored in the database.\n\n"
@@ -165,6 +170,14 @@ STATS_DEVICE_DESC = (
     "**Note:** Both `filters` JSON and individual parameters can be combined."
 )
 
+STATS_VARIANT_DESC = (
+    "**Method 2: Individual Filter Parameter**\n\n"
+    "Comma-separated A/B variant indices (`0`, `1`, ...). `(default)` matches "
+    "clicks sent to the default destination, including every click on a link "
+    "without variants.\n\n"
+    "**Note:** Both `filters` JSON and individual parameters can be combined."
+)
+
 STATS_UTM_DESC = (
     "**Method 2: Individual Filter Parameter**\n\n"
     "Comma-separated campaign tag values. Alternative to using the `filters` "
@@ -193,7 +206,10 @@ LINK_STATS_GROUP_BY_DESC = (
     "- `utm_source` — group by the `utm_source` tag on the short link "
     "(untagged clicks appear as `(none)`)\n"
     "- `utm_medium` — group by the `utm_medium` tag\n"
-    "- `utm_campaign` — group by the `utm_campaign` tag\n\n"
+    "- `utm_campaign` — group by the `utm_campaign` tag\n"
+    "- `variant` — group by the A/B variant served, as its index into "
+    "`ab_variants` (`0`, `1`, ...); clicks sent to the default destination "
+    "appear as `(default)`\n\n"
     "Multiple dimensions can be combined: `time,browser` returns time series "
     "broken down by browser."
 )
@@ -210,7 +226,9 @@ LINK_STATS_FILTERS_DESC = (
     "- `city` — Filter by city name (e.g., New York, London, Mumbai)\n"
     "- `referrer` — Filter by referrer URL (e.g., https://google.com, https://twitter.com)\n"
     "- `utm_source` / `utm_medium` / `utm_campaign` — Filter by campaign tags; "
-    "`(none)` matches untagged clicks\n\n"
+    "`(none)` matches untagged clicks\n"
+    "- `variant` — Filter by A/B variant index (`0`, `1`, ...); "
+    "`(default)` matches clicks sent to the default destination\n\n"
     "**Value format:** Array of strings for each dimension.\n\n"
     "**Important:** Filter values are case-sensitive. Use exact capitalization "
     "as stored in the database.\n\n"

--- a/schemas/dto/requests/_descriptions.py
+++ b/schemas/dto/requests/_descriptions.py
@@ -65,7 +65,8 @@ STATS_GROUP_BY_DESC = (
     "- `utm_campaign` — group by the `utm_campaign` tag\n"
     "- `variant` — group by the A/B variant served, as its index into "
     "`ab_variants` (`0`, `1`, ...); clicks sent to the default destination "
-    "appear as `(default)`\n\n"
+    "appear as `(default)`. The index is positional: editing `ab_variants` "
+    "re-keys past clicks to whatever now sits at that index\n\n"
     "Multiple dimensions can be combined: `time,browser` returns time series "
     "broken down by browser."
 )
@@ -209,7 +210,8 @@ LINK_STATS_GROUP_BY_DESC = (
     "- `utm_campaign` — group by the `utm_campaign` tag\n"
     "- `variant` — group by the A/B variant served, as its index into "
     "`ab_variants` (`0`, `1`, ...); clicks sent to the default destination "
-    "appear as `(default)`\n\n"
+    "appear as `(default)`. The index is positional: editing `ab_variants` "
+    "re-keys past clicks to whatever now sits at that index\n\n"
     "Multiple dimensions can be combined: `time,browser` returns time series "
     "broken down by browser."
 )

--- a/schemas/dto/requests/stats.py
+++ b/schemas/dto/requests/stats.py
@@ -51,6 +51,7 @@ from schemas.dto.requests._descriptions import (
     STATS_TIMEZONE_DESC,
     STATS_URL_ID_DESC,
     STATS_UTM_DESC,
+    STATS_VARIANT_DESC,
 )
 from schemas.enums.stats import (
     ALLOWED_EXPORT_FORMATS,
@@ -183,6 +184,12 @@ class _StatsQueryBase(RequestBase):
         description=STATS_UTM_DESC,
         examples=["summer-launch"],
     )
+    variant: str | None = Field(
+        default=None,
+        max_length=200,
+        description=STATS_VARIANT_DESC,
+        examples=["0,1", "(default)"],
+    )
 
     # --- Parsed/validated results (private — not exposed as query params) ---
     _parsed_group_by: list[str] = PrivateAttr(default_factory=list)
@@ -243,6 +250,7 @@ class _StatsQueryBase(RequestBase):
             "utm_source",
             "utm_medium",
             "utm_campaign",
+            "variant",
         ):
             raw = getattr(self, dim, None)
             if raw:

--- a/schemas/dto/requests/url.py
+++ b/schemas/dto/requests/url.py
@@ -37,6 +37,9 @@ _GEO_URL_MAX_LENGTH = 8192  # same bound as long_url
 # request body — the ceiling bounds the loop for anonymous callers.
 _GEO_RULES_HARD_CAP = 500
 
+# Same split for variants: settings.ab_variants_max is the product cap.
+_AB_VARIANTS_HARD_CAP = 50
+
 
 _ALNUM_ALIAS_RE = re.compile(r"[a-zA-Z0-9_-]+\Z")
 
@@ -106,6 +109,52 @@ def _normalise_geo_rules(v: dict | None) -> dict | None:
             )
         normalised[code] = url.strip()
     return normalised
+
+
+class AbVariantRequest(RequestBase):
+    """One A/B split destination as sent on create/update."""
+
+    url: str = Field(
+        min_length=1,
+        max_length=_GEO_URL_MAX_LENGTH,
+        description="Destination URL for this variant.",
+        examples=["https://example.com/b"],
+    )
+    weight: int = Field(
+        ge=1,
+        le=100,
+        description="Percentage of visitors sent to this variant (1-100).",
+        examples=[40],
+    )
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def _strip_url(cls, v: object) -> object:
+        return v.strip() if isinstance(v, str) else v
+
+
+def _cap_ab_variants(v: object) -> object:
+    """Pre-auth ceiling on the list length, like ``_normalise_geo_rules``.
+    Everything else (weights, sum, URL safety) validates after coercion."""
+    if isinstance(v, list) and len(v) > _AB_VARIANTS_HARD_CAP:
+        raise ValueError(f"ab_variants cannot exceed {_AB_VARIANTS_HARD_CAP} entries")
+    return v
+
+
+def _check_ab_weights(
+    v: list[AbVariantRequest] | None,
+) -> list[AbVariantRequest] | None:
+    if v and sum(variant.weight for variant in v) > 100:
+        raise ValueError("ab_variants weights must sum to at most 100")
+    return v
+
+
+_AB_VARIANTS_FIELD_DESC = (
+    "Weighted split destinations: each entry is `{url, weight}` where "
+    "`weight` is the percentage of visitors sent there (integers, summing to "
+    "at most 100). The default destination (`url`) receives the remainder. "
+    "Requires authentication."
+)
 
 
 class UrlFilter(RequestBase):
@@ -315,6 +364,11 @@ class CreateUrlRequest(RequestBase):
         description=_TAG_IDS_FIELD_DESC,
         examples=[["665f0c2f9e7a4b1d2c3d4e5f"]],
     )
+    ab_variants: list[AbVariantRequest] | None = Field(
+        default=None,
+        description=_AB_VARIANTS_FIELD_DESC,
+        examples=[[{"url": "https://example.com/b", "weight": 40}]],
+    )
     meta_tags: MetaTagsRequest | None = Field(
         default=None, description=_META_TAGS_FIELD_DESC
     )
@@ -357,6 +411,18 @@ class CreateUrlRequest(RequestBase):
     @classmethod
     def _norm_tag_ids(cls, v: list | None) -> list | None:
         return normalise_object_ids(v, cap=TAGS_MAX_PER_LINK, noun="tags per link")
+
+    @field_validator("ab_variants", mode="before")
+    @classmethod
+    def _cap_variants(cls, v: object) -> object:
+        return _cap_ab_variants(v)
+
+    @field_validator("ab_variants")
+    @classmethod
+    def _variant_weights(
+        cls, v: list[AbVariantRequest] | None
+    ) -> list[AbVariantRequest] | None:
+        return _check_ab_weights(v)
 
 
 class UpdateUrlRequest(RequestBase):
@@ -471,6 +537,15 @@ class UpdateUrlRequest(RequestBase):
         description=_TAG_IDS_FIELD_DESC,
         examples=[["665f0c2f9e7a4b1d2c3d4e5f"]],
     )
+    ab_variants: list[AbVariantRequest] | None = Field(
+        default=None,
+        description=(
+            _AB_VARIANTS_FIELD_DESC + " The list replaces any existing variants "
+            "in full. Pass `null` or `[]` to remove all variants; omit to keep "
+            "them unchanged."
+        ),
+        examples=[[{"url": "https://example.com/b", "weight": 40}]],
+    )
     meta_tags: MetaTagsRequest | None = Field(
         default=None, description=_META_TAGS_FIELD_DESC
     )
@@ -513,6 +588,18 @@ class UpdateUrlRequest(RequestBase):
     @classmethod
     def _norm_tag_ids(cls, v: list | None) -> list | None:
         return normalise_object_ids(v, cap=TAGS_MAX_PER_LINK, noun="tags per link")
+
+    @field_validator("ab_variants", mode="before")
+    @classmethod
+    def _cap_variants(cls, v: object) -> object:
+        return _cap_ab_variants(v)
+
+    @field_validator("ab_variants")
+    @classmethod
+    def _variant_weights(
+        cls, v: list[AbVariantRequest] | None
+    ) -> list[AbVariantRequest] | None:
+        return _check_ab_weights(v)
 
 
 class UpdateUrlStatusRequest(BaseModel):

--- a/schemas/dto/responses/public_preview.py
+++ b/schemas/dto/responses/public_preview.py
@@ -33,15 +33,21 @@ class PreviewGeoDestination(PreviewDestination):
     countries: list[str]
 
 
+class PreviewVariantDestination(PreviewDestination):
+    """One A/B variant destination with its traffic share in percent."""
+
+    weight: int
+
+
 class PublicPreviewResponse(ResponseBase):
     """Response body for the public link preview endpoint.
 
-    ``destination`` and ``geo_destinations`` are non-null only while the
-    link is active and not password-protected — the preview never reveals
-    a destination the redirect would refuse to serve. The rule runs both
-    ways: ``expired_destination`` names where an expired link still sends
-    every visitor when its owner set a fallback, so the preview never shows
-    LESS than the redirect serves either.
+    ``destination``, ``geo_destinations`` and ``variant_destinations`` are
+    non-null only while the link is active and not password-protected — the
+    preview never reveals a destination the redirect would refuse to serve.
+    The rule runs both ways: ``expired_destination`` names where an expired
+    link still sends every visitor when its owner set a fallback, so the
+    preview never shows LESS than the redirect serves either.
     """
 
     generation: Literal["v1", "v2"]
@@ -54,5 +60,6 @@ class PublicPreviewResponse(ResponseBase):
     password_protected: bool
     destination: PreviewDestination | None
     geo_destinations: list[PreviewGeoDestination] | None
+    variant_destinations: list[PreviewVariantDestination] | None = None
     # Set only while ``status`` is ``"expired"`` and the owner set a fallback.
     expired_destination: PreviewDestination | None = None

--- a/schemas/dto/responses/url.py
+++ b/schemas/dto/responses/url.py
@@ -23,7 +23,7 @@ from schemas.dto.base import ResponseBase
 from schemas.dto.responses.tag import TagRef
 from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.tag import TagDoc
-from schemas.models.url import LinkMetaTags, UrlStatus, UrlV2Doc
+from schemas.models.url import AbVariant, LinkMetaTags, UrlStatus, UrlV2Doc
 from shared.datetime_utils import to_unix_timestamp
 
 
@@ -59,6 +59,27 @@ class MetaTagsResponse(ResponseBase):
             color=meta.color,
             warnings=meta.image_warnings() or None,
         )
+
+
+class AbVariantResponse(ResponseBase):
+    """One A/B split destination."""
+
+    url: str = Field(description="Variant destination URL.")
+    weight: int = Field(description="Percentage of visitors sent here.")
+
+    @classmethod
+    def from_model(
+        cls, variants: list[AbVariant] | None
+    ) -> list[AbVariantResponse] | None:
+        if not variants:
+            return None
+        return [cls(url=v.url, weight=v.weight) for v in variants]
+
+
+_AB_VARIANTS_RESP_DESC = (
+    "Weighted split destinations ({url, weight} entries; the default "
+    "destination takes the remaining share), or null."
+)
 
 
 class UrlResponse(ResponseBase):
@@ -120,6 +141,11 @@ class UrlResponse(ResponseBase):
         default_factory=list,
         description="The link's tags (id, name, colour), in the link's order.",
     )
+    ab_variants: list[AbVariantResponse] | None = Field(
+        default=None,
+        description=_AB_VARIANTS_RESP_DESC,
+        examples=[[{"url": "https://example.com/b", "weight": 40}]],
+    )
     meta_tags: MetaTagsResponse | None = Field(
         default=None, description="Custom social preview, if configured."
     )
@@ -164,6 +190,7 @@ class UrlResponse(ResponseBase):
             geo_rules=doc.geo_rules,
             expired_redirect_url=doc.expired_redirect_url,
             tags=_tag_refs(doc, tag_refs),
+            ab_variants=AbVariantResponse.from_model(doc.ab_variants),
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
             claim_token=claim_token,
         )
@@ -236,6 +263,11 @@ class UpdateUrlResponse(ResponseBase):
         default_factory=list,
         description="The link's tags (id, name, colour), in the link's order.",
     )
+    ab_variants: list[AbVariantResponse] | None = Field(
+        default=None,
+        description=_AB_VARIANTS_RESP_DESC,
+        examples=[[{"url": "https://example.com/b", "weight": 40}]],
+    )
     updated_at: int = Field(
         description="Last update time as Unix timestamp.", examples=[1704067200]
     )
@@ -264,6 +296,7 @@ class UpdateUrlResponse(ResponseBase):
             geo_rules=doc.geo_rules,
             expired_redirect_url=doc.expired_redirect_url,
             tags=_tag_refs(doc, tag_refs),
+            ab_variants=AbVariantResponse.from_model(doc.ab_variants),
             updated_at=to_unix_timestamp(doc.updated_at, default=0),
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
         )
@@ -297,6 +330,7 @@ class UrlListItem(ResponseBase):
     geo_rules: dict[str, str] | None = None
     expired_redirect_url: str | None = None
     tags: list[TagRef] = Field(default_factory=list)
+    ab_variants: list[AbVariantResponse] | None = None
     meta_tags: MetaTagsResponse | None = None
 
     @classmethod
@@ -331,6 +365,7 @@ class UrlListItem(ResponseBase):
             geo_rules=doc.geo_rules,
             expired_redirect_url=doc.expired_redirect_url,
             tags=_tag_refs(doc, tag_refs),
+            ab_variants=AbVariantResponse.from_model(doc.ab_variants),
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
         )
 

--- a/schemas/enums/stats.py
+++ b/schemas/enums/stats.py
@@ -44,6 +44,8 @@ class StatsDimension(str, Enum):
     # resolves them (by name or id) to the owner's url_ids before the $match.
     TAG = "tag"
     TAG_ID = "tag_id"
+    # A/B variant index served ("0", "1", ...); "(default)" = long_url.
+    VARIANT = "variant"
 
 
 class StatsMetric(str, Enum):
@@ -83,6 +85,7 @@ ALLOWED_FILTERS = frozenset(
         StatsDimension.UTM_CAMPAIGN,
         StatsDimension.TAG,
         StatsDimension.TAG_ID,
+        StatsDimension.VARIANT,
     }
 )
 # Per-link endpoints pre-select the link in the path, so slicing or

--- a/schemas/models/click.py
+++ b/schemas/models/click.py
@@ -60,3 +60,6 @@ class ClickDoc(MongoBaseModel):
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None
+    # Which ab_variants entry served this click; None = default destination
+    # (and every click recorded before the field existed).
+    variant_index: int | None = None

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -202,6 +202,14 @@ class UrlDestination(BaseModel):
         return data
 
 
+class AbVariant(BaseModel):
+    """One A/B split destination. ``weight`` is the percentage of visitors
+    sent here; long_url receives whatever the variants leave over."""
+
+    url: str
+    weight: int = Field(ge=1, le=100)
+
+
 class UrlV2Doc(MongoBaseModel):
     """Document model for the `urlsV2` collection.
 
@@ -262,6 +270,9 @@ class UrlV2Doc(MongoBaseModel):
     # Ids into the owner's ``tags`` collection. Docs written before the
     # field existed read as [].
     tag_ids: list[PyObjectId] = Field(default_factory=list)
+    # Weighted split destinations; weights sum to at most 100 and long_url
+    # takes the remainder. Applied only when no geo rule matched.
+    ab_variants: list[AbVariant] | None = None
     # Where visitors go once the link is EXPIRED; INACTIVE and BLOCKED never use it.
     expired_redirect_url: str | None = None
     status: UrlStatus = UrlStatus.ACTIVE

--- a/scripts/backfill_url_dest.py
+++ b/scripts/backfill_url_dest.py
@@ -17,9 +17,10 @@ Unparseable destinations are stamped ``dest: null`` so the needs-backfill
 filter converges to zero; null adds nothing to the sparse dest_registrable
 index.
 
-Second pass, urlsV2 only: links with geo_rules or a single-URL fallback get
-``dest.secondary_hosts`` (every extra destination host but the main one) and
-the index-aligned ``dest.secondary_registrable``, so a host block and a
+Second pass, urlsV2 only: links with geo_rules, ab_variants or a single-URL
+fallback get ``dest.secondary_hosts`` (every extra destination host but the
+main one) and the index-aligned ``dest.secondary_registrable``, so a host
+block and a
 feed-domain sweep both reach links that hide the host in a rule. Idempotent:
 docs already carrying the fields are skipped, and a link whose extra
 destinations add no new host gets empty lists so the filter converges.
@@ -59,6 +60,7 @@ _SECONDARY_FILTER = {
         {
             "$or": [
                 {"geo_rules": {"$type": "object"}},
+                {"ab_variants": {"$type": "array"}},
                 *({field: {"$type": "string"}} for field in SINGLE_DESTINATION_FIELDS),
             ]
         },
@@ -111,9 +113,13 @@ def parse_destination(url: object) -> dict | None:
 
 
 def secondary_urls(doc: dict) -> list:
-    """Every extra destination a link routes to: geo rules plus each single-URL field."""
+    """Every extra destination a link routes to: geo rules, A/B variants and
+    each single-URL field."""
     geo = doc.get("geo_rules")
     urls = list(geo.values()) if isinstance(geo, dict) else []
+    variants = doc.get("ab_variants")
+    if isinstance(variants, list):
+        urls += [v.get("url") for v in variants if isinstance(v, dict)]
     for field in SINGLE_DESTINATION_FIELDS:
         if isinstance(doc.get(field), str):
             urls.append(doc[field])
@@ -175,6 +181,7 @@ def _secondary_op(d: dict) -> UpdateOne:
     flt = {
         "_id": d["_id"],
         "geo_rules": d.get("geo_rules"),
+        "ab_variants": d.get("ab_variants"),
         **{field: d.get(field) for field in SINGLE_DESTINATION_FIELDS},
         "dest.secondary_registrable": {"$exists": False},
     }
@@ -187,7 +194,7 @@ def _secondary_op(d: dict) -> UpdateOne:
 
 def backfill_secondary(coll, dry_run: bool) -> None:
     todo = coll.count_documents(_SECONDARY_FILTER)
-    print(f"[{coll.name}] geo or scheduled links needing secondary fields: {todo}")
+    print(f"[{coll.name}] geo/variant/scheduled links needing secondary fields: {todo}")
     if todo == 0 or dry_run:
         return
     stamped = failed = skipped = 0
@@ -199,7 +206,13 @@ def backfill_secondary(coll, dry_run: bool) -> None:
         batch = list(
             coll.find(
                 query,
-                {"dest": 1, "long_url": 1, "geo_rules": 1, **_SINGLE_PROJECTION},
+                {
+                    "dest": 1,
+                    "long_url": 1,
+                    "geo_rules": 1,
+                    "ab_variants": 1,
+                    **_SINGLE_PROJECTION,
+                },
             )
             .sort("_id", 1)
             .limit(_BATCH)
@@ -230,7 +243,8 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         return
     if dry_run:
         sample = coll.find_one(
-            _FILTER, {url_field: 1, "geo_rules": 1, **_SINGLE_PROJECTION}
+            _FILTER,
+            {url_field: 1, "geo_rules": 1, "ab_variants": 1, **_SINGLE_PROJECTION},
         )
         print(f"[{coll.name}] sample parse: {dest_for(sample or {}, url_field)}")
         return
@@ -245,7 +259,10 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         if last_id is not None:
             query["_id"] = {"$gt": last_id}
         batch = list(
-            coll.find(query, {url_field: 1, "geo_rules": 1, **_SINGLE_PROJECTION})
+            coll.find(
+                query,
+                {url_field: 1, "geo_rules": 1, "ab_variants": 1, **_SINGLE_PROJECTION},
+            )
             .sort("_id", 1)
             .limit(_BATCH)
         )

--- a/services/click/consumers/stats.py
+++ b/services/click/consumers/stats.py
@@ -49,6 +49,7 @@ class StatsClickConsumer:
                 utm_source=event.utm_source,
                 utm_medium=event.utm_medium,
                 utm_campaign=event.utm_campaign,
+                variant_index=event.variant_index,
             )
         except ValidationError:
             log.info(

--- a/services/click/events.py
+++ b/services/click/events.py
@@ -66,6 +66,8 @@ class ClickEvent(BaseModel):
     # Defaults keep pre-existing stream payloads decodable.
     resolved_country: str | None = None
     geo_matched: bool = False
+    # Index into url.ab_variants the redirect served; None = default URL.
+    variant_index: int | None = None
     # Campaign tags from the short link's query string. Defaults keep
     # pre-existing stream payloads decodable.
     utm_source: str | None = None

--- a/services/click/handlers.py
+++ b/services/click/handlers.py
@@ -180,6 +180,7 @@ class V2ClickHandler:
             utm_source=context.utm_source,
             utm_medium=context.utm_medium,
             utm_campaign=context.utm_campaign,
+            variant_index=context.variant_index,
         )
 
         await self._click_repo.insert(click_doc.to_mongo())

--- a/services/click/protocol.py
+++ b/services/click/protocol.py
@@ -26,6 +26,7 @@ class ClickContext:
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None
+    variant_index: int | None = None
 
 
 class ClickHandler(Protocol):

--- a/services/click/service.py
+++ b/services/click/service.py
@@ -40,6 +40,7 @@ class ClickService:
         utm_source: str | None = None,
         utm_medium: str | None = None,
         utm_campaign: str | None = None,
+        variant_index: int | None = None,
     ) -> None:
         """
         Dispatch click tracking to the appropriate handler.
@@ -64,5 +65,6 @@ class ClickService:
             utm_source=utm_source,
             utm_medium=utm_medium,
             utm_campaign=utm_campaign,
+            variant_index=variant_index,
         )
         await handler.handle(context)

--- a/services/click/sinks/inline.py
+++ b/services/click/sinks/inline.py
@@ -30,4 +30,5 @@ class InlineSink:
             utm_source=event.utm_source,
             utm_medium=event.utm_medium,
             utm_campaign=event.utm_campaign,
+            variant_index=event.variant_index,
         )

--- a/services/edge_cache/promotion.py
+++ b/services/edge_cache/promotion.py
@@ -60,6 +60,8 @@ def promotion_skip_reason(
         return "has_expiration"  # could expire mid-TTL; rare, so skip all
     if url.is_not_yet_live(time.time()):
         return "not_yet_live"  # the edge would serve the redirect early
+    if url.ab_variants:
+        return "ab_variants"  # the Worker has no entry type for a weighted pick
     # geo_rules is NOT a skip: geo links promote as geo_redirect entries —
     # the Worker resolves request.cf.country against the same rules map
     # origin would, so per-country routing is a decision the edge CAN make.

--- a/services/public_preview_service.py
+++ b/services/public_preview_service.py
@@ -26,6 +26,7 @@ from infrastructure.logging import get_logger
 from schemas.dto.responses.public_preview import (
     PreviewDestination,
     PreviewGeoDestination,
+    PreviewVariantDestination,
     PublicPreviewResponse,
 )
 from services.public_link_resolver import PublicLinkResolver, ResolvedPublicLink
@@ -69,9 +70,17 @@ class PublicPreviewService:
         # destinations stay unreachable). There is no password unlock here.
         destination: PreviewDestination | None = None
         geo_destinations: list[PreviewGeoDestination] | None = None
+        variant_destinations: list[PreviewVariantDestination] | None = None
         if status == "active" and not password_protected:
             destination = PreviewDestination(**split_destination(doc.long_url))
             geo_destinations = self._group_geo_rules(doc.geo_rules)
+            if doc.ab_variants:
+                variant_destinations = [
+                    PreviewVariantDestination(
+                        weight=v.weight, **split_destination(v.url)
+                    )
+                    for v in doc.ab_variants
+                ]
         # An expired link with a fallback still 302s everyone (the redirect
         # decides before the password gate), so the preview names that URL.
         expired_destination: PreviewDestination | None = None
@@ -93,6 +102,7 @@ class PublicPreviewService:
             password_protected=password_protected,
             destination=destination,
             geo_destinations=geo_destinations,
+            variant_destinations=variant_destinations,
             expired_destination=expired_destination,
         )
 

--- a/services/report_intake_service.py
+++ b/services/report_intake_service.py
@@ -319,7 +319,8 @@ class ReportIntakeService:
         self, domain: str | None, code: str
     ) -> list[str] | None:
         """Domain-scoped existence check that also yields every destination
-        the link routes to (long_url, geo overrides, pre-start and after-expiry pages).
+        the link routes to (long_url, geo overrides, A/B variants, pre-start
+        and after-expiry pages).
 
         System-domain codes resolve via the shared PublicLinkResolver —
         the same generation dispatch (v1/v2/emoji) as the redirect, and

--- a/services/safety/hot.py
+++ b/services/safety/hot.py
@@ -81,7 +81,7 @@ class HotLinkScreen:
             )
 
     async def _destinations(self, hot: HotUrl) -> list[str]:
-        """Every destination the link routes to: main, geo overrides, both fallbacks."""
+        """Every destination the link routes to: main, geo overrides, variants, both fallbacks."""
         domain = self._system_domain if hot.domain in ("default", "") else hot.domain
         doc = await self._url_repo.find_by_alias(hot.short_code, domain)
         if doc is not None:

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -80,7 +80,20 @@ _NULL_SENTINEL_FILTERS: dict[StatsDimension, str] = {
     StatsDimension.UTM_SOURCE: "(none)",
     StatsDimension.UTM_MEDIUM: "(none)",
     StatsDimension.UTM_CAMPAIGN: "(none)",
+    StatsDimension.VARIANT: "(default)",
 }
+
+# Wire dimension → stored field, where the two differ.
+_DIMENSION_FIELDS: dict[StatsDimension, str] = {
+    StatsDimension.VARIANT: "variant_index",
+}
+
+
+def _stored_values(dimension: str, values: list[str]) -> list[Any]:
+    """Wire filter values in the stored type: variant indices are ints."""
+    if dimension == StatsDimension.VARIANT:
+        return [int(v) if v.isdigit() else v for v in values]
+    return values
 
 
 class StatsService:
@@ -308,15 +321,17 @@ class StatsService:
                 # "unknown" is also a real stored value; for referrer/utm
                 # the extra literal matches nothing (and if a visitor ever
                 # sends the literal, group-by merges it with null anyway).
+                field = _DIMENSION_FIELDS.get(dimension, dimension)
                 or_groups.append(
                     [
-                        {dimension: {"$in": values}},
-                        {dimension: {"$in": [None, ""]}},
-                        {dimension: {"$exists": False}},
+                        {field: {"$in": _stored_values(dimension, values)}},
+                        {field: {"$in": [None, ""]}},
+                        {field: {"$exists": False}},
                     ]
                 )
             else:
-                query[dimension] = {"$in": values}
+                field = _DIMENSION_FIELDS.get(dimension, dimension)
+                query[field] = {"$in": _stored_values(dimension, values)}
 
     @staticmethod
     def _merge_or_groups(

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -47,6 +47,7 @@ from repositories.legacy.emoji_url_repository import EmojiUrlRepository
 from repositories.legacy.legacy_url_repository import LegacyUrlRepository
 from repositories.url_repository import UrlRepository
 from schemas.dto.requests.url import (
+    AbVariantRequest,
     ClaimItemRequest,
     CreateUrlRequest,
     ListUrlsQuery,
@@ -77,6 +78,7 @@ if TYPE_CHECKING:
     from services.tag_service import TagService
 from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.url import (
+    AbVariant,
     EmojiUrlDoc,
     LegacyUrlDoc,
     LinkMetaTags,
@@ -85,6 +87,7 @@ from schemas.models.url import (
     UrlStatus,
     UrlV2Doc,
 )
+from shared.ab_variants import variant_urls
 from shared.alias_dispatch import (
     emoji_lookup_candidates,
     resolution_order,
@@ -140,6 +143,35 @@ def _validate_geo_rules_shape(
             raise ValidationError(
                 f"'{code}' is not a valid ISO 3166-1 alpha-2 country code",
                 field=f"geo_rules.{code}",
+            )
+
+
+def _validate_ab_variants_shape(
+    variants: Sequence[AbVariantRequest],
+    *,
+    max_variants: int,
+    enabled: bool = True,
+) -> None:
+    """Feature gate + entry cap. Weights and URL safety are checked
+    elsewhere (DTO and ``url_policy.check`` respectively)."""
+    if not enabled:
+        raise ValidationError("A/B variants are not available yet", field="ab_variants")
+    if len(variants) > max_variants:
+        raise ValidationError(
+            f"ab_variants cannot exceed {max_variants} entries", field="ab_variants"
+        )
+
+
+async def _check_variant_destinations(
+    service: UrlService, variants: Sequence[AbVariantRequest]
+) -> None:
+    """Every variant URL runs the full L0 gate, same as long_url and geo."""
+    for index, variant in enumerate(variants):
+        rejection = await service._url_policy.check(variant.url)
+        if rejection is not None:
+            log.info("url_create_rejected", reason=rejection.code)
+            raise ValidationError(
+                rejection.public_message, field=f"ab_variants.{index}.url"
             )
 
 
@@ -382,6 +414,27 @@ async def _handle_geo_rules(
     ops["geo_rules"] = request.geo_rules
 
 
+async def _handle_ab_variants(
+    request: UpdateUrlRequest, existing: UrlV2Doc, ops: dict, service: UrlService
+) -> None:
+    if "ab_variants" not in request.model_fields_set:
+        return
+    if not request.ab_variants:
+        if existing.ab_variants:
+            ops["ab_variants"] = None
+        return
+    new = [AbVariant(url=v.url, weight=v.weight) for v in request.ab_variants]
+    if new == existing.ab_variants:
+        return
+    _validate_ab_variants_shape(
+        request.ab_variants,
+        max_variants=service._ab_variants_max,
+        enabled=service._ab_variants_enabled,
+    )
+    await _check_variant_destinations(service, request.ab_variants)
+    ops["ab_variants"] = [v.model_dump() for v in new]
+
+
 async def _handle_meta_tags(
     request: UpdateUrlRequest, existing: UrlV2Doc, ops: dict, service: UrlService
 ) -> None:
@@ -455,6 +508,7 @@ FIELD_HANDLERS: dict[str, Callable[..., Awaitable[None]]] = {
     "status": _handle_status,
     "geo_rules": _handle_geo_rules,
     "tag_ids": _handle_tag_ids,
+    "ab_variants": _handle_ab_variants,
     "expired_redirect_url": _handle_expired_redirect_url,
     # Must follow long_url — the handler validates against ops["long_url"]
     # when the destination changes in the same request.
@@ -509,6 +563,8 @@ class UrlService:
         emoji_generated_alias_length: int = 3,
         geo_rules_max_countries: int = 50,
         geo_rules_enabled: bool = False,
+        ab_variants_max: int = 10,
+        ab_variants_enabled: bool = False,
         og_writethrough: OgEdgeWritethrough | None = None,
         edge_kv: CloudflareKVClient | None = None,
         r2_storage: R2StorageClient | None = None,
@@ -539,6 +595,8 @@ class UrlService:
         self._emoji_generated_alias_length = emoji_generated_alias_length
         self._geo_rules_max_countries = geo_rules_max_countries
         self._geo_rules_enabled = geo_rules_enabled
+        self._ab_variants_max = ab_variants_max
+        self._ab_variants_enabled = ab_variants_enabled
         # Edge KV write-through for og-links; None when edge cache is
         # unconfigured (self-host) — origin then serves all previews.
         self._og_writethrough = og_writethrough
@@ -939,6 +997,13 @@ class UrlService:
                     raise ValidationError(
                         geo_rejection.public_message, field=f"geo_rules.{geo_code}"
                     )
+        if request.ab_variants:
+            _validate_ab_variants_shape(
+                request.ab_variants,
+                max_variants=self._ab_variants_max,
+                enabled=self._ab_variants_enabled,
+            )
+            await _check_variant_destinations(self, request.ab_variants)
         if request.expired_redirect_url:
             await self.check_expired_redirect_url(request.expired_redirect_url)
         # Meta-tags: resolve data-URI uploads to R2 URLs, then run abuse
@@ -1020,6 +1085,7 @@ class UrlService:
             dest=UrlDestination.for_link(
                 request.long_url,
                 geo_rules=request.geo_rules,
+                variants=variant_urls(request.ab_variants),
                 pre_start_url=request.pre_start_url or None,
                 expired_redirect_url=request.expired_redirect_url or None,
             ),
@@ -1031,6 +1097,11 @@ class UrlService:
             pre_start_url=request.pre_start_url or None,
             geo_rules=request.geo_rules or None,
             tag_ids=tag_ids,
+            ab_variants=(
+                [AbVariant(url=v.url, weight=v.weight) for v in request.ab_variants]
+                if request.ab_variants
+                else None
+            ),
             expired_redirect_url=request.expired_redirect_url or None,
             status=UrlStatus.ACTIVE,
             private_stats=private_stats,
@@ -1097,6 +1168,7 @@ class UrlService:
             domain=target_domain,
             geo_rules=len(request.geo_rules or {}),
             tags=len(tag_ids),
+            ab_variants=len(request.ab_variants or []),
             has_expired_fallback=bool(request.expired_redirect_url),
             has_meta_tags=bool(request.meta_tags),
         )
@@ -1243,12 +1315,16 @@ class UrlService:
         if {
             "long_url",
             "geo_rules",
+            "ab_variants",
             "pre_start_url",
             "expired_redirect_url",
         } & update_ops.keys():
             dest = UrlDestination.for_link(
                 update_ops.get("long_url", existing.long_url),
                 geo_rules=update_ops.get("geo_rules", existing.geo_rules),
+                variants=variant_urls(
+                    update_ops.get("ab_variants", existing.ab_variants)
+                ),
                 pre_start_url=update_ops.get("pre_start_url", existing.pre_start_url),
                 expired_redirect_url=update_ops.get(
                     "expired_redirect_url", existing.expired_redirect_url

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -163,13 +163,16 @@ def _validate_ab_variants_shape(
 
 
 async def _check_variant_destinations(
-    service: UrlService, variants: Sequence[AbVariantRequest]
+    service: UrlService,
+    variants: Sequence[AbVariantRequest],
+    *,
+    event: str = "url_create_rejected",
 ) -> None:
     """Every variant URL runs the full L0 gate, same as long_url and geo."""
     for index, variant in enumerate(variants):
         rejection = await service._url_policy.check(variant.url)
         if rejection is not None:
-            log.info("url_create_rejected", reason=rejection.code)
+            log.info(event, reason=rejection.code)
             raise ValidationError(
                 rejection.public_message, field=f"ab_variants.{index}.url"
             )
@@ -431,7 +434,9 @@ async def _handle_ab_variants(
         max_variants=service._ab_variants_max,
         enabled=service._ab_variants_enabled,
     )
-    await _check_variant_destinations(service, request.ab_variants)
+    await _check_variant_destinations(
+        service, request.ab_variants, event="url_update_rejected"
+    )
     ops["ab_variants"] = [v.model_dump() for v in new]
 
 

--- a/services/webhooks/payloads.py
+++ b/services/webhooks/payloads.py
@@ -50,7 +50,7 @@ def link_snapshot(doc: UrlV2Doc) -> dict[str, Any]:
     """The public snapshot carried by every link.* lifecycle event.
 
     A projection of the link DOCUMENT, never of entitlements: feature
-    fields (geo_rules, meta_tags) are null when unset, which needs no
+    fields (geo_rules, ab_variants, meta_tags) are null when unset, which needs no
     flag lookup — flags gate writes, the doc already carries the truth.
     """
     return {
@@ -68,6 +68,9 @@ def link_snapshot(doc: UrlV2Doc) -> dict[str, Any]:
         "pre_start_url": doc.pre_start_url,
         "geo_rules": doc.geo_rules or None,
         "tag_ids": [str(i) for i in doc.tag_ids],
+        "ab_variants": (
+            [v.model_dump() for v in doc.ab_variants] if doc.ab_variants else None
+        ),
         "meta_tags": _public_meta_tags(doc.meta_tags),
         "total_clicks": doc.total_clicks,
         "created_at": doc.created_at.isoformat(),

--- a/services/webhooks/registry.py
+++ b/services/webhooks/registry.py
@@ -63,6 +63,7 @@ class LinkSnapshot(_PayloadBase):
     starts_at: str | None = None
     pre_start_url: str | None = None
     geo_rules: dict[str, str] | None = None
+    ab_variants: list[dict[str, Any]] | None = None
     meta_tags: dict[str, Any] | None = None
     # Ids into the owner's tags (GET /api/v1/tags resolves name, colour, icon).
     tag_ids: list[str] = Field(default_factory=list)
@@ -130,6 +131,7 @@ def _sample_link() -> dict[str, Any]:
         "starts_at": None,
         "pre_start_url": None,
         "geo_rules": None,
+        "ab_variants": None,
         "meta_tags": None,
         "tag_ids": ["68b6f0c2f9e7a4b1d2c3d4e5"],
         "total_clicks": 4102,

--- a/shared/ab_variants.py
+++ b/shared/ab_variants.py
@@ -1,0 +1,21 @@
+"""Weighted destination pick for A/B split links."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from schemas.models.url import AbVariant
+
+
+def pick_variant(variants: Sequence[AbVariant], roll: int) -> int | None:
+    """Map a roll in 0..99 onto the variant whose weight band it falls in.
+
+    Bands are laid out in list order; the unclaimed remainder above the
+    summed weights maps to None, meaning the default destination.
+    """
+    ceiling = 0
+    for index, variant in enumerate(variants):
+        ceiling += variant.weight
+        if roll < ceiling:
+            return index
+    return None

--- a/shared/ab_variants.py
+++ b/shared/ab_variants.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 from schemas.models.url import AbVariant
 
@@ -19,3 +20,8 @@ def pick_variant(variants: Sequence[AbVariant], roll: int) -> int | None:
         if roll < ceiling:
             return index
     return None
+
+
+def variant_urls(variants: Iterable[Any] | None) -> list[str]:
+    """Destination URLs of ab_variants entries, as models or raw Mongo dicts."""
+    return [v["url"] if isinstance(v, dict) else v.url for v in variants or []]

--- a/shared/aggregation_strategies.py
+++ b/shared/aggregation_strategies.py
@@ -285,6 +285,10 @@ class AggregationStrategyFactory:
         "utm_campaign": lambda: FieldAggregationStrategy(
             "$utm_campaign", "utm_campaign", 50, default="(none)"
         ),
+        # Indices are stored as ints; str() keeps every wire value a string.
+        "variant": lambda: FieldAggregationStrategy(
+            "$variant_index", "variant", 50, default="(default)", transform_fn=str
+        ),
     }
 
     @classmethod

--- a/shared/url_utils.py
+++ b/shared/url_utils.py
@@ -100,9 +100,13 @@ def link_destination_urls_for(link: object) -> list[str]:
     The one place that knows which fields hold destinations. Readers that
     enumerate by keyword drift the moment a field is added; they call this.
     """
+    # Duck-typed like shared.ab_variants.variant_urls, not imported here to
+    # dodge a cycle (that module imports schemas.models.url, which imports this).
+    variants = getattr(link, "ab_variants", None) or []
     return link_destination_urls(
         getattr(link, "long_url", None),
         geo_rules=getattr(link, "geo_rules", None),
+        variants=[v["url"] if isinstance(v, dict) else v.url for v in variants],
         **{
             field: getattr(link, field, None) or None
             for field in SINGLE_DESTINATION_FIELDS

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -139,6 +139,34 @@
             </div>
             {% endfor %}
             {% endif %}
+            {% if variant_destinations %}
+            <div class="geo-banner">
+                <i class="ti ti-arrows-split"></i>
+                This link splits visitors between several destinations at random.
+            </div>
+            {% for dest in variant_destinations %}
+            <div class="url-display destination">
+                <span class="url-label">{{ dest.weight }}% of visitors:</span>
+                <div class="long-url">
+                    <div class="url-content">
+                        <div class="url-header">
+                            <img src="https://www.google.com/s2/favicons?domain={{ dest.domain }}&sz=32" class="favicon"
+                                alt="favicon" onerror="this.style.display='none'">
+                            <span class="full-url">
+                                <span class="domain-name">{{ dest.domain }}</span><span class="url-path">{{ dest.path }}</span>
+                            </span>
+                            {% if dest.is_https %}
+                            <span class="https-badge">
+                                <i class="ti ti-lock"></i>
+                                HTTPS
+                            </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+            {% endif %}
             {% if meta_tags %}
             <!-- Custom social preview set by the link owner. Shown next to the
                  real destination above so recipients can compare what the

--- a/tests/integration/api_v1/test_management.py
+++ b/tests/integration/api_v1/test_management.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import typing
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
+import pytest
 from bson import ObjectId
 from fastapi.testclient import TestClient
 
@@ -14,6 +16,7 @@ from dependencies import (
     require_auth,
 )
 from errors import ForbiddenError, NotFoundError
+from schemas.models.url import AbVariant
 
 from .conftest import _build_test_app, _make_api_key_doc, _make_url_doc, _make_user
 
@@ -250,6 +253,85 @@ class TestUpdateUrlWithDomain:
         # Crucially: the service must not have been called. The route guard
         # must reject *before* the move attempt.
         url_svc.update.assert_not_called()
+
+
+class TestUpdateUrlAbVariants:
+    """Setting ab_variants is flag-gated (403 when off); clearing never is."""
+
+    VARIANTS: typing.ClassVar[list[dict]] = [
+        {"url": "https://example.com/b", "weight": 40}
+    ]
+
+    @staticmethod
+    def _flag_svc(enabled: bool) -> AsyncMock:
+        svc = AsyncMock()
+        svc.is_enabled = AsyncMock(return_value=enabled)
+        svc.require = AsyncMock(
+            side_effect=None
+            if enabled
+            else ForbiddenError("A/B testing is not enabled for this account")
+        )
+        return svc
+
+    def _app(self, user, mock_svc, flag_svc):
+        from dependencies import get_feature_flag_service
+
+        return _build_test_app(
+            {
+                require_auth: lambda: user,
+                get_url_service: lambda: mock_svc,
+                get_feature_flag_service: lambda: flag_svc,
+            }
+        )
+
+    def test_set_ab_variants_flag_on_returns_200(self):
+        user = _make_user()
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.updated_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        url_doc.ab_variants = [AbVariant(url="https://example.com/b", weight=40)]
+        mock_svc = AsyncMock()
+        mock_svc.update = AsyncMock(return_value=url_doc)
+
+        application = self._app(user, mock_svc, self._flag_svc(True))
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.patch(
+                f"/api/v1/urls/{ObjectId()}", json={"ab_variants": self.VARIANTS}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["ab_variants"] == self.VARIANTS
+
+    def test_set_ab_variants_flag_off_returns_403(self):
+        user = _make_user()
+        mock_svc = AsyncMock()
+
+        application = self._app(user, mock_svc, self._flag_svc(False))
+        with TestClient(application, raise_server_exceptions=False) as client:
+            resp = client.patch(
+                f"/api/v1/urls/{ObjectId()}", json={"ab_variants": self.VARIANTS}
+            )
+
+        assert resp.status_code == 403
+        mock_svc.update.assert_not_called()
+
+    @pytest.mark.parametrize("clear_value", [None, []])
+    def test_clear_ab_variants_bypasses_flag(self, clear_value):
+        user = _make_user()
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.updated_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        mock_svc = AsyncMock()
+        mock_svc.update = AsyncMock(return_value=url_doc)
+        flag_svc = self._flag_svc(False)
+
+        application = self._app(user, mock_svc, flag_svc)
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.patch(
+                f"/api/v1/urls/{ObjectId()}", json={"ab_variants": clear_value}
+            )
+
+        assert resp.status_code == 200
+        flag_svc.require.assert_not_awaited()
+        mock_svc.update.assert_called_once()
 
 
 class TestUpdateUrlGeoRules:

--- a/tests/integration/api_v1/test_public_preview.py
+++ b/tests/integration/api_v1/test_public_preview.py
@@ -117,6 +117,7 @@ def test_v2_active_plain_full_body():
             "is_https": True,
         },
         "geo_destinations": None,
+        "variant_destinations": None,
         "expired_destination": None,
     }
 
@@ -180,6 +181,41 @@ def test_v2_geo_rules_grouped_by_url_countries_sorted():
     assert body["destination"]["url"] == "https://example.com/long"
 
 
+def test_v2_ab_variants_listed_with_weights():
+    doc = _make_v2(
+        ab_variants=[
+            {"url": "https://b.example.com/promo", "weight": 60},
+            {"url": "https://example.com/c", "weight": 20},
+        ]
+    )
+    resp = _get(_make_service(v2_docs=(doc,)), "testme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["variant_destinations"] == [
+        {
+            "weight": 60,
+            "url": "https://b.example.com/promo",
+            "domain": "b.example.com",
+            "path": "/promo",
+            "is_https": True,
+        },
+        {
+            "weight": 20,
+            "url": "https://example.com/c",
+            "domain": "example.com",
+            "path": "/c",
+            "is_https": True,
+        },
+    ]
+    assert body["destination"]["url"] == "https://example.com/long"
+
+
+def test_v2_without_variants_has_null_variant_destinations():
+    resp = _get(_make_service(v2_docs=(_make_v2(),)), "testme")
+    assert resp.json()["variant_destinations"] is None
+
+
 # ── v2, withholding ────────────────────────────────────────────────────────────
 
 
@@ -187,6 +223,7 @@ def test_v2_password_protected_withholds_destination_and_geo():
     doc = _make_v2(
         password="$argon2id$fakehash",
         geo_rules={"US": "https://us.example.com/"},
+        ab_variants=[{"url": "https://b.example.com/", "weight": 50}],
     )
     resp = _get(_make_service(v2_docs=(doc,)), "testme")
 
@@ -196,6 +233,8 @@ def test_v2_password_protected_withholds_destination_and_geo():
     assert body["password_protected"] is True
     assert body["destination"] is None
     assert body["geo_destinations"] is None
+    assert body["variant_destinations"] is None
+    assert "b.example.com" not in resp.text
     # No password unlock exists on this wire — the hash must never leak.
     assert "argon2" not in resp.text
 
@@ -285,6 +324,7 @@ def test_v1_active_full_body():
             "is_https": True,
         },
         "geo_destinations": None,
+        "variant_destinations": None,
         "expired_destination": None,
     }
 

--- a/tests/integration/api_v1/test_reports.py
+++ b/tests/integration/api_v1/test_reports.py
@@ -720,6 +720,29 @@ def test_safety_sink_absent_means_no_enqueue_and_no_failure():
     assert len(reports_col.update_calls) == 1
 
 
+def test_reported_link_enqueues_variant_destinations_too():
+    from schemas.models.url import AbVariant
+
+    doc = _make_v2_doc("var1234")
+    doc.long_url = "https://clean.example/"
+    doc.ab_variants = [AbVariant(url="https://hidden.example/b", weight=40)]
+    sink = _CapturingSafetySink()
+    service, _, _ = _build_service(v2_docs=[doc], safety_sink=sink)
+
+    with _client(service) as c:
+        resp = c.post(
+            _URL, json={"items": [{"code_or_url": "var1234", "reason": "phishing"}]}
+        )
+    assert resp.status_code == 200
+
+    by_host = {e.host: e for e in sink.events}
+    assert set(by_host) == {"clean.example", "hidden.example"}
+    assert by_host["hidden.example"].context["link_destinations"] == [
+        "https://clean.example/",
+        "https://hidden.example/b",
+    ]
+
+
 def test_reported_link_enqueues_every_destination_including_geo_rules():
     """A phish hidden in a geo rule must be judged, not just long_url."""
     doc = _make_v2_doc("geo1234")

--- a/tests/integration/api_v1/test_shorten.py
+++ b/tests/integration/api_v1/test_shorten.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from dependencies import get_current_user, get_url_service
 from errors import ConflictError, ForbiddenError, ValidationError
+from schemas.models.url import AbVariant
 
 from .conftest import _build_test_app, _make_api_key_doc, _make_url_doc, _make_user
 
@@ -426,6 +427,101 @@ class TestCheckAliasWithCustomDomain:
         assert custom_svc.assert_owned_and_active.await_count == 0
         kwargs = url_svc.check_alias.call_args.kwargs
         assert kwargs.get("domain") is None
+
+
+class TestShortenAbVariants:
+    """ab_variants is authed-only and gated by the ab_testing feature flag."""
+
+    VARIANTS: typing.ClassVar[list[dict]] = [
+        {"url": "https://example.com/b", "weight": 40}
+    ]
+    BODY: typing.ClassVar[dict] = {
+        "long_url": "https://example.com",
+        "ab_variants": VARIANTS,
+    }
+
+    @staticmethod
+    def _flag_svc(enabled: bool) -> AsyncMock:
+        svc = AsyncMock()
+        svc.is_enabled = AsyncMock(return_value=enabled)
+        svc.require = AsyncMock(
+            side_effect=None
+            if enabled
+            else ForbiddenError("A/B testing is not enabled for this account")
+        )
+        return svc
+
+    def _app(self, user, mock_svc, flag_svc):
+        from dependencies import get_feature_flag_service
+
+        return _build_test_app(
+            {
+                get_current_user: lambda: user,
+                get_url_service: lambda: mock_svc,
+                get_feature_flag_service: lambda: flag_svc,
+            }
+        )
+
+    def test_anonymous_with_ab_variants_returns_401(self):
+        mock_svc = AsyncMock()
+        flag_svc = self._flag_svc(True)
+        with TestClient(
+            self._app(None, mock_svc, flag_svc), raise_server_exceptions=False
+        ) as client:
+            resp = client.post("/api/v1/shorten", json=self.BODY)
+
+        assert resp.status_code == 401
+        mock_svc.create.assert_not_called()
+        flag_svc.require.assert_not_awaited()
+
+    def test_flag_off_returns_403(self):
+        mock_svc = AsyncMock()
+        with TestClient(
+            self._app(_make_user(), mock_svc, self._flag_svc(False)),
+            raise_server_exceptions=False,
+        ) as client:
+            resp = client.post("/api/v1/shorten", json=self.BODY)
+
+        assert resp.status_code == 403
+        mock_svc.create.assert_not_called()
+
+    def test_flag_on_returns_201_with_ab_variants_echoed(self):
+        user = _make_user()
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.ab_variants = [AbVariant(url="https://example.com/b", weight=40)]
+        mock_svc = AsyncMock()
+        mock_svc.create = AsyncMock(return_value=(url_doc, None))
+
+        with TestClient(
+            self._app(user, mock_svc, self._flag_svc(True)),
+            raise_server_exceptions=True,
+        ) as client:
+            resp = client.post("/api/v1/shorten", json=self.BODY)
+
+        assert resp.status_code == 201
+        assert resp.json()["ab_variants"] == self.VARIANTS
+        sent = mock_svc.create.call_args.args[0]
+        assert [v.model_dump() for v in sent.ab_variants] == self.VARIANTS
+
+    def test_empty_list_flag_never_consulted(self):
+        user = _make_user()
+        mock_svc = AsyncMock()
+        mock_svc.create = AsyncMock(
+            return_value=(_make_url_doc(owner_id=user.user_id), None)
+        )
+        flag_svc = self._flag_svc(False)
+
+        with TestClient(
+            self._app(user, mock_svc, flag_svc), raise_server_exceptions=True
+        ) as client:
+            resp = client.post(
+                "/api/v1/shorten",
+                json={"long_url": "https://example.com", "ab_variants": []},
+            )
+
+        assert resp.status_code == 201
+        assert resp.json()["ab_variants"] is None
+        flag_svc.require.assert_not_awaited()
 
 
 class TestShortenExpiredFallback:

--- a/tests/integration/api_v1/test_stats.py
+++ b/tests/integration/api_v1/test_stats.py
@@ -230,6 +230,26 @@ class TestLinkStats:
 
         assert resp.status_code == 200
 
+    def test_link_stats_variant_group_by_accepted(self):
+        user = _make_user()
+        url_doc = _make_url_doc(alias="mylink", owner_id=user.user_id)
+        url_svc = AsyncMock()
+        url_svc.get_owned = AsyncMock(return_value=url_doc)
+        stats_svc = AsyncMock()
+        stats_svc.query_link = AsyncMock(
+            return_value={**self._LINK_STATS_RESULT, "group_by": ["variant"]}
+        )
+
+        application = self._app(user=user, stats_svc=stats_svc, url_svc=url_svc)
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.get(
+                f"/api/v1/stats/links/{self._URL_ID}?group_by=variant&variant=0"
+            )
+
+        assert resp.status_code == 200
+        query = stats_svc.query_link.call_args.args[0]
+        assert query.parsed_filters["variant"] == ["0"]
+
     def test_link_stats_short_code_group_by_rejected(self):
         user = _make_user()
         application = self._app(user=user)

--- a/tests/integration/test_legacy_url_routes.py
+++ b/tests/integration/test_legacy_url_routes.py
@@ -746,6 +746,36 @@ def test_preview_geo_link_lists_every_destination():
     assert "US:" in html
 
 
+def test_preview_variant_link_lists_every_destination():
+    from schemas.models.url import AbVariant
+
+    db = _mock_db()
+    v2_doc = MagicMock()
+    v2_doc.alias = "abc1234"
+    v2_doc.long_url = "https://example.com/default"
+    v2_doc.password = None
+    v2_doc.geo_rules = None
+    v2_doc.ab_variants = [AbVariant(url="https://b.example.net/offer", weight=40)]
+
+    with (
+        patch("routes.legacy.url_shortener.UrlRepository") as MockUrlRepo,
+        patch("routes.legacy.url_shortener.LegacyUrlRepository") as MockLegacyRepo,
+    ):
+        MockUrlRepo.return_value.find_by_alias = AsyncMock(return_value=v2_doc)
+        MockLegacyRepo.return_value.find_by_id = AsyncMock(return_value=None)
+
+        app = build_test_app(legacy_url_router, overrides={get_db: lambda: db})
+        with TestClient(app) as client:
+            resp = client.get("/abc1234+")
+
+    assert resp.status_code == 200
+    html = resp.text
+    assert "splits visitors between several destinations" in html
+    assert "40% of visitors:" in html
+    assert "b.example.net" in html
+    assert "example.com" in html
+
+
 def test_preview_non_geo_link_has_no_banner():
     db = _mock_db()
     v2_doc = MagicMock()

--- a/tests/integration/test_redirect_routes.py
+++ b/tests/integration/test_redirect_routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from dependencies import get_click_sink, get_url_service
@@ -23,6 +24,7 @@ from errors import (
 )
 from infrastructure.cache.url_cache import UrlCacheData
 from routes.redirect_routes import router as redirect_router
+from schemas.models.url import AbVariant
 from services.click.events import ClickEvent
 from tests.conftest import build_test_app
 from tests.factories import make_url_cache
@@ -398,6 +400,110 @@ def test_password_form_url_not_password_protected_returns_400_html():
         resp = client.post("/abc1234/password", data={"password": "pw"})
     assert resp.status_code == 400
     assert "text/html" in resp.headers["content-type"]
+
+
+# ── A/B variant tests ─────────────────────────────────────────────────────────
+
+AB_VARIANTS = [
+    AbVariant(url="https://example.com/b", weight=60),
+    AbVariant(url="https://example.com/c", weight=30),
+]
+
+
+class TestAbVariantRedirect:
+    def _app(self, url_data, sink=None):
+        return _build_app(_mock_url_service(url_data), sink)
+
+    def _get(self, client, method="get"):
+        return getattr(client, method)("/abc1234", headers={"User-Agent": BROWSER_UA})
+
+    @pytest.mark.parametrize(
+        ("roll", "location", "index"),
+        [
+            (0, "https://example.com/b", 0),
+            (59, "https://example.com/b", 0),
+            (60, "https://example.com/c", 1),
+            (89, "https://example.com/c", 1),
+            (90, "https://example.com/default", None),
+            (99, "https://example.com/default", None),
+        ],
+    )
+    def test_roll_picks_variant_and_stamps_event(
+        self, monkeypatch, roll, location, index
+    ):
+        monkeypatch.setattr("routes.redirect_routes.randrange", lambda n: roll)
+        url_data = _make_url_cache(
+            long_url="https://example.com/default", ab_variants=AB_VARIANTS
+        )
+        sink = _mock_click_sink()
+        with TestClient(self._app(url_data, sink), follow_redirects=False) as client:
+            resp = self._get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == location
+        assert resp.headers["cache-control"] == "no-store"
+        event = sink.emit.await_args.args[0]
+        assert event.variant_index == index
+
+    def test_split_over_many_requests_is_roughly_the_weights(self):
+        url_data = _make_url_cache(
+            long_url="https://example.com/default", ab_variants=AB_VARIANTS
+        )
+        sink = _mock_click_sink()
+        with TestClient(self._app(url_data, sink), follow_redirects=False) as client:
+            locations = [self._get(client).headers["location"] for _ in range(400)]
+        b = locations.count("https://example.com/b")
+        c = locations.count("https://example.com/c")
+        d = locations.count("https://example.com/default")
+        # 60/30/10 with a generous band; a broken pick lands far outside it.
+        assert 190 <= b <= 290, b
+        assert 80 <= c <= 160, c
+        assert 15 <= d <= 70, d
+
+    def test_matched_geo_rule_wins_over_variants(self, monkeypatch):
+        from dependencies import get_geoip_service
+
+        monkeypatch.setattr("routes.redirect_routes.randrange", lambda n: 0)
+        url_data = _make_url_cache(
+            long_url="https://example.com/default",
+            geo_rules={"IN": "https://example.in/"},
+            ab_variants=AB_VARIANTS,
+        )
+        sink = _mock_click_sink()
+        app = build_test_app(
+            redirect_router,
+            overrides={
+                get_url_service: lambda: _mock_url_service(url_data),
+                get_click_sink: lambda: sink,
+                get_geoip_service: lambda: MagicMock(),
+            },
+        )
+        with TestClient(app, follow_redirects=False) as client:
+            resp = client.get(
+                "/abc1234", headers={"User-Agent": BROWSER_UA, "CF-IPCountry": "IN"}
+            )
+        assert resp.headers["location"] == "https://example.in/"
+        event = sink.emit.await_args.args[0]
+        assert event.geo_matched is True
+        assert event.variant_index is None
+
+    def test_head_request_picks_a_variant_without_event(self, monkeypatch):
+        monkeypatch.setattr("routes.redirect_routes.randrange", lambda n: 0)
+        url_data = _make_url_cache(ab_variants=AB_VARIANTS)
+        sink = _mock_click_sink()
+        with TestClient(self._app(url_data, sink), follow_redirects=False) as client:
+            resp = self._get(client, "head")
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/b"
+        sink.emit.assert_not_awaited()
+
+    def test_plain_link_has_no_variant_and_stays_cacheable(self):
+        url_data = _make_url_cache(long_url="https://example.com/target")
+        sink = _mock_click_sink()
+        with TestClient(self._app(url_data, sink), follow_redirects=False) as client:
+            resp = self._get(client)
+        assert resp.headers["location"] == "https://example.com/target"
+        assert "cache-control" not in resp.headers
+        assert sink.emit.await_args.args[0].variant_index is None
 
 
 # ── Geo-targeting tests ───────────────────────────────────────────────────────

--- a/tests/unit/infrastructure/test_cache.py
+++ b/tests/unit/infrastructure/test_cache.py
@@ -296,6 +296,43 @@ class TestUrlCacheDataGeoRules:
         assert result.geo_rules == rules
 
 
+class TestUrlCacheDataAbVariants:
+    async def test_pre_variants_payload_decodes_with_none(self):
+        payload = {
+            "_id": "507f1f77bcf86cd799439011",
+            "alias": "abc1234",
+            "long_url": "https://example.com",
+            "block_bots": False,
+            "password_hash": None,
+            "expiration_time": None,
+            "max_clicks": None,
+            "url_status": "ACTIVE",
+            "schema_version": "v2",
+            "owner_id": "507f1f77bcf86cd799439012",
+            "domain": DOMAIN,
+        }
+        r = _fake_redis(get_returns=json.dumps(payload))
+        cache = UrlCache(r)
+        result = await cache.get("abc1234", DOMAIN)
+        assert result is not None
+        assert result.ab_variants is None
+
+    async def test_ab_variants_round_trip(self):
+        from schemas.models.url import AbVariant
+
+        variants = [AbVariant(url="https://example.com/b", weight=40)]
+        data = _url_data(domain=DOMAIN).model_copy(update={"ab_variants": variants})
+        r = _fake_redis()
+        cache = UrlCache(r)
+        await cache.set("abc1234", data)
+        stored_json = r.setex.call_args[0][2]
+
+        r2 = _fake_redis(get_returns=stored_json)
+        result = await UrlCache(r2).get("abc1234", DOMAIN)
+        assert result is not None
+        assert result.ab_variants == variants
+
+
 class TestUrlCacheDataIsTimeExpired:
     def _data(self, expiration_time):
         return UrlCacheData(

--- a/tests/unit/repositories/test_url_repository.py
+++ b/tests/unit/repositories/test_url_repository.py
@@ -925,10 +925,11 @@ class TestSweepSampleUrls:
         assert urls[1]["$map"]["input"] == {
             "$objectToArray": {"$ifNull": ["$geo_rules", {}]}
         }
+        assert urls[2]["$map"]["input"] == {"$ifNull": ["$ab_variants", []]}
         # One arm per single-URL destination field, in the shared list's order:
         # a field missing here is a sweep that samples the wrong URL.
         from shared.url_utils import SINGLE_DESTINATION_FIELDS
 
-        arms = [arm["$cond"][1] for arm in urls[2:]]
+        arms = [arm["$cond"][1] for arm in urls[3:]]
         assert arms == [[f"${field}"] for field in SINGLE_DESTINATION_FIELDS]
         assert pipeline[3]["$group"]["urls"] == {"$first": "$urls"}

--- a/tests/unit/schemas/dto/test_stats.py
+++ b/tests/unit/schemas/dto/test_stats.py
@@ -58,6 +58,11 @@ class TestStatsQuery:
             "utm_campaign",
         ]
 
+    def test_variant_dimension_accepted_in_group_by_and_filter(self):
+        q = StatsQuery.model_validate({"group_by": "variant", "variant": "0,(default)"})
+        assert q.parsed_group_by == ["variant"]
+        assert q.parsed_filters["variant"] == ["0", "(default)"]
+
     def test_device_and_utm_filter_params_parsed(self):
         q = StatsQuery.model_validate(
             {

--- a/tests/unit/schemas/dto/test_url.py
+++ b/tests/unit/schemas/dto/test_url.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import typing
 from datetime import datetime, timezone
 
 import pytest
@@ -696,3 +697,147 @@ class TestFromDocDerivedStatus:
         future = datetime(2099, 1, 1, tzinfo=timezone.utc)
         r = UrlListItem.from_doc(_make_doc(expire_after=future))
         assert r.status == "ACTIVE"
+
+
+# ── ab_variants ────────────────────────────────────────────────────────────────
+
+
+class TestAbVariantsField:
+    def test_urls_stripped_and_weights_coerced(self):
+        req = CreateUrlRequest.model_validate(
+            {
+                "long_url": "https://example.com",
+                "ab_variants": [{"url": "  https://example.com/b ", "weight": "40"}],
+            }
+        )
+        assert req.ab_variants is not None
+        assert req.ab_variants[0].url == "https://example.com/b"
+        assert req.ab_variants[0].weight == 40
+
+    def test_weights_over_100_rejected(self):
+        with pytest.raises(ValidationError, match="sum to at most 100"):
+            CreateUrlRequest.model_validate(
+                {
+                    "long_url": "https://example.com",
+                    "ab_variants": [
+                        {"url": "https://example.com/b", "weight": 70},
+                        {"url": "https://example.com/c", "weight": 40},
+                    ],
+                }
+            )
+
+    def test_weights_exactly_100_accepted(self):
+        req = CreateUrlRequest.model_validate(
+            {
+                "long_url": "https://example.com",
+                "ab_variants": [
+                    {"url": "https://example.com/b", "weight": 60},
+                    {"url": "https://example.com/c", "weight": 40},
+                ],
+            }
+        )
+        assert sum(v.weight for v in req.ab_variants) == 100
+
+    @pytest.mark.parametrize("weight", [0, 101, -1, 60.5, "many"])
+    def test_bad_weight_rejected(self, weight):
+        with pytest.raises(ValidationError):
+            CreateUrlRequest.model_validate(
+                {
+                    "long_url": "https://example.com",
+                    "ab_variants": [{"url": "https://example.com/b", "weight": weight}],
+                }
+            )
+
+    def test_empty_url_rejected(self):
+        with pytest.raises(ValidationError):
+            CreateUrlRequest.model_validate(
+                {
+                    "long_url": "https://example.com",
+                    "ab_variants": [{"url": "   ", "weight": 10}],
+                }
+            )
+
+    def test_oversized_url_rejected(self):
+        with pytest.raises(ValidationError):
+            CreateUrlRequest.model_validate(
+                {
+                    "long_url": "https://example.com",
+                    "ab_variants": [
+                        {"url": "https://example.com/" + "a" * 8192, "weight": 10}
+                    ],
+                }
+            )
+
+    def test_non_list_returns_clean_validation_error(self):
+        for bad in ({"url": "https://example.com/b", "weight": 10}, "x", 42):
+            with pytest.raises(ValidationError):
+                CreateUrlRequest.model_validate(
+                    {"long_url": "https://example.com", "ab_variants": bad}
+                )
+
+    def test_hard_entry_ceiling_bounds_the_pre_auth_loop(self):
+        variants = [{"url": "https://example.com/x", "weight": 1} for _ in range(51)]
+        with pytest.raises(ValidationError, match="cannot exceed 50"):
+            CreateUrlRequest.model_validate(
+                {"long_url": "https://example.com", "ab_variants": variants}
+            )
+
+    def test_update_null_registers_in_fields_set(self):
+        req = UpdateUrlRequest.model_validate({"ab_variants": None})
+        assert "ab_variants" in req.model_fields_set
+        assert req.ab_variants is None
+
+    def test_update_empty_list_registers_in_fields_set(self):
+        req = UpdateUrlRequest.model_validate({"ab_variants": []})
+        assert "ab_variants" in req.model_fields_set
+        assert req.ab_variants == []
+
+    def test_update_omitted_not_in_fields_set(self):
+        req = UpdateUrlRequest.model_validate({})
+        assert "ab_variants" not in req.model_fields_set
+
+    def test_update_weights_over_100_rejected(self):
+        with pytest.raises(ValidationError, match="sum to at most 100"):
+            UpdateUrlRequest.model_validate(
+                {
+                    "ab_variants": [
+                        {"url": "https://example.com/b", "weight": 60},
+                        {"url": "https://example.com/c", "weight": 50},
+                    ]
+                }
+            )
+
+
+class TestAbVariantsResponse:
+    def _doc(self, **overrides) -> UrlV2Doc:
+        base = {
+            "_id": ObjectId(),
+            "alias": "abc1234",
+            "owner_id": ObjectId(),
+            "domain": "spoo.me",
+            "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "long_url": "https://example.com",
+        }
+        base.update(overrides)
+        return UrlV2Doc.model_validate(base)
+
+    VARIANTS: typing.ClassVar[list[dict]] = [
+        {"url": "https://example.com/b", "weight": 60},
+        {"url": "https://example.com/c", "weight": 40},
+    ]
+
+    def test_echoed_on_all_three_shapes(self):
+        doc = self._doc(ab_variants=self.VARIANTS)
+        assert (
+            UrlResponse.from_doc(doc, "https://spoo.me").model_dump()["ab_variants"]
+            == self.VARIANTS
+        )
+        assert UpdateUrlResponse.from_doc(doc).model_dump()["ab_variants"] == (
+            self.VARIANTS
+        )
+        assert UrlListItem.from_doc(doc).model_dump()["ab_variants"] == self.VARIANTS
+
+    def test_null_when_unset(self):
+        doc = self._doc()
+        assert UrlResponse.from_doc(doc, "https://spoo.me").ab_variants is None
+        assert UrlListItem.from_doc(doc).ab_variants is None

--- a/tests/unit/schemas/models/test_url.py
+++ b/tests/unit/schemas/models/test_url.py
@@ -229,6 +229,37 @@ class TestUrlV2DocGeoRules:
         assert doc.to_mongo()["geo_rules"] == rules
 
 
+class TestUrlV2DocAbVariants:
+    def _make(self, **overrides):
+        base = {
+            "_id": oid(),
+            "alias": "abc1234",
+            "owner_id": oid(),
+            "domain": "spoo.me",
+            "created_at": now(),
+            "long_url": "https://example.com",
+        }
+        base.update(overrides)
+        return UrlV2Doc.model_validate(base)
+
+    def test_absent_ab_variants_defaults_to_none(self):
+        assert self._make().ab_variants is None
+
+    def test_ab_variants_round_trip(self):
+        variants = [{"url": "https://example.com/b", "weight": 40}]
+        doc = self._make(ab_variants=variants)
+        assert doc.ab_variants is not None
+        assert doc.ab_variants[0].url == "https://example.com/b"
+        assert doc.ab_variants[0].weight == 40
+        assert doc.to_mongo()["ab_variants"] == variants
+
+    def test_weight_bounds_enforced_on_the_model(self):
+        with pytest.raises(PydanticValidationError):
+            self._make(ab_variants=[{"url": "https://example.com/b", "weight": 0}])
+        with pytest.raises(PydanticValidationError):
+            self._make(ab_variants=[{"url": "https://example.com/b", "weight": 101}])
+
+
 # ── LinkMetaTags ──────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/scripts/test_backfill_url_dest.py
+++ b/tests/unit/scripts/test_backfill_url_dest.py
@@ -57,6 +57,22 @@ def test_secondary_fields_are_index_aligned():
     }
 
 
+def test_secondary_hosts_include_variant_destinations():
+    variants = [
+        {"url": "https://B.example/x", "weight": 40},
+        {"url": "https://main.example/b", "weight": 10},
+    ]
+    urls = backfill.secondary_urls({"ab_variants": variants})
+    assert backfill.secondary_hosts(urls, "main.example") == ["b.example"]
+    both_urls = backfill.secondary_urls(
+        {"geo_rules": {"IN": "https://geo.example/"}, "ab_variants": variants}
+    )
+    assert backfill.secondary_hosts(both_urls, "main.example") == [
+        "b.example",
+        "geo.example",
+    ]
+
+
 def test_dest_for_includes_secondary_hosts_only_when_present():
     plain = backfill.dest_for({"long_url": "https://main.example/p"}, "long_url")
     assert plain["host"] == "main.example" and "secondary_hosts" not in plain
@@ -69,6 +85,14 @@ def test_dest_for_includes_secondary_hosts_only_when_present():
     )
     assert geo["secondary_hosts"] == ["geo.example"]
     assert geo["secondary_registrable"] == ["geo.example"]
+    variant = backfill.dest_for(
+        {
+            "long_url": "https://main.example/p",
+            "ab_variants": [{"url": "https://variant.example/b", "weight": 50}],
+        },
+        "long_url",
+    )
+    assert variant["secondary_hosts"] == ["variant.example"]
     assert backfill.dest_for({"long_url": "nonsense"}, "long_url") is None
     scheduled = backfill.dest_for(
         {
@@ -108,6 +132,7 @@ def test_backfill_secondary_stamps_and_reports(capsys):
     assert ops[0]._filter == {
         "_id": 1,
         "geo_rules": {"IN": "https://geo.example/"},
+        "ab_variants": None,
         "pre_start_url": None,
         "expired_redirect_url": None,
         "dest.host": "main.example",
@@ -123,7 +148,7 @@ def test_backfill_secondary_stamps_and_reports(capsys):
         2: {"dest.secondary_hosts": [], "dest.secondary_registrable": []},
     }
     out = capsys.readouterr().out
-    assert "geo or scheduled links needing secondary fields: 2" in out
+    assert "geo/variant/scheduled links needing secondary fields: 2" in out
     assert (
         "secondary fields stamped 2; failed: 0; skipped (changed meanwhile): 0; "
         "remaining (expect 0): 0"

--- a/tests/unit/services/safety/test_hot.py
+++ b/tests/unit/services/safety/test_hot.py
@@ -113,6 +113,31 @@ class TestHotLinkScreenSecondaryDestinations:
         assert [c.args[0].host for c in sink.emit.await_args_list] == ["clean.example"]
 
     @pytest.mark.asyncio
+    async def test_variant_destinations_each_get_an_event(self):
+        from schemas.models.url import AbVariant
+
+        doc = MagicMock(
+            long_url="https://clean.example/",
+            geo_rules=None,
+            ab_variants=[
+                AbVariant(url="https://variant.example/b", weight=50),
+                AbVariant(url="https://clean.example/c", weight=20),
+            ],
+        )
+        screen, _u, sink = _screen(v2_doc=doc)
+
+        await screen.on_hot(_hot())
+
+        hosts = [c.args[0].host for c in sink.emit.await_args_list]
+        assert hosts == ["clean.example", "variant.example"]
+        event = sink.emit.await_args_list[1].args[0]
+        assert event.context["link_destinations"] == [
+            "https://clean.example/",
+            "https://variant.example/b",
+            "https://clean.example/c",
+        ]
+
+    @pytest.mark.asyncio
     async def test_single_destination_carries_no_link_destinations(self):
         doc = MagicMock(long_url="https://only.example/", geo_rules=None)
         screen, _u, sink = _screen(v2_doc=doc)

--- a/tests/unit/services/test_click_consumers.py
+++ b/tests/unit/services/test_click_consumers.py
@@ -46,6 +46,7 @@ class TestStatsClickConsumer:
             utm_source=event.utm_source,
             utm_medium=event.utm_medium,
             utm_campaign=event.utm_campaign,
+            variant_index=event.variant_index,
         )
 
     async def test_drops_undecodable_payload_without_raising(self):

--- a/tests/unit/services/test_click_events.py
+++ b/tests/unit/services/test_click_events.py
@@ -135,6 +135,24 @@ class TestGeoDecisionFields:
         assert restored.geo_matched is False
 
 
+class TestVariantIndexField:
+    def test_defaults_to_none(self):
+        assert make_event().variant_index is None
+
+    def test_round_trips_through_stream(self):
+        restored = from_stream_fields(to_stream_fields(make_event(variant_index=1)))
+        assert restored.variant_index == 1
+
+    def test_pre_variant_stream_payload_still_parses(self):
+        import json as _json
+
+        fields = to_stream_fields(make_event())
+        data = _json.loads(fields[STREAM_FIELD_DATA])
+        data.pop("variant_index", None)
+        fields[STREAM_FIELD_DATA] = _json.dumps(data)
+        assert from_stream_fields(fields).variant_index is None
+
+
 class TestUtmSanitization:
     """UTM values are visitor-controlled input — the bound is structural,
     enforced at event construction like the password-hash strip."""

--- a/tests/unit/services/test_click_service.py
+++ b/tests/unit/services/test_click_service.py
@@ -155,6 +155,7 @@ def make_context(
     utm_source: str | None = None,
     utm_medium: str | None = None,
     utm_campaign: str | None = None,
+    variant_index: int | None = None,
 ) -> ClickContext:
     return ClickContext(
         url_data=url_data,
@@ -168,6 +169,7 @@ def make_context(
         utm_source=utm_source,
         utm_medium=utm_medium,
         utm_campaign=utm_campaign,
+        variant_index=variant_index,
     )
 
 
@@ -294,6 +296,24 @@ class TestV2ClickHandler:
         assert doc["utm_source"] == "newsletter"
         assert doc["utm_medium"] == "email"
         assert doc["utm_campaign"] == "launch"
+
+    @pytest.mark.asyncio
+    async def test_variant_index_recorded_in_click_doc(self):
+        d = make_deps()
+        handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
+
+        await handler.handle(make_context(make_v2_cache(), variant_index=1))
+
+        assert d.click_repo.insert.call_args[0][0]["variant_index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_variant_index_defaults_to_none(self):
+        d = make_deps()
+        handler = make_v2_handler(d.click_repo, d.url_repo, d.geoip, d.url_cache)
+
+        await handler.handle(make_context(make_v2_cache()))
+
+        assert d.click_repo.insert.call_args[0][0]["variant_index"] is None
 
     @pytest.mark.asyncio
     async def test_utm_tags_default_to_none(self):

--- a/tests/unit/services/test_click_sinks.py
+++ b/tests/unit/services/test_click_sinks.py
@@ -32,6 +32,7 @@ def assert_track_click_matches_event(
         utm_source=event.utm_source,
         utm_medium=event.utm_medium,
         utm_campaign=event.utm_campaign,
+        variant_index=event.variant_index,
     )
 
 

--- a/tests/unit/services/test_edge_cache.py
+++ b/tests/unit/services/test_edge_cache.py
@@ -83,6 +83,16 @@ class TestEligibility:
         url = make_url_cache(start_time=1_000_000_000)
         assert promotion_skip_reason(url, SYSTEM, SYSTEM) is None
 
+    def test_ab_variant_urls_are_skipped(self):
+        """No Worker entry type makes a weighted pick — variant links stay
+        origin-served so every click gets its variant_index."""
+        from schemas.models.url import AbVariant
+
+        url = make_url_cache(
+            ab_variants=[AbVariant(url="https://example.com/b", weight=50)]
+        )
+        assert promotion_skip_reason(url, SYSTEM, SYSTEM) == "ab_variants"
+
     def test_geo_targeted_urls_are_eligible(self):
         """Geo links promote as geo_redirect entries — the Worker can make
         the per-country decision from request.cf.country."""

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -460,6 +460,27 @@ class TestClickQueryBuilding:
             {"utm_medium": {"$exists": False}},
         ]
 
+    def test_variant_filter_targets_variant_index_as_ints(self):
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            OWNER_ID, START, NOW, {"variant": ["0", "1"]}
+        )
+        assert q["variant_index"] == {"$in": [0, 1]}
+        assert "variant" not in q
+
+    def test_variant_default_sentinel_matches_missing_field(self):
+        from services.stats_service import StatsService
+
+        q = StatsService._build_click_query(
+            OWNER_ID, START, NOW, {"variant": ["(default)", "1"]}
+        )
+        assert q["$or"] == [
+            {"variant_index": {"$in": ["(default)", 1]}},
+            {"variant_index": {"$in": [None, ""]}},
+            {"variant_index": {"$exists": False}},
+        ]
+
     def test_two_null_sentinel_filters_nest_under_and(self):
         """Two $or groups must combine under $and — a second bare "$or"
         key would silently overwrite the first."""
@@ -707,6 +728,17 @@ class TestQueryLink:
             {"utm_source": {"$in": [None, ""]}},
             {"utm_source": {"$exists": False}},
         ]
+
+    @pytest.mark.asyncio
+    async def test_variant_group_by_groups_on_variant_index(self):
+        svc, click_repo, _ = make_service()
+        click_repo.aggregate.return_value = facet_response()
+
+        await svc.query_link(_lq(group_by="variant"), make_url_doc())
+
+        facet = click_repo.aggregate.call_args[0][0][1]["$facet"]
+        group = next(s["$group"] for s in facet["variant"] if "$group" in s)
+        assert group["_id"] == {"$ifNull": ["$variant_index", "(default)"]}
 
     @pytest.mark.asyncio
     async def test_utm_group_by_allowed(self):

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -62,6 +62,7 @@ def make_url_v2_doc(
     starts_at: datetime | None = None,
     pre_start_url: str | None = None,
     tag_ids: list | None = None,
+    ab_variants: list | None = None,
     expired_redirect_url: str | None = None,
 ) -> UrlV2Doc:
     return UrlV2Doc.from_mongo(
@@ -80,6 +81,7 @@ def make_url_v2_doc(
             "starts_at": starts_at,
             "pre_start_url": pre_start_url,
             "geo_rules": geo_rules,
+            "ab_variants": ab_variants,
             "expired_redirect_url": expired_redirect_url,
             "status": status,
             "private_stats": True,
@@ -183,6 +185,7 @@ def make_service(
     og_writethrough=None,
     edge_kv=None,
     geo_rules_enabled=True,
+    ab_variants_enabled=True,
 ):
     from services.url_service import UrlService
 
@@ -198,6 +201,7 @@ def make_service(
         og_writethrough=og_writethrough,
         edge_kv=edge_kv,
         geo_rules_enabled=geo_rules_enabled,
+        ab_variants_enabled=ab_variants_enabled,
     )
 
 
@@ -2791,6 +2795,255 @@ class TestUrlServiceGeoRules:
         url_repo.find_by_alias.assert_not_called()
 
 
+# TestUrlServiceAbVariants
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAbVariantsFeatureGate:
+    @pytest.mark.asyncio
+    async def test_ab_variants_refused_while_the_feature_is_dark(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo,
+            legacy_repo,
+            emoji_repo,
+            blocked_url_repo,
+            url_cache,
+            ab_variants_enabled=False,
+        )
+        blocked_url_repo.get_patterns.return_value = []
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com",
+            ab_variants=[{"url": "https://example.com/b", "weight": 40}],
+        )
+        with pytest.raises(ValidationError) as exc:
+            await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+        assert exc.value.field == "ab_variants"
+        url_repo.insert.assert_not_awaited()
+
+
+class TestUrlServiceAbVariants:
+    """A/B variants: create/update validation, persistence, cache projection."""
+
+    VARIANTS: typing.ClassVar[list[dict]] = [
+        {"url": "https://example.com/b", "weight": 60},
+        {"url": "https://example.com/c", "weight": 40},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_create_persists_ab_variants(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com", ab_variants=self.VARIANTS
+        )
+        result, _token = await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        assert [v.model_dump() for v in result.ab_variants] == self.VARIANTS
+        inserted = url_repo.insert.call_args[0][0]
+        assert inserted["ab_variants"] == self.VARIANTS
+
+    @pytest.mark.asyncio
+    async def test_create_without_variants_stores_none(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        await svc.create(
+            CreateUrlRequest(long_url="https://example.com", ab_variants=[]),
+            owner_id=USER_OID,
+            client_ip="1.2.3.4",
+        )
+        assert url_repo.insert.call_args[0][0]["ab_variants"] is None
+
+    def test_too_many_entries_rejected(self):
+        from schemas.dto.requests.url import AbVariantRequest
+        from services.url_service import _validate_ab_variants_shape
+
+        variants = [
+            AbVariantRequest(url="https://example.com/x", weight=1) for _ in range(11)
+        ]
+        with pytest.raises(ValidationError) as exc:
+            _validate_ab_variants_shape(variants, max_variants=10)
+        assert exc.value.field == "ab_variants"
+
+    @pytest.mark.asyncio
+    async def test_create_blocked_variant_destination_rejected(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = [r"https://evil\.com"]
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com",
+            ab_variants=[
+                {"url": "https://example.com/b", "weight": 30},
+                {"url": "https://evil.com/page", "weight": 30},
+            ],
+        )
+        with pytest.raises(ValidationError) as exc:
+            await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+        assert exc.value.field == "ab_variants.1.url"
+        assert "blocked" in str(exc.value).lower()
+        url_repo.insert.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_self_link_variant_rejected(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com",
+            ab_variants=[{"url": "https://spoo.me/other", "weight": 50}],
+        )
+        with pytest.raises(ValidationError) as exc:
+            await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+        assert exc.value.field == "ab_variants.0.url"
+
+    @pytest.mark.asyncio
+    async def test_update_sets_ab_variants(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        existing = make_url_v2_doc()
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = make_url_v2_doc(ab_variants=self.VARIANTS)
+        blocked_url_repo.get_patterns.return_value = []
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(URL_OID, UpdateUrlRequest(ab_variants=self.VARIANTS), USER_OID)
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert update_doc["$set"]["ab_variants"] == self.VARIANTS
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("clear_value", [None, []])
+    async def test_update_null_or_empty_clears_ab_variants(self, clear_value):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        existing = make_url_v2_doc(ab_variants=self.VARIANTS)
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = make_url_v2_doc()
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        req = UpdateUrlRequest.model_validate({"ab_variants": clear_value})
+        await svc.update(URL_OID, req, USER_OID)
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert update_doc["$set"]["ab_variants"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_omitted_ab_variants_untouched(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        existing = make_url_v2_doc(ab_variants=self.VARIANTS)
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = existing
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(URL_OID, UpdateUrlRequest(block_bots=True), USER_OID)
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert "ab_variants" not in update_doc["$set"]
+
+    @pytest.mark.asyncio
+    async def test_update_identical_variants_is_noop_and_skips_validation(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        url_repo.find_by_id.return_value = make_url_v2_doc(ab_variants=self.VARIANTS)
+        blocked_url_repo.get_patterns.return_value = [r"https://example\."]
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(URL_OID, UpdateUrlRequest(ab_variants=self.VARIANTS), USER_OID)
+
+        url_repo.update.assert_not_called()
+        blocked_url_repo.get_patterns.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_blocked_variant_destination_rejected(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        url_repo.find_by_id.return_value = make_url_v2_doc()
+        blocked_url_repo.get_patterns.return_value = [r"https://evil\.com"]
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        req = UpdateUrlRequest(
+            ab_variants=[{"url": "https://evil.com/x", "weight": 10}]
+        )
+        with pytest.raises(ValidationError) as exc:
+            await svc.update(URL_OID, req, USER_OID)
+        assert exc.value.field == "ab_variants.0.url"
+
+    @pytest.mark.asyncio
+    async def test_update_refused_while_the_feature_is_dark(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo,
+            legacy_repo,
+            emoji_repo,
+            blocked_url_repo,
+            url_cache,
+            ab_variants_enabled=False,
+        )
+        url_repo.find_by_id.return_value = make_url_v2_doc()
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        with pytest.raises(ValidationError) as exc:
+            await svc.update(
+                URL_OID, UpdateUrlRequest(ab_variants=self.VARIANTS), USER_OID
+            )
+        assert exc.value.field == "ab_variants"
+
+    def test_v2_doc_to_cache_carries_ab_variants(self):
+        from infrastructure.cache.url_cache import UrlCacheData
+
+        cache_data = UrlCacheData.from_v2_doc(
+            make_url_v2_doc(ab_variants=self.VARIANTS)
+        )
+        assert [v.model_dump() for v in cache_data.ab_variants] == self.VARIANTS
+        assert UrlCacheData.from_v2_doc(make_url_v2_doc()).ab_variants is None
+
+
 # _v2_doc_to_cache — meta_tags mapping
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -4331,6 +4584,72 @@ class TestSecondaryDestinationStamping:
         from shared.url_utils import parse_destination
 
         assert written["dest"]["host"] == parse_destination(existing.long_url)["host"]
+
+    @pytest.mark.asyncio
+    async def test_create_with_ab_variants_stamps_secondary_hosts(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = []
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://clean.example/",
+            geo_rules={"IN": "https://geo.example/in"},
+            ab_variants=[
+                {"url": "https://hidden.example/b", "weight": 30},
+                {"url": "https://clean.example/c", "weight": 30},
+            ],
+        )
+        await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        inserted = url_repo.insert.call_args.args[0]
+        assert inserted["dest"]["secondary_hosts"] == ["geo.example", "hidden.example"]
+
+    @pytest.mark.asyncio
+    async def test_update_ab_variants_restamps_secondary_hosts(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        existing = make_url_v2_doc()
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = existing
+        blocked_url_repo.get_patterns.return_value = []
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        req = UpdateUrlRequest(
+            ab_variants=[{"url": "https://hidden.example/b", "weight": 40}]
+        )
+        await svc.update(URL_OID, req, USER_OID)
+
+        written = url_repo.update.call_args[0][1]["$set"]
+        assert written["dest"]["secondary_hosts"] == ["hidden.example"]
+
+    @pytest.mark.asyncio
+    async def test_clearing_ab_variants_drops_secondary_hosts(self):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        existing = make_url_v2_doc(
+            ab_variants=[{"url": "https://hidden.example/b", "weight": 40}]
+        )
+        url_repo.find_by_id.return_value = existing
+        url_repo.update.return_value = make_url_v2_doc()
+
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        await svc.update(URL_OID, UpdateUrlRequest(ab_variants=None), USER_OID)
+
+        written = url_repo.update.call_args[0][1]["$set"]
+        assert written["ab_variants"] is None
+        assert "secondary_hosts" not in written["dest"]
 
     @pytest.mark.asyncio
     async def test_clearing_geo_rules_drops_secondary_hosts(self):

--- a/tests/unit/shared/test_ab_variants.py
+++ b/tests/unit/shared/test_ab_variants.py
@@ -1,0 +1,33 @@
+"""Weighted pick for A/B split links."""
+
+from __future__ import annotations
+
+import pytest
+
+from schemas.models.url import AbVariant
+from shared.ab_variants import pick_variant
+
+VARIANTS = [
+    AbVariant(url="https://example.com/b", weight=60),
+    AbVariant(url="https://example.com/c", weight=30),
+]
+
+
+@pytest.mark.parametrize(
+    ("roll", "expected"),
+    [(0, 0), (59, 0), (60, 1), (89, 1), (90, None), (99, None)],
+)
+def test_bands_follow_list_order_and_remainder_is_default(roll, expected):
+    assert pick_variant(VARIANTS, roll) == expected
+
+
+def test_every_roll_lands_in_proportion():
+    picks = [pick_variant(VARIANTS, roll) for roll in range(100)]
+    assert picks.count(0) == 60
+    assert picks.count(1) == 30
+    assert picks.count(None) == 10
+
+
+def test_full_hundred_never_falls_to_default():
+    full = [AbVariant(url="https://example.com/b", weight=100)]
+    assert all(pick_variant(full, roll) == 0 for roll in range(100))

--- a/tests/unit/shared/test_aggregation_strategies.py
+++ b/tests/unit/shared/test_aggregation_strategies.py
@@ -58,6 +58,7 @@ def test_factory_get_available_strategies():
         "utm_source",
         "utm_medium",
         "utm_campaign",
+        "variant",
     }
 
 
@@ -151,6 +152,7 @@ def test_referrer_pipeline_uses_direct_as_null_fallback():
         ("utm_source", "(none)"),
         ("utm_medium", "(none)"),
         ("utm_campaign", "(none)"),
+        ("variant", "(default)"),
     ],
 )
 def test_pipeline_uses_unknown_as_null_fallback(strategy_name, expected_null_fallback):
@@ -368,3 +370,14 @@ def test_time_format_results_dynamic_adds_bucket_strategy():
 
 def test_time_format_results_empty():
     assert TimeAggregationStrategy().format_results([]) == []
+
+
+def test_variant_indices_format_as_strings():
+    """Stored ints become wire strings so every dimension value has one type."""
+    rows = _strategy("variant").format_results(
+        [
+            {"_id": 0, "total_clicks": 6, "unique_clicks": 5},
+            {"_id": "(default)", "total_clicks": 4, "unique_clicks": 4},
+        ]
+    )
+    assert [r["variant"] for r in rows] == ["0", "(default)"]

--- a/tests/unit/test_ab_testing_launch_guard.py
+++ b/tests/unit/test_ab_testing_launch_guard.py
@@ -2,16 +2,18 @@
 
 Variants add destinations exactly like geo rules do. Safety enforcement
 matches ``dest.host`` or ``dest.secondary_hosts``; a variant host that is
-never stamped there matches nothing. The flag does not exist yet; this
-test names the work the moment someone adds it and flips it on.
+never stamped there matches nothing. AB_VARIANTS_ENABLED keeps the feature
+dark; this test fails the moment it is flipped without the stamping work.
 """
 
 from __future__ import annotations
 
 import inspect
+import typing
 
 from config import AppSettings
 from schemas.models.url import UrlDestination
+from shared.url_utils import link_destination_urls_for
 
 _FLAGS = ("ab_testing_enabled", "ab_variants_enabled")
 
@@ -23,11 +25,13 @@ Required before shipping them:
      every write point (create, update, backfill) so secondary_hosts
      carries them
   2. include variant URLs in link_destination_urls callers (report intake,
-     hot screening) so each variant gets its own safety event
+     hot screening, the L1 create-time burst counter) via
+     shared.url_utils.link_destination_urls_for, the one place that reads
+     a link's fields, so all three stay in sync as fields are added
   3. stamp existing links: scripts/backfill_url_dest.py
   4. add the variant URLs to _ALL_URLS in repositories/url_repository.py so
      the sweeps sample a variant host's own URL (today: long_url, geo rules,
-     and every field in shared.url_utils.SINGLE_DESTINATION_FIELDS)
+     ab_variants, and every field in shared.url_utils.SINGLE_DESTINATION_FIELDS)
 """
 
 
@@ -41,3 +45,13 @@ def test_ab_variants_stay_dark_until_enforcement_sees_them():
         "https://main.example/", variants=["https://variant.example/b"]
     )
     assert stamped is not None and stamped.secondary_hosts == ["variant.example"], _WORK
+    assert stamped.secondary_registrable == ["variant.example"], _WORK
+
+    class _FakeLink:
+        long_url = "https://main.example/"
+        geo_rules = None
+        ab_variants: typing.ClassVar = [
+            {"url": "https://variant.example/b", "weight": 40}
+        ]
+
+    assert "https://variant.example/b" in link_destination_urls_for(_FakeLink()), _WORK


### PR DESCRIPTION
## Why

The dashboard editor already sends `ab_variants` and the API silently dropped it. This is the backend for link variants, end to end, kept dark behind `AB_VARIANTS_ENABLED=false` until the flag is registered.

## What

Contract, fixed by the frontend: `ab_variants: [{url, weight}] | null`, integer weights summing to at most 100, `long_url` keeps the remainder.

- Schema and DTOs: `AbVariant` on `UrlV2Doc` and the redirect cache, echoed on every link response, hard cap 50 in the DTO and product cap `ab_variants_max` (10) in settings.
- Service: same shape as geo rules. Every variant URL runs the full destination policy on create and patch; identical patches are no-ops; `null` or `[]` clears.
- Gates: `ab_testing` feature flag on create and patch, anonymous creates rejected.
- Redirect: one roll from 0 to 99 per request walks the weight bands in list order; the remainder goes to `long_url`; a matched geo rule wins over the split. Responses carry `Cache-Control: no-store`.
- Click attribution: `variant_index` rides `ClickEvent` through both sinks onto `ClickDoc`.
- Stats: `variant` as a filter and group-by on the account and per-link endpoints. Values are the index as a string and `(default)` for clicks that went to `long_url`; filters coerce indices back to the stored int. `openapi.json` regenerated.
- Edge cache: variant links are never promoted, since the Worker cannot make the pick.
- Safety: variant hosts flow into `dest.secondary_hosts` at create, update and backfill, and into report intake and hot screening, so a host block reaches a link that hides the host in a variant. The public preview API and the legacy preview page list every variant with its share.

## Proof

Live against the compose stack with the flag on:

- A 60/40 link over 200 redirects split 118/82; `ClickDoc` counts and `group_by=variant` agree exactly.
- After a 30/30 patch, 200 more requests produced a `(default)` bucket of 76; filtering by `(default)` or a variant index works.
- The real cached entry is refused by edge promotion with reason `ab_variants`.
- Preview API and legacy preview list both variants; a foreign variant host lands in `dest.secondary_hosts`.
- Anonymous create 401, weights over 100 422, disabled flag 403 once the flag cache expires.
- `uv run pytest`: 3818 passed.

Stacked on `feat/safety-secondary-destinations`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weighted A/B testing destinations for shortened links.
  * Users can configure variants when creating or updating links, with validation and feature controls.
  * Redirects now distribute visitors among configured destinations and expose variant details in previews.
  * Statistics and exports support filtering and grouping by variant.
  * Webhook link snapshots include configured variants.

* **Bug Fixes**
  * Geo-targeting continues to take precedence over A/B variants.
  * Variant destinations are included in safety checks and destination discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->