### PR TITLE
perf(webhooks): run delivery attempts under a bounded semaphore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,8 @@ GITHUB_REPO="" # org/repo format
 # WEBHOOKS_MAX_CONSECUTIVE_FAILURES="10"         # exhausted deliveries → auto-disable
 # WEBHOOKS_DELIVERY_LOG_TTL_DAYS="30"            # events + delivery log retention
 # WEBHOOKS_MAX_PENDING_PER_ENDPOINT="1000"       # backlog cap; beyond = drop+count
+# WEBHOOKS_EXECUTOR_CONCURRENCY="8"              # delivery attempts in flight per process
+# WEBHOOKS_EXECUTOR_PER_ENDPOINT_CONCURRENCY="2" # of those, max held by one endpoint
 
 # ── URL safety pipeline ──────────────────────────────────────────────────
 # Report-triggered destination analysis, per-host verdicts, and automatic

--- a/config.py
+++ b/config.py
@@ -469,6 +469,10 @@ class WebhookSettings(BaseSettings):
     max_pending_per_endpoint: int = Field(default=1000, ge=10)
     executor_poll_seconds: float = Field(default=1.0, gt=0)
     executor_lease_seconds: int = Field(default=60, ge=10)
+    # Attempts in flight per executor process, and how many of those one
+    # endpoint may hold so a hanging receiver cannot occupy every slot.
+    executor_concurrency: int = Field(default=8, ge=1)
+    executor_per_endpoint_concurrency: int = Field(default=2, ge=1)
     # Owner→subscription-count cache in front of the matcher.
     matcher_cache_ttl_seconds: int = Field(default=60, ge=5)
     domain_stream_maxlen: int = Field(default=100_000, ge=1000)

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -506,6 +506,8 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         max_consecutive_failures=wh_settings.max_consecutive_failures,
         poll_interval=wh_settings.executor_poll_seconds,
         lease_seconds=wh_settings.executor_lease_seconds,
+        concurrency=wh_settings.executor_concurrency,
+        per_endpoint_concurrency=wh_settings.executor_per_endpoint_concurrency,
     )
     if not wh_settings.enabled:
         app.state.domain_event_sink = NullDomainEventSink()

--- a/repositories/webhook_delivery_repository.py
+++ b/repositories/webhook_delivery_repository.py
@@ -9,6 +9,7 @@ beyond Mongo itself. The claim query is stateless over
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 
 from bson import ObjectId
@@ -77,22 +78,31 @@ class WebhookDeliveryRepository(BaseRepository[WebhookDeliveryDoc]):
 
     # ── Executor surface ─────────────────────────────────────────────────
 
-    async def claim_due(self, *, lease_seconds: int = 60) -> WebhookDeliveryDoc | None:
+    async def claim_due(
+        self,
+        *,
+        lease_seconds: int = 60,
+        exclude_endpoints: Sequence[ObjectId] = (),
+    ) -> WebhookDeliveryDoc | None:
         """Atomically claim one due delivery, or None when nothing is due.
 
         A crashed executor's claim expires with its lease — rows are never
-        stranded.
+        stranded. ``exclude_endpoints`` skips rows for endpoints the caller
+        already has enough attempts in flight for.
         """
         now = datetime.now(timezone.utc)
+        query: dict = {
+            "status": DeliveryStatus.PENDING.value,
+            "next_attempt_at": {"$lte": now},
+            "$or": [
+                {"claimed_until": None},
+                {"claimed_until": {"$lte": now}},
+            ],
+        }
+        if exclude_endpoints:
+            query["endpoint_id"] = {"$nin": list(exclude_endpoints)}
         doc = await self._col.find_one_and_update(
-            {
-                "status": DeliveryStatus.PENDING.value,
-                "next_attempt_at": {"$lte": now},
-                "$or": [
-                    {"claimed_until": None},
-                    {"claimed_until": {"$lte": now}},
-                ],
-            },
+            query,
             {"$set": {"claimed_until": now + timedelta(seconds=lease_seconds)}},
             sort=[("next_attempt_at", 1)],
             return_document=ReturnDocument.AFTER,

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Awaitable, Callable
+from collections import Counter
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
+
+from bson import ObjectId
 
 from infrastructure.crypto import decrypt_secret
 from infrastructure.logging import get_logger
@@ -68,6 +71,8 @@ class DeliveryExecutor:
         max_consecutive_failures: int = 10,
         poll_interval: float = 1.0,
         lease_seconds: int = 60,
+        concurrency: int = 8,
+        per_endpoint_concurrency: int = 2,
         on_disabled: OnDisabled | None = None,
     ) -> None:
         self._deliveries = delivery_repo
