### PR TITLE
perf(webhooks): O(1) pending cap via a counter on the endpoint doc

### DIFF
--- a/repositories/webhook_delivery_repository.py
+++ b/repositories/webhook_delivery_repository.py
@@ -37,8 +37,14 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
         return await self._find_one({"_id": delivery_id, "user_id": user_id})
 
     async def count_pending(self, endpoint_id: ObjectId) -> int:
+        """Rows that hold a pending slot. Test sends are never reserved, so
+        one that died mid-attempt must not inflate the recount."""
         return await self._count(
-            {"endpoint_id": endpoint_id, "status": DeliveryStatus.PENDING.value}
+            {
+                "endpoint_id": endpoint_id,
+                "status": DeliveryStatus.PENDING.value,
+                "is_test": {"$ne": True},
+            }
         )
 
     async def list_by_endpoint(
@@ -114,9 +120,12 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
 
     async def record_attempt_and_finish(
         self, delivery_id: ObjectId, attempt: DeliveryAttempt, status: DeliveryStatus
-    ) -> None:
-        await self._update(
-            {"_id": delivery_id},
+    ) -> bool:
+        """Terminal write. Returns True when this call moved the row out of
+        PENDING (False for a manual retry of an already-finished row), so
+        the caller releases the endpoint's pending slot exactly once."""
+        return await self._finish(
+            delivery_id,
             {
                 "$push": {"attempts": attempt.model_dump()},
                 "$inc": {"attempt_count": 1},
@@ -143,11 +152,12 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
             },
         )
 
-    async def mark_failed(self, delivery_id: ObjectId, reason: str) -> None:
+    async def mark_failed(self, delivery_id: ObjectId, reason: str) -> bool:
         """Terminal failure without an HTTP attempt (endpoint inactive,
-        event row TTL-expired)."""
-        await self._update(
-            {"_id": delivery_id},
+        event row TTL-expired). Same return contract as
+        ``record_attempt_and_finish``."""
+        return await self._finish(
+            delivery_id,
             {
                 "$inc": {"attempt_count": 1},
                 "$set": {
@@ -162,4 +172,15 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
                     ).model_dump()
                 },
             },
+        )
+
+    async def _finish(self, delivery_id: ObjectId, ops: dict) -> bool:
+        before = await self._col.find_one_and_update(
+            {"_id": delivery_id},
+            ops,
+            projection={"status": 1},
+            return_document=ReturnDocument.BEFORE,
+        )
+        return (
+            before is not None and before.get("status") == DeliveryStatus.PENDING.value
         )

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -100,11 +100,32 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
         )
         return int(doc.get("consecutive_failures", 0)) if doc else 0
 
-    async def increment_deliveries(self, endpoint_id: ObjectId, by: int = 1) -> None:
-        """Counted at ENQUEUE, not at terminal state — "0 of 2" while two
-        deliveries are mid-ladder beats a "0 of 0" that contradicts the
-        visible delivery log. Success keeps its own counter."""
-        await self._update({"_id": endpoint_id}, {"$inc": {"total_deliveries": by}})
+    async def reserve_pending(self, endpoint_id: ObjectId, cap: int) -> bool:
+        """Take one pending slot under ``cap``; False when the endpoint is
+        at the cap (or the counter field is missing, which the caller
+        repairs). ``total_deliveries`` is counted at ENQUEUE, not at
+        terminal state — "0 of 2" while two deliveries are mid-ladder beats
+        a "0 of 0" that contradicts the visible delivery log."""
+        return await self._update(
+            {"_id": endpoint_id, "pending_count": {"$lt": cap}},
+            {"$inc": {"pending_count": 1, "total_deliveries": 1}},
+        )
+
+    async def release_pending(self, endpoint_id: ObjectId) -> None:
+        await self._update(
+            {"_id": endpoint_id, "pending_count": {"$gt": 0}},
+            {"$inc": {"pending_count": -1}},
+        )
+
+    async def set_pending_count(self, endpoint_id: ObjectId, count: int) -> int:
+        """Overwrite the counter with a real count; returns the value it
+        replaced (0 when the field was missing)."""
+        doc = await self._col.find_one_and_update(
+            {"_id": endpoint_id},
+            {"$set": {"pending_count": count}},
+            projection={"pending_count": 1},
+        )
+        return int(doc.get("pending_count", 0)) if doc else 0
 
     async def increment_dropped(self, endpoint_id: ObjectId) -> None:
         await self._update({"_id": endpoint_id}, {"$inc": {"dropped_count": 1}})

--- a/schemas/models/webhook.py
+++ b/schemas/models/webhook.py
@@ -63,6 +63,7 @@ class WebhookEndpointDoc(MongoBaseModel):
     # consecutive_failures counts EXHAUSTED deliveries, not attempts.
     consecutive_failures: int = 0
     dropped_count: int = 0  # pending-cap drops since last successful delivery
+    pending_count: int = 0  # reserved at dispatch, released on every terminal outcome
     total_deliveries: int = 0
     total_successes: int = 0
     last_delivery_at: datetime | None = None

--- a/services/webhooks/dispatcher.py
+++ b/services/webhooks/dispatcher.py
@@ -10,6 +10,7 @@ multi-hour retry ladder cannot hold a stream entry pending.
 
 from __future__ import annotations
 
+import time
 from datetime import datetime, timezone
 
 from bson import ObjectId
@@ -63,12 +64,15 @@ class WebhookDispatcher:
         endpoint_repo: WebhookEndpointRepository,
         *,
         max_pending_per_endpoint: int = 1000,
+        recount_interval_seconds: float = 30.0,
     ) -> None:
         self._matcher = matcher
         self._event_repo = event_repo
         self._delivery_repo = delivery_repo
         self._endpoint_repo = endpoint_repo
         self._max_pending = max_pending_per_endpoint
+        self._recount_interval = recount_interval_seconds
+        self._recount_not_before: dict[ObjectId, float] = {}
 
     async def dispatch(self, event: DomainEvent) -> None:
         endpoints = await self._matcher.match(event)
@@ -80,14 +84,8 @@ class WebhookDispatcher:
         for endpoint in endpoints:
             # The pending cap protects the queue itself. A subscriber
             # who can't drink max_pending deliveries has already lost the
-            # facts — counting beats pretending. Count-then-insert is
-            # deliberately non-atomic: concurrent dispatchers can overshoot
-            # by a batch, which is fine for a protective backstop; an exact
-            # cap would cost a reservation counter on every dispatch.
-            if (
-                await self._delivery_repo.count_pending(endpoint.id)
-                >= self._max_pending
-            ):
+            # facts — counting beats pretending.
+            if not await self._reserve_slot(endpoint):
                 await self._endpoint_repo.increment_dropped(endpoint.id)
                 log.warning(
                     "webhook_delivery_dropped_over_cap",
@@ -98,11 +96,38 @@ class WebhookDispatcher:
             rows.append(make_delivery_row(event_oid, event, endpoint))
 
         await self._delivery_repo.insert_many_rows(rows)
-        for row in rows:
-            await self._endpoint_repo.increment_deliveries(row["endpoint_id"])
         log.info(
             "webhook_dispatched",
             event_type=event.type,
             event_id=event.event_id,
             endpoints=len(rows),
         )
+
+    async def _reserve_slot(self, endpoint: WebhookEndpointDoc) -> bool:
+        """One conditional increment per dispatch; no count in the hot path.
+
+        The counter drifts upward (row insert failed after reserving, TTL
+        deleted pending rows), so an over-cap verdict is re-verified with
+        one real count before dropping, throttled per endpoint so an
+        endpoint truly at the cap does not pay a count per event. A recount
+        while sibling dispatches hold uninserted reservations undercounts
+        by that many; the cap is a backstop, so that overshoot is accepted.
+        """
+        if await self._endpoint_repo.reserve_pending(endpoint.id, self._max_pending):
+            return True
+        now = time.monotonic()
+        if now < self._recount_not_before.get(endpoint.id, 0.0):
+            return False
+        self._recount_not_before[endpoint.id] = now + self._recount_interval
+        counted = await self._delivery_repo.count_pending(endpoint.id)
+        previous = await self._endpoint_repo.set_pending_count(endpoint.id, counted)
+        if previous != counted:
+            log.warning(
+                "webhook_pending_count_repaired",
+                endpoint_id=str(endpoint.id),
+                previous=previous,
+                counted=counted,
+            )
+        if counted >= self._max_pending:
+            return False
+        return await self._endpoint_repo.reserve_pending(endpoint.id, self._max_pending)

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -117,7 +117,7 @@ class DeliveryExecutor:
 
         endpoint = await self._endpoints.find_by_id(row.endpoint_id)
         if endpoint is None or endpoint.status == WebhookStatus.DISABLED:
-            await self._deliveries.mark_failed(row.id, "endpoint_inactive")
+            await self._fail(row, "endpoint_inactive")
             return
         if endpoint.status == WebhookStatus.PAUSED and not single_shot:
             # Paused is a temporary state the owner controls: hold the
@@ -146,7 +146,7 @@ class DeliveryExecutor:
                 webhook_id=row.webhook_id,
                 error_type=type(exc).__name__,
             )
-            await self._deliveries.mark_failed(row.id, "secret_unreadable")
+            await self._fail(row, "secret_unreadable")
             if not single_shot:
                 await self._disable(endpoint, EndpointDisabledReason.SECRET_UNREADABLE)
             return
@@ -169,9 +169,7 @@ class DeliveryExecutor:
 
         ok = result.status_code is not None and 200 <= result.status_code < 300
         if ok:
-            await self._deliveries.record_attempt_and_finish(
-                row.id, attempt, DeliveryStatus.SUCCESS
-            )
+            await self._finish(row, attempt, DeliveryStatus.SUCCESS)
             if not single_shot:
                 await self._endpoints.record_success(endpoint.id)
             log.info(
@@ -222,24 +220,18 @@ class DeliveryExecutor:
         if single_shot:
             # One recorded attempt, terminal, health untouched: the caller
             # (test send / manual retry) reads the outcome synchronously.
-            await self._deliveries.record_attempt_and_finish(
-                row.id, attempt, DeliveryStatus.FAILED
-            )
+            await self._finish(row, attempt, DeliveryStatus.FAILED)
             return
 
         if result.status_code == 410:
-            await self._deliveries.record_attempt_and_finish(
-                row.id, attempt, DeliveryStatus.FAILED
-            )
+            await self._finish(row, attempt, DeliveryStatus.FAILED)
             await self._disable(endpoint, EndpointDisabledReason.GONE)
             return
 
         # attempt_count on the claimed row predates this attempt.
         attempts_done = row.attempt_count + 1
         if attempts_done >= len(RETRY_SCHEDULE_SECONDS):
-            await self._deliveries.record_attempt_and_finish(
-                row.id, attempt, DeliveryStatus.FAILED
-            )
+            await self._finish(row, attempt, DeliveryStatus.FAILED)
             reason = result.error or f"status {result.status_code}"
             streak = await self._endpoints.record_exhausted(endpoint.id, reason)
             if streak >= self._max_consecutive:
@@ -254,6 +246,23 @@ class DeliveryExecutor:
             attempt,
             datetime.now(timezone.utc) + timedelta(seconds=delay),
         )
+
+    # ── Terminal writes ──────────────────────────────────────────────────
+
+    async def _finish(
+        self, row: WebhookDeliveryDoc, attempt: DeliveryAttempt, status: DeliveryStatus
+    ) -> None:
+        if await self._deliveries.record_attempt_and_finish(row.id, attempt, status):
+            await self._release_slot(row)
+
+    async def _fail(self, row: WebhookDeliveryDoc, reason: str) -> None:
+        if await self._deliveries.mark_failed(row.id, reason):
+            await self._release_slot(row)
+
+    async def _release_slot(self, row: WebhookDeliveryDoc) -> None:
+        # Test sends are inserted PENDING without a dispatch reservation.
+        if not row.is_test:
+            await self._endpoints.release_pending(row.endpoint_id)
 
     # ── Internals ────────────────────────────────────────────────────────
 
@@ -274,13 +283,11 @@ class DeliveryExecutor:
         event = await self._events.find_by_oid(row.event_oid)
         if event is None:
             # TTL race at the 30-day edge — terminal, never a crash.
-            await self._deliveries.mark_failed(row.id, "event_expired")
+            await self._fail(row, "event_expired")
             return None
         renderer = self._renderers.get(endpoint.flavor.value)
         if renderer is None:
-            await self._deliveries.mark_failed(
-                row.id, f"unknown_flavor:{endpoint.flavor}"
-            )
+            await self._fail(row, f"unknown_flavor:{endpoint.flavor}")
             return None
         payload = dict(event.payload)
         if row.dropped_since_last:
@@ -295,7 +302,7 @@ class DeliveryExecutor:
             payload,
         )
         if len(body.encode()) > self._max_bytes:
-            await self._deliveries.mark_failed(row.id, "payload_over_cap")
+            await self._fail(row, "payload_over_cap")
             return None
         await self._deliveries.set_rendered_body(row.id, body)
         return body

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -126,11 +126,30 @@ class _FakeEndpointRepo:
         )
         return streak
 
-    async def increment_deliveries(self, endpoint_id, by=1):
+    async def reserve_pending(self, endpoint_id, cap):
         doc = self.docs[endpoint_id]
+        if doc.pending_count >= cap:
+            return False
         await self.update_fields(
-            endpoint_id, {"total_deliveries": doc.total_deliveries + by}
+            endpoint_id,
+            {
+                "pending_count": doc.pending_count + 1,
+                "total_deliveries": doc.total_deliveries + 1,
+            },
         )
+        return True
+
+    async def release_pending(self, endpoint_id):
+        doc = self.docs[endpoint_id]
+        if doc.pending_count > 0:
+            await self.update_fields(
+                endpoint_id, {"pending_count": doc.pending_count - 1}
+            )
+
+    async def set_pending_count(self, endpoint_id, count):
+        previous = self.docs[endpoint_id].pending_count
+        await self.update_fields(endpoint_id, {"pending_count": count})
+        return previous
 
     async def increment_dropped(self, endpoint_id):
         doc = self.docs[endpoint_id]
@@ -170,7 +189,9 @@ class _FakeDeliveryRepo:
         return sum(
             1
             for d in self.docs.values()
-            if d.endpoint_id == endpoint_id and d.status == DeliveryStatus.PENDING
+            if d.endpoint_id == endpoint_id
+            and d.status == DeliveryStatus.PENDING
+            and not d.is_test
         )
 
     async def list_by_endpoint(self, endpoint_id, *, page, page_size, status=None):
@@ -207,6 +228,7 @@ class _FakeDeliveryRepo:
 
     async def record_attempt_and_finish(self, delivery_id, attempt, status):
         doc = self.docs[delivery_id]
+        was_pending = doc.status == DeliveryStatus.PENDING
         self._update(
             delivery_id,
             attempts=[*[a.model_dump() for a in doc.attempts], attempt.model_dump()],
@@ -215,9 +237,12 @@ class _FakeDeliveryRepo:
             completed_at=datetime.now(timezone.utc),
             next_attempt_at=None,
         )
+        return was_pending
 
     async def mark_failed(self, delivery_id, reason):
+        was_pending = self.docs[delivery_id].status == DeliveryStatus.PENDING
         self._update(delivery_id, status=DeliveryStatus.FAILED.value)
+        return was_pending
 
 
 class _FakeEventRepo:

--- a/tests/unit/repositories/test_webhook_delivery_repository.py
+++ b/tests/unit/repositories/test_webhook_delivery_repository.py
@@ -1,0 +1,87 @@
+"""Terminal writes report whether they moved the row out of PENDING, so the
+executor releases the endpoint's pending slot exactly once per row."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from bson import ObjectId
+
+from repositories.webhook_delivery_repository import WebhookDeliveryRepository
+from schemas.enums.webhook import DeliveryStatus
+from schemas.models.webhook import DeliveryAttempt
+
+from .conftest import make_collection
+
+_ROW = ObjectId("dddddddddddddddddddddddd")
+
+
+def _attempt() -> DeliveryAttempt:
+    return DeliveryAttempt(attempted_at=datetime.now(timezone.utc), status_code=204)
+
+
+class TestTerminalWrites:
+    @pytest.mark.asyncio
+    async def test_finish_from_pending_reports_transition(self):
+        col = make_collection()
+        col.find_one_and_update.return_value = {"_id": _ROW, "status": "pending"}
+        repo = WebhookDeliveryRepository(col)
+        assert (
+            await repo.record_attempt_and_finish(
+                _ROW, _attempt(), DeliveryStatus.SUCCESS
+            )
+            is True
+        )
+        query, ops = col.find_one_and_update.await_args[0]
+        assert query == {"_id": _ROW}
+        assert ops["$set"]["status"] == DeliveryStatus.SUCCESS.value
+        assert ops["$inc"] == {"attempt_count": 1}
+        assert ops["$push"]["attempts"]["status_code"] == 204
+
+    @pytest.mark.asyncio
+    async def test_finish_of_already_finished_row_reports_no_transition(self):
+        """A manual retry re-attempts a FAILED row: the attempt is recorded
+        but no pending slot was ever held for it."""
+        col = make_collection()
+        col.find_one_and_update.return_value = {"_id": _ROW, "status": "failed"}
+        repo = WebhookDeliveryRepository(col)
+        assert (
+            await repo.record_attempt_and_finish(
+                _ROW, _attempt(), DeliveryStatus.SUCCESS
+            )
+            is False
+        )
+        col.find_one_and_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_finish_of_missing_row_is_false(self):
+        col = make_collection()
+        col.find_one_and_update.return_value = None
+        assert (
+            await WebhookDeliveryRepository(col).mark_failed(_ROW, "event_expired")
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_records_reason_and_transition(self):
+        col = make_collection()
+        col.find_one_and_update.return_value = {"_id": _ROW, "status": "pending"}
+        assert (
+            await WebhookDeliveryRepository(col).mark_failed(_ROW, "endpoint_inactive")
+            is True
+        )
+        _, ops = col.find_one_and_update.await_args[0]
+        assert ops["$set"]["status"] == DeliveryStatus.FAILED.value
+        assert ops["$push"]["attempts"]["error"] == "endpoint_inactive"
+
+
+class TestCountPending:
+    @pytest.mark.asyncio
+    async def test_counts_only_rows_that_hold_a_slot(self):
+        col = make_collection()
+        col.count_documents.return_value = 3
+        assert await WebhookDeliveryRepository(col).count_pending(_ROW) == 3
+        query = col.count_documents.await_args[0][0]
+        assert query["status"] == DeliveryStatus.PENDING.value
+        assert query["is_test"] == {"$ne": True}

--- a/tests/unit/repositories/test_webhook_endpoint_repository.py
+++ b/tests/unit/repositories/test_webhook_endpoint_repository.py
@@ -1,0 +1,63 @@
+"""Pending-slot counter on the endpoint document: the reserve is a single
+conditional update (the cap is enforced by Mongo, not by a read), the
+release floors at zero, and the repair overwrite reports what it replaced."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from bson import ObjectId
+
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+
+from .conftest import make_collection
+
+_EP = ObjectId("eeeeeeeeeeeeeeeeeeeeeeee")
+
+
+def _repo():
+    col = make_collection()
+    return WebhookEndpointRepository(col), col
+
+
+class TestPendingCounter:
+    @pytest.mark.asyncio
+    async def test_reserve_is_one_conditional_increment(self):
+        repo, col = _repo()
+        col.update_one.return_value = MagicMock(matched_count=1)
+        assert await repo.reserve_pending(_EP, 1000) is True
+        query, ops = col.update_one.await_args[0]
+        assert query == {"_id": _EP, "pending_count": {"$lt": 1000}}
+        assert ops == {"$inc": {"pending_count": 1, "total_deliveries": 1}}
+        col.count_documents.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reserve_at_cap_is_refused(self):
+        repo, col = _repo()
+        col.update_one.return_value = MagicMock(matched_count=0)
+        assert await repo.reserve_pending(_EP, 1000) is False
+
+    @pytest.mark.asyncio
+    async def test_release_never_goes_negative(self):
+        repo, col = _repo()
+        col.update_one.return_value = MagicMock(matched_count=0)
+        await repo.release_pending(_EP)
+        query, ops = col.update_one.await_args[0]
+        assert query == {"_id": _EP, "pending_count": {"$gt": 0}}
+        assert ops == {"$inc": {"pending_count": -1}}
+
+    @pytest.mark.asyncio
+    async def test_set_pending_count_returns_previous(self):
+        repo, col = _repo()
+        col.find_one_and_update.return_value = {"_id": _EP, "pending_count": 4200}
+        assert await repo.set_pending_count(_EP, 17) == 4200
+        query, ops = col.find_one_and_update.await_args[0]
+        assert query == {"_id": _EP}
+        assert ops == {"$set": {"pending_count": 17}}
+
+    @pytest.mark.asyncio
+    async def test_set_pending_count_missing_field_reads_as_zero(self):
+        repo, col = _repo()
+        col.find_one_and_update.return_value = {"_id": _EP}
+        assert await repo.set_pending_count(_EP, 3) == 0

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -290,6 +290,68 @@ class TestFailurePaths:
         assert deliveries.mark_failed.await_args[0][1] == "event_expired"
         post.assert_not_awaited()
 
+
+class TestPendingSlotRelease:
+    """Every terminal outcome releases the endpoint's pending slot exactly
+    once; non-terminal outcomes and rows that never reserved one do not."""
+
+    @pytest.mark.asyncio
+    async def test_success_releases(self):
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        deliveries.record_attempt_and_finish.return_value = True
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(_delivery(endpoint_id=endpoint.id))
+        endpoints.release_pending.assert_awaited_once_with(endpoint.id)
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_releases(self):
+        endpoint = _endpoint()
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        deliveries.record_attempt_and_finish.return_value = True
+        last = len(RETRY_SCHEDULE_SECONDS) - 1
+        with patch("services.webhooks.executor.post_public", _post(500)):
+            await executor.attempt(
+                _delivery(endpoint_id=endpoint.id, attempt_count=last)
+            )
+        endpoints.release_pending.assert_awaited_once_with(endpoint.id)
+
+    @pytest.mark.asyncio
+    async def test_terminal_without_attempt_releases(self):
+        endpoint = _endpoint(status=WebhookStatus.DISABLED)
+        executor, deliveries, endpoints, _ = _make(endpoint)
+        deliveries.mark_failed.return_value = True
+        await executor.attempt(_delivery(endpoint_id=endpoint.id))
+        endpoints.release_pending.assert_awaited_once_with(endpoint.id)
+
+    @pytest.mark.asyncio
+    async def test_reschedule_and_defer_keep_the_slot(self):
+        executor, _, endpoints, _ = _make(_endpoint())
+        with patch("services.webhooks.executor.post_public", _post(500)):
+            await executor.attempt(_delivery())
+        with patch("services.webhooks.executor.post_public", _post(429)):
+            await executor.attempt(_delivery())
+        endpoints.release_pending.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_test_send_never_releases(self):
+        executor, deliveries, endpoints, _ = _make(_endpoint())
+        deliveries.record_attempt_and_finish.return_value = True
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(_delivery(is_test=True))
+        endpoints.release_pending.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_manual_retry_of_finished_row_never_releases(self):
+        executor, deliveries, endpoints, _ = _make(_endpoint())
+        deliveries.record_attempt_and_finish.return_value = False
+        row = _delivery(status=DeliveryStatus.FAILED, rendered_body="{}")
+        with patch("services.webhooks.executor.post_public", _post(204)):
+            await executor.attempt(row)
+        endpoints.release_pending.assert_not_awaited()
+
+
+class TestRotationGrace:
     @pytest.mark.asyncio
     async def test_success_after_grace_secret_sends_dual_signatures(self):
         old_secret = "whsec_b2xkLXNlY3JldC1vbGQtc2VjcmV0"
@@ -380,3 +442,42 @@ class TestDeliveryUrl:
         with patch("services.webhooks.executor.post_public", post):
             await executor.attempt(_delivery())
         assert post.await_args[0][0] == endpoint.url
+
+
+class TestRenderFailures:
+    @pytest.mark.asyncio
+    async def test_unknown_flavor_is_terminal(self):
+        endpoint = _endpoint()
+        deliveries, endpoints, events = AsyncMock(), AsyncMock(), AsyncMock()
+        endpoints.find_by_id.return_value = endpoint
+        events.find_by_oid.return_value = _event()
+        deliveries.mark_failed.return_value = True
+        executor = DeliveryExecutor(
+            deliveries, endpoints, events, {}, master_secret=_MASTER
+        )
+        with patch("services.webhooks.executor.post_public", _post(204)) as post:
+            await executor.attempt(_delivery(endpoint_id=endpoint.id))
+        assert deliveries.mark_failed.await_args[0][1].startswith("unknown_flavor:")
+        endpoints.release_pending.assert_awaited_once_with(endpoint.id)
+        post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_payload_over_cap_is_terminal(self):
+        endpoint = _endpoint()
+        deliveries, endpoints, events = AsyncMock(), AsyncMock(), AsyncMock()
+        endpoints.find_by_id.return_value = endpoint
+        events.find_by_oid.return_value = _event()
+        deliveries.mark_failed.return_value = True
+        executor = DeliveryExecutor(
+            deliveries,
+            endpoints,
+            events,
+            default_renderers(),
+            master_secret=_MASTER,
+            max_payload_bytes=16,
+        )
+        with patch("services.webhooks.executor.post_public", _post(204)) as post:
+            await executor.attempt(_delivery(endpoint_id=endpoint.id))
+        assert deliveries.mark_failed.await_args[0][1] == "payload_over_cap"
+        endpoints.release_pending.assert_awaited_once_with(endpoint.id)
+        post.assert_not_awaited()

--- a/tests/unit/services/webhooks/test_matcher_dispatcher.py
+++ b/tests/unit/services/webhooks/test_matcher_dispatcher.py
@@ -3,6 +3,7 @@ pending cap. All fakes are in-memory; no Mongo, no Redis."""
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -120,15 +121,45 @@ class TestMatcher:
         repo.find_active_for_owner.assert_not_awaited()
 
 
+class _CountingEndpointRepo:
+    """In-memory stand-in for the atomic reserve/release counter."""
+
+    def __init__(self, pending: int = 0) -> None:
+        self.pending = pending
+        self.dropped = 0
+        self.reserve_calls = 0
+
+    async def reserve_pending(self, endpoint_id, cap):
+        self.reserve_calls += 1
+        if self.pending >= cap:
+            return False
+        self.pending += 1
+        return True
+
+    async def set_pending_count(self, endpoint_id, count):
+        previous, self.pending = self.pending, count
+        return previous
+
+    async def increment_dropped(self, endpoint_id):
+        self.dropped += 1
+
+
 class TestDispatcher:
-    def _make(self, endpoints, pending: int = 0):
+    def _make(self, endpoints, pending: int = 0, real_pending: int | None = None):
         matcher = AsyncMock()
         matcher.match.return_value = endpoints
         event_repo = AsyncMock()
         event_repo.insert_event.return_value = ObjectId()
         delivery_repo = AsyncMock()
-        delivery_repo.count_pending.return_value = pending
-        endpoint_repo = AsyncMock()
+
+        def real_count(_endpoint_id):
+            if real_pending is not None:
+                return real_pending
+            inserted = delivery_repo.insert_many_rows.await_args_list
+            return pending + sum(len(call.args[0]) for call in inserted)
+
+        delivery_repo.count_pending.side_effect = real_count
+        endpoint_repo = _CountingEndpointRepo(pending)
         dispatcher = WebhookDispatcher(
             matcher,
             event_repo,
@@ -170,10 +201,53 @@ class TestDispatcher:
         assert rows[0]["dropped_since_last"] == 7
 
     @pytest.mark.asyncio
+    async def test_under_cap_reserves_without_counting(self):
+        dispatcher, _, delivery_repo, endpoint_repo = self._make([_endpoint()])
+        await dispatcher.dispatch(_click_event())
+        assert endpoint_repo.pending == 1
+        delivery_repo.count_pending.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_pending_cap_drops_and_counts(self):
+        """At the cap the verdict is re-verified against one real count,
+        then the delivery is dropped and counted."""
         ep = _endpoint()
         dispatcher, _, delivery_repo, endpoint_repo = self._make([ep], pending=10)
         await dispatcher.dispatch(_click_event())
-        endpoint_repo.increment_dropped.assert_awaited_once_with(ep.id)
+        delivery_repo.count_pending.assert_awaited_once_with(ep.id)
+        assert endpoint_repo.dropped == 1
+        assert endpoint_repo.pending == 10
         rows = delivery_repo.insert_many_rows.await_args[0][0]
         assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_drifted_counter_is_repaired_not_dropped(self):
+        """Counter says 10, Mongo says 3: repair to 3, reserve, deliver."""
+        dispatcher, _, delivery_repo, endpoint_repo = self._make(
+            [_endpoint()], pending=10, real_pending=3
+        )
+        await dispatcher.dispatch(_click_event())
+        assert endpoint_repo.dropped == 0
+        assert endpoint_repo.pending == 4
+        assert len(delivery_repo.insert_many_rows.await_args[0][0]) == 1
+
+    @pytest.mark.asyncio
+    async def test_recount_is_throttled_per_endpoint(self):
+        """A confirmed over-cap endpoint pays one real count per interval,
+        not one per event."""
+        dispatcher, _, delivery_repo, endpoint_repo = self._make([_endpoint()], 10)
+        for _ in range(5):
+            await dispatcher.dispatch(_click_event())
+        delivery_repo.count_pending.assert_awaited_once()
+        assert endpoint_repo.dropped == 5
+
+    @pytest.mark.asyncio
+    async def test_concurrent_enqueue_never_exceeds_cap(self):
+        dispatcher, _, delivery_repo, endpoint_repo = self._make([_endpoint()], 7)
+        await asyncio.gather(*(dispatcher.dispatch(_click_event()) for _ in range(20)))
+        assert endpoint_repo.pending == 10
+        inserted = sum(
+            len(call.args[0]) for call in delivery_repo.insert_many_rows.await_args_list
+        )
+        assert inserted == 3
+        assert endpoint_repo.dropped == 17


### PR DESCRIPTION
## What

- Each webhook endpoint document now carries `pending_count`. Dispatch takes a slot with one conditional increment (the same write also bumps `total_deliveries`), and the executor releases the slot on every terminal outcome: success, ladder exhausted, 410, endpoint inactive, secret unreadable, event expired, payload over cap.
- An over-cap verdict is re-verified against one real count before anything is dropped. The counter is overwritten with the real value, and the recount is throttled to once per 30 seconds per endpoint so an endpoint that is genuinely at the cap does not pay a count per event.
- Test sends never touch the counter. Manual retries of an already finished row never release a slot. Reschedules and 429 deferrals keep the slot.
- Endpoint documents created before this change have no counter field; the first over-cap verdict on them recounts and writes the field.

## Why

The dispatcher enforced the per-endpoint pending cap with a `count_documents` per matched endpoint per event. That count grows with the endpoint's backlog and runs on the serial stream consumer, so one backed-up endpoint slowed dispatch for every owner queued behind it. The count-then-insert check was also not atomic, so concurrent dispatchers could overshoot the cap.

## How proven

Rig against local Mongo with the real repositories, matcher, dispatcher and executor: one dead endpoint pre-loaded with a backlog for owner A, one healthy endpoint for owner B, events for A and B dispatched serially in alternation, runs of `main` and this branch interleaved on the same host.

- 20k backlog with the cap raised to 50k, 400 events: on `main` the dead endpoint's events dispatch at 9.4 to 11.5ms p50 and the count alone costs 5 to 6ms. On this branch they dispatch at 5.6 to 5.9ms p50, the same as the healthy endpoint.
- 1000 backlog at the default cap on a quiet host, 2000 events: 3.9s total on this branch against 4.7s on `main`.
- 1000 healthy deliveries drained through the real executor to a local receiver: receiver saw 1000 hits, real pending 0, counter 0.
- Counter forced to 5000 with 900 real pending rows: the next dispatch repaired it to 900 and inserted its row (901 and 901).
- 50 concurrent dispatches with the endpoint at cap minus 5: exactly 5 rows inserted, 45 dropped, counter equal to the real count, zero overshoot.
- Endpoint document with the counter field unset and 1000 real pending rows: first event recounted, wrote 1000, dropped; 100 events later still 1000 real, counter 1000, 100 dropped.
- `uv run pytest`: 3724 passed, 5 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook endpoints now enforce pending-delivery limits more reliably, preventing excess queued deliveries.
  - Pending delivery counts are tracked and corrected automatically when needed.
  - Test deliveries no longer consume endpoint pending-capacity slots.
  - Delivery completion and failure handling now release pending capacity accurately, including for non-HTTP and terminal outcomes.

- **Bug Fixes**
  - Improved handling of duplicate or already-completed deliveries to prevent incorrect capacity updates.
  - Pending counters are protected from becoming negative or drifting from actual delivery state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->