@@ -80,31 +85,89 @@ class DeliveryExecutor:
         self._max_consecutive = max_consecutive_failures
         self._poll_interval = poll_interval
         self._lease = lease_seconds
+        self._concurrency = concurrency
+        self._per_endpoint = per_endpoint_concurrency
         self._on_disabled = on_disabled
 
     # ── Loop ─────────────────────────────────────────────────────────────
 
     async def run(self) -> None:
-        """Long-lived task; cancellation is the shutdown path."""
-        log.info("webhook_executor_started", poll_interval=self._poll_interval)
-        while True:
-            try:
-                row = await self._deliveries.claim_due(lease_seconds=self._lease)
+        """Long-lived task; cancellation is the shutdown path.
+
+        Attempts run as their own tasks under an executor-wide bound, with
+        at most ``per_endpoint_concurrency`` of them for one endpoint, so a
+        receiver that hangs for the full delivery timeout can hold only its
+        own slots. Rows are claimed one at a time exactly as before; only
+        the wait for the HTTP round trip overlaps. Shutdown drains in-flight
+        attempts for up to one delivery timeout, then cancels the rest.
+        """
+        log.info(
+            "webhook_executor_started",
+            poll_interval=self._poll_interval,
+            concurrency=self._concurrency,
+            per_endpoint_concurrency=self._per_endpoint,
+        )
+        slots = asyncio.Semaphore(self._concurrency)
+        in_flight: dict[asyncio.Task, ObjectId] = {}
+        try:
+            while True:
+                await slots.acquire()
+                row = None
+                try:
+                    row = await self._deliveries.claim_due(
+                        lease_seconds=self._lease,
+                        exclude_endpoints=self._saturated(in_flight.values()),
+                    )
+                except Exception as exc:
+                    log.error(
+                        "webhook_executor_tick_failed",
+                        stage="claim",
+                        error=str(exc),
+                        error_type=type(exc).__name__,
+                    )
                 if row is None:
+                    slots.release()
                     await asyncio.sleep(self._poll_interval)
                     continue
-                await self.attempt(row)
-            except asyncio.CancelledError:
-                log.info("webhook_executor_stopped")
-                raise
-            except Exception as exc:
-                # One bad row must not kill the loop.
-                log.error(
-                    "webhook_executor_tick_failed",
-                    error=str(exc),
-                    error_type=type(exc).__name__,
+                task = asyncio.create_task(self._run_attempt(row, slots))
+                in_flight[task] = row.endpoint_id
+                task.add_done_callback(lambda t: in_flight.pop(t, None))
+        except asyncio.CancelledError:
+            pending = set(in_flight)
+            try:
+                if pending:
+                    await asyncio.wait(pending, timeout=self._timeout)
+            finally:
+                abandoned = [t for t in pending if not t.done()]
+                for t in abandoned:
+                    t.cancel()
+                log.info(
+                    "webhook_executor_stopped",
+                    drained=len(pending) - len(abandoned),
+                    abandoned=len(abandoned),
                 )
-                await asyncio.sleep(self._poll_interval)
+            raise
+
+    def _saturated(self, endpoint_ids: Iterable[ObjectId]) -> list[ObjectId]:
+        counts = Counter(endpoint_ids)
+        return [eid for eid, n in counts.items() if n >= self._per_endpoint]
+
+    async def _run_attempt(
+        self, row: WebhookDeliveryDoc, slots: asyncio.Semaphore
+    ) -> None:
+        try:
+            await self.attempt(row)
+        except Exception as exc:
+            # One bad row must not take the loop or its slot with it.
+            log.error(
+                "webhook_executor_tick_failed",
+                stage="attempt",
+                webhook_id=row.webhook_id,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+        finally:
+            slots.release()
 
     # ── One attempt ──────────────────────────────────────────────────────
 

--- a/tests/unit/repositories/test_webhook_delivery_repository.py
+++ b/tests/unit/repositories/test_webhook_delivery_repository.py
@@ -1,5 +1,6 @@
-"""Terminal writes report whether they moved the row out of PENDING, so the
-executor releases the endpoint's pending slot exactly once per row."""
+"""Claim and terminal-write contracts of the deliveries repository: the
+atomic lease can skip saturated endpoints, and terminal writes report whether
+they moved the row out of PENDING so the pending slot is released once."""
 
 from __future__ import annotations
 
@@ -85,3 +86,23 @@ class TestCountPending:
         query = col.count_documents.await_args[0][0]
         assert query["status"] == DeliveryStatus.PENDING.value
         assert query["is_test"] == {"$ne": True}
+
+
+class TestClaimDue:
+    @pytest.mark.asyncio
+    async def test_plain_claim_has_no_endpoint_filter(self):
+        col = make_collection()
+        col.find_one_and_update.return_value = None
+        assert await WebhookDeliveryRepository(col).claim_due() is None
+        query = col.find_one_and_update.await_args[0][0]
+        assert query["status"] == DeliveryStatus.PENDING.value
+        assert "endpoint_id" not in query
+
+    @pytest.mark.asyncio
+    async def test_exclusions_become_nin(self):
+        col = make_collection()
+        col.find_one_and_update.return_value = None
+        saturated = [ObjectId(), ObjectId()]
+        await WebhookDeliveryRepository(col).claim_due(exclude_endpoints=saturated)
+        query = col.find_one_and_update.await_args[0][0]
+        assert query["endpoint_id"] == {"$nin": saturated}

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -3,6 +3,7 @@ paths. post_public is patched; repos are AsyncMocks shaped per call."""
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -481,3 +482,184 @@ class TestRenderFailures:
         assert deliveries.mark_failed.await_args[0][1] == "payload_over_cap"
         endpoints.release_pending.assert_awaited_once_with(endpoint.id)
         post.assert_not_awaited()
+
+
+class _RowQueue:
+    """claim_due stand-in: hands out queued rows, records the exclusions."""
+
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.exclusions: list[list] = []
+
+    async def claim_due(self, *, lease_seconds, exclude_endpoints=()):
+        self.exclusions.append(list(exclude_endpoints))
+        for i, row in enumerate(self.rows):
+            if row.endpoint_id not in exclude_endpoints:
+                return self.rows.pop(i)
+        return None
+
+
+def _loop_executor(rows, *, concurrency, per_endpoint):
+    deliveries = AsyncMock()
+    queue = _RowQueue(rows)
+    deliveries.claim_due = queue.claim_due
+    executor = DeliveryExecutor(
+        deliveries,
+        AsyncMock(),
+        AsyncMock(),
+        default_renderers(),
+        master_secret=_MASTER,
+        poll_interval=0.01,
+        delivery_timeout=0.5,
+        concurrency=concurrency,
+        per_endpoint_concurrency=per_endpoint,
+    )
+    return executor, queue
+
+
+async def _settle():
+    for _ in range(20):
+        await asyncio.sleep(0)
+
+
+class TestRunLoop:
+    @pytest.mark.asyncio
+    async def test_attempts_overlap_up_to_the_bound(self):
+        rows = [_delivery(endpoint_id=ObjectId()) for _ in range(6)]
+        executor, queue = _loop_executor(rows, concurrency=4, per_endpoint=4)
+        gate = asyncio.Event()
+        in_flight = {"now": 0, "peak": 0}
+
+        async def blocking_attempt(row):
+            in_flight["now"] += 1
+            in_flight["peak"] = max(in_flight["peak"], in_flight["now"])
+            await gate.wait()
+            in_flight["now"] -= 1
+
+        executor.attempt = blocking_attempt
+        task = asyncio.create_task(executor.run())
+        await _settle()
+        assert in_flight["now"] == 4  # four claimed, two still queued
+        gate.set()
+        await _settle()
+        assert not queue.rows
+        assert in_flight["peak"] == 4
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_one_endpoint_cannot_hold_every_slot(self):
+        slow, healthy = ObjectId(), ObjectId()
+        rows = [_delivery(endpoint_id=slow) for _ in range(5)] + [
+            _delivery(endpoint_id=healthy)
+        ]
+        executor, queue = _loop_executor(rows, concurrency=4, per_endpoint=2)
+        gate = asyncio.Event()
+        started: list[ObjectId] = []
+
+        async def blocking_attempt(row):
+            started.append(row.endpoint_id)
+            if row.endpoint_id == slow:
+                await gate.wait()
+
+        executor.attempt = blocking_attempt
+        task = asyncio.create_task(executor.run())
+        await _settle()
+        # Two slow attempts hold their two slots; the healthy row went
+        # through even though five slow rows were queued ahead of it.
+        assert started.count(slow) == 2
+        assert started.count(healthy) == 1
+        assert [slow] in queue.exclusions
+        gate.set()
+        await _settle()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_cancel_drains_in_flight_attempts(self):
+        executor, _ = _loop_executor([_delivery()], concurrency=2, per_endpoint=2)
+        finished = asyncio.Event()
+
+        async def slow_attempt(row):
+            await asyncio.sleep(0.05)
+            finished.set()
+
+        executor.attempt = slow_attempt
+        task = asyncio.create_task(executor.run())
+        await _settle()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert finished.is_set()
+
+    @pytest.mark.asyncio
+    async def test_attempt_that_raises_frees_its_slot(self):
+        rows = [_delivery(), _delivery()]
+        executor, _ = _loop_executor(rows, concurrency=1, per_endpoint=1)
+        seen: list[str] = []
+
+        async def flaky_attempt(row):
+            seen.append(row.webhook_id)
+            if len(seen) == 1:
+                raise RuntimeError("boom")
+
+        executor.attempt = flaky_attempt
+        task = asyncio.create_task(executor.run())
+        await _settle()
+        assert len(seen) == 2
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+class TestRunLoopEdges:
+    @pytest.mark.asyncio
+    async def test_claim_error_frees_slot_and_loop_continues(self):
+        row = _delivery()
+        executor, _ = _loop_executor([], concurrency=1, per_endpoint=1)
+        calls = {"n": 0}
+
+        async def flaky_claim(*, lease_seconds, exclude_endpoints=()):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("mongo hiccup")
+            return row if calls["n"] == 2 else None
+
+        executor._deliveries.claim_due = flaky_claim
+        attempted: list[str] = []
+
+        async def record(r):
+            attempted.append(r.webhook_id)
+
+        executor.attempt = record
+        task = asyncio.create_task(executor.run())
+        await asyncio.sleep(0.1)
+        assert attempted == [row.webhook_id]
+        assert calls["n"] >= 3  # kept polling after the error and the idle tick
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_cancel_abandons_attempts_past_the_delivery_timeout(self):
+        executor, _ = _loop_executor([_delivery()], concurrency=1, per_endpoint=1)
+        executor._timeout = 0.02
+        cancelled = asyncio.Event()
+
+        async def hanging_attempt(row):
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        executor.attempt = hanging_attempt
+        task = asyncio.create_task(executor.run())
+        await _settle()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+        assert cancelled.is_set()

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -244,6 +244,8 @@ async def _build_runtime(
             max_consecutive_failures=wh.max_consecutive_failures,
             poll_interval=wh.executor_poll_seconds,
             lease_seconds=wh.executor_lease_seconds,
+            concurrency=wh.executor_concurrency,
+            per_endpoint_concurrency=wh.executor_per_endpoint_concurrency,
         )
         runtime.telemetry_tasks.append(
             asyncio.create_task(executor.run(), name="webhook-delivery-executor")


### PR DESCRIPTION
Stacked on #347.

## What

- `DeliveryExecutor.run` claims rows one at a time as before, but each attempt runs as its own task under a semaphore. `WEBHOOKS_EXECUTOR_CONCURRENCY` (default 8) bounds attempts in flight per process.
- `WEBHOOKS_EXECUTOR_PER_ENDPOINT_CONCURRENCY` (default 2) caps how many of those slots one endpoint may hold. Saturated endpoints are excluded from the claim query with `$nin`, so their rows wait while other endpoints' rows keep flowing.
- Per-row atomic claim, lease and outcome writes are unchanged.
- Shutdown still drains: on cancel the loop waits up to one delivery timeout for in-flight attempts, then cancels whatever is left and logs how many were drained or abandoned.
- An attempt that raises logs `webhook_executor_tick_failed` with `stage=attempt` and frees its slot; a claim failure logs the same event with `stage=claim`.

## Why

The claim loop was one serial task. A subscriber endpoint that accepted the connection and then sat on it held the whole executor for the 15s delivery timeout, once per attempt, and every other owner's deliveries queued behind it.

## How proven

Rig against local Mongo with the real dispatcher and executor and a local receiver that answers `/slow` after 14s and `/ok` at once. Slow rows were dispatched first so they sat at the head of the claim order, then 50 healthy rows for a second owner. Four executors ran against the same Mongo.

- `main`, 4 slow rows: the first healthy delivery completed at 14.75s and the last at 15.76s. Every healthy row waited behind the slow ones.
- This branch, 4 slow rows: first healthy at 0.19s, all 50 at 0.51s, all 4 slow rows still pending.
- This branch, 8 slow rows (exactly filling the 4 x 2 per-endpoint slots): first healthy at 0.12s, all 50 at 0.41s, healthy created to completed p50 0.32s and max 0.41s, all 8 slow rows still pending. The slow rows completed at 14.2s.
- Exactly once under 4 claimers: receiver saw 58 hits and 58 distinct webhook ids, 58 rows in SUCCESS, every row with exactly one attempt.
- Shutdown drain: one executor cancelled while its two slow attempts were in flight; `run()` returned after 13.7s, once those attempts had completed, and both rows were delivered once.
- `uv run pytest`: 3730 passed, 5 skipped.
