### PR TITLE
feat(links): fallback URL served once a link has expired

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -144,6 +144,14 @@ class GoneError(AppError):
     error_code = "gone"
 
 
+class ExpiredRedirectError(GoneError):
+    """Expired link whose owner set a fallback destination."""
+
+    def __init__(self, redirect_url: str) -> None:
+        super().__init__("URL has expired")
+        self.redirect_url = redirect_url
+
+
 class RateLimitError(AppError):
     status_code = 429
     error_code = "rate_limit_exceeded"

--- a/infrastructure/cache/url_cache.py
+++ b/infrastructure/cache/url_cache.py
@@ -44,6 +44,8 @@ class UrlCacheData(BaseModel):
     # non-geo links; entries cached before this field existed deserialize
     # to None (default), so no cache version bump is needed.
     geo_rules: dict[str, str] | None = None
+    # v2 only; served with 302 once the link is EXPIRED.
+    expired_redirect_url: str | None = None
     # Custom meta-tags (v2 only; None = feature disabled on this link).
     # meta_title is the enabled-signal: LinkMetaTags.title is mandatory.
     meta_title: str | None = None
@@ -82,6 +84,7 @@ class UrlCacheData(BaseModel):
             owner_id=str(doc.owner_id) if doc.owner_id else None,
             domain=doc.domain,
             geo_rules=doc.geo_rules,
+            expired_redirect_url=doc.expired_redirect_url,
             meta_title=doc.meta_tags.title if doc.meta_tags else None,
             meta_description=doc.meta_tags.description if doc.meta_tags else None,
             meta_image=doc.meta_tags.image if doc.meta_tags else None,

--- a/openapi.json
+++ b/openapi.json
@@ -1872,7 +1872,7 @@
           "URL Shortening"
         ],
         "summary": "Create Shortened URL",
-        "description": "Create a new shortened URL.\n\nCreate a shortened URL with optional customization including password\nprotection, expiration, click limits, and bot blocking. Authenticated\nusers may target an owned, ACTIVE custom domain via the ``domain`` field.\n\n**Emoji aliases**: ``alias`` also accepts an emoji-only short code\n(e.g. ``\ud83d\ude80\ud83d\udd25``) \u2014 1-15 fully-qualified emoji; ZWJ sequences, flags,\nkeycaps, and text-style symbols are rejected (they render or copy\ninconsistently across platforms). Set ``alias_type: \"emoji\"`` to\nauto-generate an emoji code instead of an alphanumeric one. Stored\nand returned in canonical form (variation selectors stripped).\n\n**Authentication**: Optional \u2014 higher rate limits when authenticated.\nRequired if ``domain`` is supplied.\n\n**API Key Scope**: `shorten:create` or `admin:all`\n\n**Rate Limits**:\n\n- Authenticated: 60/min, 5,000/day\n- Anonymous: 20/min, 1,000/day\n\n**Anonymous Usage Consequences**:\n\n- Lower rate limits\n- Cannot manage or view URLs later\n- Cannot use private stats\n- URLs not linked to any account\n- Cannot use custom domains\n- Cannot use geo targeting\n- Cannot use custom meta tags",
+        "description": "Create a new shortened URL.\n\nCreate a shortened URL with optional customization including password\nprotection, expiration, click limits, and bot blocking. Authenticated\nusers may target an owned, ACTIVE custom domain via the ``domain`` field.\n\n**Emoji aliases**: ``alias`` also accepts an emoji-only short code\n(e.g. ``\ud83d\ude80\ud83d\udd25``) \u2014 1-15 fully-qualified emoji; ZWJ sequences, flags,\nkeycaps, and text-style symbols are rejected (they render or copy\ninconsistently across platforms). Set ``alias_type: \"emoji\"`` to\nauto-generate an emoji code instead of an alphanumeric one. Stored\nand returned in canonical form (variation selectors stripped).\n\n**Authentication**: Optional \u2014 higher rate limits when authenticated.\nRequired if ``domain`` is supplied.\n\n**API Key Scope**: `shorten:create` or `admin:all`\n\n**Rate Limits**:\n\n- Authenticated: 60/min, 5,000/day\n- Anonymous: 20/min, 1,000/day\n\n**Anonymous Usage Consequences**:\n\n- Lower rate limits\n- Cannot manage or view URLs later\n- Cannot use private stats\n- URLs not linked to any account\n- Cannot use custom domains\n- Cannot use geo targeting\n- Cannot set an expired-link fallback\n- Cannot use custom meta tags",
         "operationId": "shortenUrl",
         "requestBody": {
           "content": {
@@ -2621,7 +2621,7 @@
           "Link Management"
         ],
         "summary": "Update URL",
-        "description": "Update an existing URL's properties.\n\nPartially update a shortened URL. Only provided fields are modified; omitted\nfields remain unchanged. Pass `null` to remove optional settings like\n`password`, `max_clicks`, or `expire_after`.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 120/min, 2,000/day\n\n**Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,\n`max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,\n`geo_rules`, `meta_tags`\n\n**Notes**:\n\n- Setting `max_clicks` to `0` or `null` removes the click limit\n- Changing the `alias` checks availability and may fail with 409 Conflict\n- Setting `domain` moves the URL to a different tenant; caller must own\n  the target as an ACTIVE custom domain, or pass `null` to move back to\n  the system default. Alias collision is verified on the target.\n- `geo_rules` replaces the whole map; pass `null` or `{}` to remove all\n  rules\n- The `url_id` is the MongoDB ObjectId, not the alias",
+        "description": "Update an existing URL's properties.\n\nPartially update a shortened URL. Only provided fields are modified; omitted\nfields remain unchanged. Pass `null` to remove optional settings like\n`password`, `max_clicks`, or `expire_after`.\n\n**Authentication**: Required \u2014 you must own the URL.\n\n**API Key Scope**: `urls:manage` or `admin:all`\n\n**Rate Limits**: 120/min, 2,000/day\n\n**Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,\n`max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,\n`geo_rules`, `expired_redirect_url`, `meta_tags`\n\n**Notes**:\n\n- Setting `max_clicks` to `0` or `null` removes the click limit\n- Changing the `alias` checks availability and may fail with 409 Conflict\n- Setting `domain` moves the URL to a different tenant; caller must own\n  the target as an ACTIVE custom domain, or pass `null` to move back to\n  the system default. Alias collision is verified on the target.\n- `geo_rules` replaces the whole map; pass `null` or `{}` to remove all\n  rules\n- `expired_redirect_url` is where visitors land once the link has expired;\n  pass `null` to go back to the expired page\n- The `url_id` is the MongoDB ObjectId, not the alias",
         "operationId": "updateUrl",
         "parameters": [
           {
@@ -11342,6 +11342,22 @@
               }
             ]
           },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 8192
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Where visitors land once the link has expired, by time or by click limit, instead of the expired page. Validated like a destination. Requires authentication.",
+            "examples": [
+              "https://example.com/offer-ended"
+            ]
+          },
           "tag_ids": {
             "anyOf": [
               {
@@ -14780,6 +14796,22 @@
               }
             ]
           },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 8192
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Where visitors land once the link has expired, by time or by click limit, instead of the expired page. Validated like a destination. Pass `null` or empty to remove; omit to keep.",
+            "examples": [
+              "https://example.com/offer-ended"
+            ]
+          },
           "tag_ids": {
             "anyOf": [
               {
@@ -14992,6 +15024,21 @@
               {
                 "IN": "https://example.in/"
               }
+            ]
+          },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Destination served once the link has expired, or null.",
+            "examples": [
+              "https://example.com/offer-ended"
             ]
           },
           "tags": {
@@ -15319,6 +15366,17 @@
             ],
             "title": "Geo Rules"
           },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url"
+          },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/TagRef"
@@ -15487,6 +15545,21 @@
               {
                 "IN": "https://example.in/"
               }
+            ]
+          },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url",
+            "description": "Destination served once the link has expired, or null.",
+            "examples": [
+              "https://example.com/offer-ended"
             ]
           },
           "tags": {

--- a/openapi.json
+++ b/openapi.json
@@ -13339,6 +13339,17 @@
             ],
             "title": "Long Url"
           },
+          "expired_redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expired Redirect Url"
+          },
           "created_at": {
             "anyOf": [
               {
@@ -13471,6 +13482,16 @@
               }
             ],
             "title": "Geo Destinations"
+          },
+          "expired_destination": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PreviewDestination"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13485,7 +13506,7 @@
           "geo_destinations"
         ],
         "title": "PublicPreviewResponse",
-        "description": "Response body for the public link preview endpoint.\n\n``destination`` and ``geo_destinations`` are non-null only while the\nlink is active and not password-protected \u2014 the preview never reveals\na destination the redirect would refuse to serve."
+        "description": "Response body for the public link preview endpoint.\n\n``destination`` and ``geo_destinations`` are non-null only while the\nlink is active and not password-protected \u2014 the preview never reveals\na destination the redirect would refuse to serve. The rule runs both\nways: ``expired_destination`` names where an expired link still sends\nevery visitor when its owner set a fallback, so the preview never shows\nLESS than the redirect serves either."
       },
       "PublicStatsBody": {
         "properties": {

--- a/repositories/url_repository.py
+++ b/repositories/url_repository.py
@@ -18,7 +18,7 @@ from infrastructure.logging import get_logger
 from repositories.base import BaseRepository
 from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.url import UrlStatus, UrlV2Doc
-from shared.url_utils import parse_destination
+from shared.url_utils import SINGLE_DESTINATION_FIELDS, parse_destination
 
 log = get_logger(__name__)
 
@@ -44,13 +44,10 @@ _ALL_URLS = {
                 "in": "$$rule.v",
             }
         },
-        {
-            "$cond": [
-                {"$eq": [{"$type": "$pre_start_url"}, "string"]},
-                ["$pre_start_url"],
-                [],
-            ]
-        },
+        *(
+            {"$cond": [{"$eq": [{"$type": f"${field}"}, "string"]}, [f"${field}"], []]}
+            for field in SINGLE_DESTINATION_FIELDS
+        ),
     ]
 }
 # (host, registrable) pairs for every destination; secondary_registrable is

--- a/routes/api_v1/management.py
+++ b/routes/api_v1/management.py
@@ -38,6 +38,7 @@ from schemas.dto.responses.url import (
     UpdateUrlResponse,
 )
 from services.feature_flag_service import (
+    EXPIRED_FALLBACK_FLAG,
     GEO_TARGETING_FLAG,
     LINK_SCHEDULING_FLAG,
     META_TAGS_FLAG,
@@ -126,7 +127,7 @@ async def update_url_v1(
 
     **Updatable Fields**: `long_url`, `alias`, `password`, `block_bots`,
     `max_clicks`, `expire_after`, `private_stats`, `status`, `domain`,
-    `geo_rules`, `meta_tags`
+    `geo_rules`, `expired_redirect_url`, `meta_tags`
 
     **Notes**:
 
@@ -137,6 +138,8 @@ async def update_url_v1(
       the system default. Alias collision is verified on the target.
     - `geo_rules` replaces the whole map; pass `null` or `{}` to remove all
       rules
+    - `expired_redirect_url` is where visitors land once the link has expired;
+      pass `null` to go back to the expired page
     - The `url_id` is the MongoDB ObjectId, not the alias
     """
     oid = parse_url_id(url_id)
@@ -144,6 +147,8 @@ async def update_url_v1(
     # de-allowlisted owners can remove their rules during rollback.
     if "geo_rules" in body.model_fields_set and body.geo_rules:
         await flag_svc.require(GEO_TARGETING_FLAG, user)
+    if "expired_redirect_url" in body.model_fields_set and body.expired_redirect_url:
+        await flag_svc.require(EXPIRED_FALLBACK_FLAG, user)
     # Same deal for meta_tags: setting/replacing is flag-gated, clearing
     # (null) never is.
     if "meta_tags" in body.model_fields_set and body.meta_tags is not None:

--- a/routes/api_v1/shorten.py
+++ b/routes/api_v1/shorten.py
@@ -31,6 +31,7 @@ from middleware.rate_limiter import Limits, dynamic_limit, limiter
 from schemas.dto.requests.url import AliasCheckQuery, CreateUrlRequest
 from schemas.dto.responses.url import AliasCheckResponse, UrlResponse
 from services.feature_flag_service import (
+    EXPIRED_FALLBACK_FLAG,
     GEO_TARGETING_FLAG,
     LINK_SCHEDULING_FLAG,
     META_TAGS_FLAG,
@@ -94,6 +95,7 @@ async def shorten_v1(
     - URLs not linked to any account
     - Cannot use custom domains
     - Cannot use geo targeting
+    - Cannot set an expired-link fallback
     - Cannot use custom meta tags
     """
     owner_id = user.user_id if user is not None else None
@@ -103,6 +105,13 @@ async def shorten_v1(
         if user is None:
             raise AuthenticationError("Authentication required to set geo_rules")
         await flag_svc.require(GEO_TARGETING_FLAG, user)
+
+    if body.expired_redirect_url:
+        if user is None:
+            raise AuthenticationError(
+                "Authentication required to set expired_redirect_url"
+            )
+        await flag_svc.require(EXPIRED_FALLBACK_FLAG, user)
 
     # optional_scopes_verified already rejects unverified authenticated users,
     # so the flag is the only remaining gate here.

--- a/routes/legacy/url_shortener.py
+++ b/routes/legacy/url_shortener.py
@@ -506,6 +506,11 @@ async def preview_url(
                         else None,
                         "blocked": v2.effective_status is UrlStatus.BLOCKED,
                         "scheduled": v2.effective_status is UrlStatus.SCHEDULED,
+                        "expired_fallback": (
+                            v2.expired_redirect_url
+                            if v2.effective_status is UrlStatus.EXPIRED
+                            else None
+                        ),
                     }
                     schema_type = "v2"
         else:
@@ -522,6 +527,11 @@ async def preview_url(
                     "meta_tags": v2.meta_tags.model_dump() if v2.meta_tags else None,
                     "blocked": v2.effective_status is UrlStatus.BLOCKED,
                     "scheduled": v2.effective_status is UrlStatus.SCHEDULED,
+                    "expired_fallback": (
+                        v2.expired_redirect_url
+                        if v2.effective_status is UrlStatus.EXPIRED
+                        else None
+                    ),
                 }
                 schema_type = "v2"
             else:
@@ -621,6 +631,12 @@ async def preview_url(
             "path": default_dest["path"],
             "is_https": default_dest["is_https"],
             "geo_destinations": geo_destinations,
+            # An expired link with a fallback still sends everyone there.
+            "expired_destination": (
+                split_destination(url_data["expired_fallback"])
+                if url_data.get("expired_fallback")
+                else None
+            ),
             "password_protected": False,
             "host_url": host_url,
             # Anti-phishing transparency: show the custom card NEXT TO the

--- a/routes/redirect_routes.py
+++ b/routes/redirect_routes.py
@@ -16,6 +16,7 @@ from fastapi.responses import RedirectResponse, Response
 from dependencies import ClickSink, GeoIP, UrlSvc
 from errors import (
     BlockedUrlError,
+    ExpiredRedirectError,
     ForbiddenError,
     GoneError,
     NotFoundError,
@@ -185,6 +186,17 @@ async def redirect_url(
     except BlockedUrlError:
         log.info("url_blocked", short_code=short_code)
         return _error_page(request, "451", "THIS URL HAS BEEN BLOCKED", 451)
+    except ExpiredRedirectError as exc:
+        # Not a click: the owner's limit was reached, so nothing is counted.
+        log.info(
+            "url_expired_fallback",
+            short_code=short_code,
+            fallback_domain=extract_hostname(exc.redirect_url),
+        )
+        resp = RedirectResponse(exc.redirect_url, status_code=302)
+        resp.headers["X-Robots-Tag"] = _NOINDEX_HEADER
+        resp.headers["Cache-Control"] = "no-store"
+        return resp
     except GoneError:
         log.info("url_gone", short_code=short_code)
         return _error_page(request, "410", "SHORT URL EXPIRED", 410)

--- a/schemas/dto/requests/url.py
+++ b/schemas/dto/requests/url.py
@@ -300,6 +300,16 @@ class CreateUrlRequest(RequestBase):
         ),
         examples=[{"IN": "https://example.in/", "US": "https://example.com/us"}],
     )
+    expired_redirect_url: str | None = Field(
+        default=None,
+        max_length=8192,
+        description=(
+            "Where visitors land once the link has expired, by time or by "
+            "click limit, instead of the expired page. Validated like a "
+            "destination. Requires authentication."
+        ),
+        examples=["https://example.com/offer-ended"],
+    )
     tag_ids: list[str] | None = Field(
         default=None,
         description=_TAG_IDS_FIELD_DESC,
@@ -445,6 +455,16 @@ class UpdateUrlRequest(RequestBase):
             "omit to keep existing rules unchanged."
         ),
         examples=[{"IN": "https://example.in/", "US": "https://example.com/us"}],
+    )
+    expired_redirect_url: str | None = Field(
+        default=None,
+        max_length=8192,
+        description=(
+            "Where visitors land once the link has expired, by time or by "
+            "click limit, instead of the expired page. Validated like a "
+            "destination. Pass `null` or empty to remove; omit to keep."
+        ),
+        examples=["https://example.com/offer-ended"],
     )
     tag_ids: list[str] | None = Field(
         default=None,

--- a/schemas/dto/responses/public_preview.py
+++ b/schemas/dto/responses/public_preview.py
@@ -38,7 +38,10 @@ class PublicPreviewResponse(ResponseBase):
 
     ``destination`` and ``geo_destinations`` are non-null only while the
     link is active and not password-protected — the preview never reveals
-    a destination the redirect would refuse to serve.
+    a destination the redirect would refuse to serve. The rule runs both
+    ways: ``expired_destination`` names where an expired link still sends
+    every visitor when its owner set a fallback, so the preview never shows
+    LESS than the redirect serves either.
     """
 
     generation: Literal["v1", "v2"]
@@ -51,3 +54,5 @@ class PublicPreviewResponse(ResponseBase):
     password_protected: bool
     destination: PreviewDestination | None
     geo_destinations: list[PreviewGeoDestination] | None
+    # Set only while ``status`` is ``"expired"`` and the owner set a fallback.
+    expired_destination: PreviewDestination | None = None

--- a/schemas/dto/responses/public_stats.py
+++ b/schemas/dto/responses/public_stats.py
@@ -30,6 +30,9 @@ class PublicLinkFacts(ResponseBase):
     # null unless the effective status is "active"; owner sessions
     # always get it.
     long_url: str | None = None
+    # Where an expired link still sends visitors; set only while ``status``
+    # is "expired" and the owner set a fallback.
+    expired_redirect_url: str | None = None
     created_at: datetime | None = None
     status: Literal["active", "inactive", "expired", "blocked", "scheduled"]
     max_clicks: int | None = None

--- a/schemas/dto/responses/url.py
+++ b/schemas/dto/responses/url.py
@@ -111,6 +111,11 @@ class UrlResponse(ResponseBase):
         description="Per-country destination overrides (ISO alpha-2 code → URL), or null.",
         examples=[{"IN": "https://example.in/"}],
     )
+    expired_redirect_url: str | None = Field(
+        default=None,
+        description="Destination served once the link has expired, or null.",
+        examples=["https://example.com/offer-ended"],
+    )
     tags: list[TagRef] = Field(
         default_factory=list,
         description="The link's tags (id, name, colour), in the link's order.",
@@ -157,6 +162,7 @@ class UrlResponse(ResponseBase):
             status=doc.effective_status,
             private_stats=doc.private_stats,
             geo_rules=doc.geo_rules,
+            expired_redirect_url=doc.expired_redirect_url,
             tags=_tag_refs(doc, tag_refs),
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
             claim_token=claim_token,
@@ -221,6 +227,11 @@ class UpdateUrlResponse(ResponseBase):
         description="Per-country destination overrides (ISO alpha-2 code → URL), or null.",
         examples=[{"IN": "https://example.in/"}],
     )
+    expired_redirect_url: str | None = Field(
+        default=None,
+        description="Destination served once the link has expired, or null.",
+        examples=["https://example.com/offer-ended"],
+    )
     tags: list[TagRef] = Field(
         default_factory=list,
         description="The link's tags (id, name, colour), in the link's order.",
@@ -251,6 +262,7 @@ class UpdateUrlResponse(ResponseBase):
             private_stats=doc.private_stats,
             domain=doc.domain,
             geo_rules=doc.geo_rules,
+            expired_redirect_url=doc.expired_redirect_url,
             tags=_tag_refs(doc, tag_refs),
             updated_at=to_unix_timestamp(doc.updated_at, default=0),
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
@@ -283,6 +295,7 @@ class UrlListItem(ResponseBase):
     last_click: datetime | None = None
     domain: str | None = None
     geo_rules: dict[str, str] | None = None
+    expired_redirect_url: str | None = None
     tags: list[TagRef] = Field(default_factory=list)
     meta_tags: MetaTagsResponse | None = None
 
@@ -316,6 +329,7 @@ class UrlListItem(ResponseBase):
             last_click=_ensure_utc(doc.last_click),
             domain=doc.domain,
             geo_rules=doc.geo_rules,
+            expired_redirect_url=doc.expired_redirect_url,
             tags=_tag_refs(doc, tag_refs),
             meta_tags=MetaTagsResponse.from_model(doc.meta_tags),
         )

--- a/schemas/models/url.py
+++ b/schemas/models/url.py
@@ -168,12 +168,17 @@ class UrlDestination(BaseModel):
         geo_rules: dict[str, str] | None = None,
         variants: list[str] | None = None,
         pre_start_url: str | None = None,
+        expired_redirect_url: str | None = None,
     ) -> UrlDestination | None:
         """Main parts plus every secondary host. None only when nothing
         about the link parses."""
         main = parse_destination(long_url)
         urls = link_destination_urls(
-            None, geo_rules=geo_rules, variants=variants, pre_start_url=pre_start_url
+            None,
+            geo_rules=geo_rules,
+            variants=variants,
+            pre_start_url=pre_start_url,
+            expired_redirect_url=expired_redirect_url,
         )
         exclude = (main or {}).get("host", "")
         extra = secondary_hosts(urls, exclude=exclude)
@@ -257,6 +262,8 @@ class UrlV2Doc(MongoBaseModel):
     # Ids into the owner's ``tags`` collection. Docs written before the
     # field existed read as [].
     tag_ids: list[PyObjectId] = Field(default_factory=list)
+    # Where visitors go once the link is EXPIRED; INACTIVE and BLOCKED never use it.
+    expired_redirect_url: str | None = None
     status: UrlStatus = UrlStatus.ACTIVE
     # Enforcement audit trail, stamped when safety flips status to BLOCKED.
     # ``updated_at`` is lossy (any later touch overwrites); these survive.

--- a/scripts/backfill_url_dest.py
+++ b/scripts/backfill_url_dest.py
@@ -17,7 +17,7 @@ Unparseable destinations are stamped ``dest: null`` so the needs-backfill
 filter converges to zero; null adds nothing to the sparse dest_registrable
 index.
 
-Second pass, urlsV2 only: links with geo_rules or a pre_start_url get
+Second pass, urlsV2 only: links with geo_rules or a single-URL fallback get
 ``dest.secondary_hosts`` (every extra destination host but the main one) and
 the index-aligned ``dest.secondary_registrable``, so a host block and a
 feed-domain sweep both reach links that hide the host in a rule. Idempotent:
@@ -50,12 +50,16 @@ from pymongo import MongoClient, UpdateOne
 from pymongo.errors import BulkWriteError
 
 _FILTER = {"dest": {"$exists": False}}
+# Mirrors shared.url_utils.SINGLE_DESTINATION_FIELDS (pinned by test); the
+# script imports nothing from the app so it runs against any checkout.
+SINGLE_DESTINATION_FIELDS = ("pre_start_url", "expired_redirect_url")
+_SINGLE_PROJECTION = dict.fromkeys(SINGLE_DESTINATION_FIELDS, 1)
 _SECONDARY_FILTER = {
     "$and": [
         {
             "$or": [
                 {"geo_rules": {"$type": "object"}},
-                {"pre_start_url": {"$type": "string"}},
+                *({field: {"$type": "string"}} for field in SINGLE_DESTINATION_FIELDS),
             ]
         },
         {
@@ -107,11 +111,12 @@ def parse_destination(url: object) -> dict | None:
 
 
 def secondary_urls(doc: dict) -> list:
-    """Every extra destination a link routes to: geo rules and the pre-start page."""
+    """Every extra destination a link routes to: geo rules plus each single-URL field."""
     geo = doc.get("geo_rules")
     urls = list(geo.values()) if isinstance(geo, dict) else []
-    if isinstance(doc.get("pre_start_url"), str):
-        urls.append(doc["pre_start_url"])
+    for field in SINGLE_DESTINATION_FIELDS:
+        if isinstance(doc.get(field), str):
+            urls.append(doc[field])
     return urls
 
 
@@ -170,7 +175,7 @@ def _secondary_op(d: dict) -> UpdateOne:
     flt = {
         "_id": d["_id"],
         "geo_rules": d.get("geo_rules"),
-        "pre_start_url": d.get("pre_start_url"),
+        **{field: d.get(field) for field in SINGLE_DESTINATION_FIELDS},
         "dest.secondary_registrable": {"$exists": False},
     }
     if isinstance(d.get("dest"), dict):
@@ -194,7 +199,7 @@ def backfill_secondary(coll, dry_run: bool) -> None:
         batch = list(
             coll.find(
                 query,
-                {"dest": 1, "long_url": 1, "geo_rules": 1, "pre_start_url": 1},
+                {"dest": 1, "long_url": 1, "geo_rules": 1, **_SINGLE_PROJECTION},
             )
             .sort("_id", 1)
             .limit(_BATCH)
@@ -225,7 +230,7 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         return
     if dry_run:
         sample = coll.find_one(
-            _FILTER, {url_field: 1, "geo_rules": 1, "pre_start_url": 1}
+            _FILTER, {url_field: 1, "geo_rules": 1, **_SINGLE_PROJECTION}
         )
         print(f"[{coll.name}] sample parse: {dest_for(sample or {}, url_field)}")
         return
@@ -240,7 +245,7 @@ def backfill(coll, url_field: str, dry_run: bool) -> None:
         if last_id is not None:
             query["_id"] = {"$gt": last_id}
         batch = list(
-            coll.find(query, {url_field: 1, "geo_rules": 1, "pre_start_url": 1})
+            coll.find(query, {url_field: 1, "geo_rules": 1, **_SINGLE_PROJECTION})
             .sort("_id", 1)
             .limit(_BATCH)
         )

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -57,6 +57,7 @@ GEO_TARGETING_FLAG = "geo_targeting"
 META_TAGS_FLAG = "custom_meta_tags"
 AB_TESTING_FLAG = "ab_testing"
 WEBHOOKS_FLAG = "webhooks"
+EXPIRED_FALLBACK_FLAG = "expired_fallback"
 LINK_SCHEDULING_FLAG = "link_scheduling"
 
 # Flags whose per-user answer is exposed to clients via GET /api/v1/me/
@@ -69,6 +70,7 @@ EXPOSED_FEATURES: tuple[str, ...] = (
     META_TAGS_FLAG,
     AB_TESTING_FLAG,
     WEBHOOKS_FLAG,
+    EXPIRED_FALLBACK_FLAG,
     LINK_SCHEDULING_FLAG,
 )
 

--- a/services/public_preview_service.py
+++ b/services/public_preview_service.py
@@ -72,6 +72,13 @@ class PublicPreviewService:
         if status == "active" and not password_protected:
             destination = PreviewDestination(**split_destination(doc.long_url))
             geo_destinations = self._group_geo_rules(doc.geo_rules)
+        # An expired link with a fallback still 302s everyone (the redirect
+        # decides before the password gate), so the preview names that URL.
+        expired_destination: PreviewDestination | None = None
+        if status == "expired" and doc.expired_redirect_url:
+            expired_destination = PreviewDestination(
+                **split_destination(doc.expired_redirect_url)
+            )
 
         created_at = link.created_at()
         return PublicPreviewResponse(
@@ -86,6 +93,7 @@ class PublicPreviewService:
             password_protected=password_protected,
             destination=destination,
             geo_destinations=geo_destinations,
+            expired_destination=expired_destination,
         )
 
     @staticmethod

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -222,6 +222,12 @@ class PublicStatsService:
             # expired, paused, or blocked link's stats page must not out
             # the destination. Owner sessions always get it.
             "long_url": long_url if (status == "active" or is_owner) else None,
+            # The redirect serves this to everyone, so the page names it.
+            "expired_redirect_url": (
+                doc.expired_redirect_url
+                if (link.is_v2 and status == "expired")
+                else None
+            ),
             "created_at": link.created_at(),
             "status": status,
             "max_clicks": doc.max_clicks,

--- a/services/report_intake_service.py
+++ b/services/report_intake_service.py
@@ -38,7 +38,11 @@ from schemas.enums.report import RejectionCode
 from services.public_link_resolver import PublicLinkResolver
 from services.safety.events import SafetyAnalyzeEvent
 from services.safety.sinks import SafetySink
-from shared.url_utils import link_destination_urls, parse_destination
+from shared.url_utils import (
+    link_destination_urls,
+    link_destination_urls_for,
+    parse_destination,
+)
 
 log = get_logger(__name__)
 
@@ -315,7 +319,7 @@ class ReportIntakeService:
         self, domain: str | None, code: str
     ) -> list[str] | None:
         """Domain-scoped existence check that also yields every destination
-        the link routes to (long_url, geo overrides, pre-start page).
+        the link routes to (long_url, geo overrides, pre-start and after-expiry pages).
 
         System-domain codes resolve via the shared PublicLinkResolver —
         the same generation dispatch (v1/v2/emoji) as the redirect, and
@@ -329,19 +333,12 @@ class ReportIntakeService:
             if resolved is None:
                 return None
             if resolved.v2_doc is not None:
-                doc = resolved.v2_doc
-                return link_destination_urls(
-                    doc.long_url,
-                    geo_rules=doc.geo_rules,
-                    pre_start_url=doc.pre_start_url,
-                )
+                return link_destination_urls_for(resolved.v2_doc)
             return link_destination_urls(str((resolved.raw_v1 or {}).get("url") or ""))
         doc = await self._url_repo.find_by_alias(code, domain)
         if doc is None:
             return None
-        return link_destination_urls(
-            doc.long_url, geo_rules=doc.geo_rules, pre_start_url=doc.pre_start_url
-        )
+        return link_destination_urls_for(doc)
 
     async def _enqueue_safety_analysis(
         self, accepted: list[tuple[str | None, str, ReportItemRequest, list[str]]]

--- a/services/safety/hot.py
+++ b/services/safety/hot.py
@@ -14,7 +14,11 @@ from repositories.verdict_repository import VerdictRepository
 from services.click.consumers.hotness import HotUrl
 from services.safety.events import SafetyAnalyzeEvent
 from services.safety.sinks import SafetySink
-from shared.url_utils import link_destination_urls, parse_destination
+from shared.url_utils import (
+    link_destination_urls,
+    link_destination_urls_for,
+    parse_destination,
+)
 
 log = get_logger(__name__)
 
@@ -77,12 +81,10 @@ class HotLinkScreen:
             )
 
     async def _destinations(self, hot: HotUrl) -> list[str]:
-        """Every destination the link routes to: main, geo overrides, pre-start page."""
+        """Every destination the link routes to: main, geo overrides, both fallbacks."""
         domain = self._system_domain if hot.domain in ("default", "") else hot.domain
         doc = await self._url_repo.find_by_alias(hot.short_code, domain)
         if doc is not None:
-            return link_destination_urls(
-                doc.long_url, geo_rules=doc.geo_rules, pre_start_url=doc.pre_start_url
-            )
+            return link_destination_urls_for(doc)
         legacy = await self._legacy_repo.find_by_id(hot.short_code)
         return link_destination_urls(legacy.url) if legacy is not None else []

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -99,7 +99,11 @@ from shared.emoji_policy import (
 )
 from shared.generators import generate_emoji_alias_v2, generate_short_code_v2
 from shared.reserved_aliases import is_reserved_alias
-from shared.url_utils import extract_hostname, link_destination_urls, parse_destination
+from shared.url_utils import (
+    extract_hostname,
+    link_destination_urls_for,
+    parse_destination,
+)
 from shared.validators import (
     validate_alias,
     validate_blocked_url,
@@ -1065,11 +1069,7 @@ class UrlService:
         # One record per registrable domain: the counters key on the domain,
         # so fifty geo paths on one host must not read as a fifty-link burst.
         counted: set[str] = set()
-        for destination in link_destination_urls(
-            request.long_url,
-            geo_rules=request.geo_rules,
-            pre_start_url=request.pre_start_url or None,
-        ):
+        for destination in link_destination_urls_for(request):
             parts = parse_destination(destination)
             domain = parts["registrable_domain"] if parts else destination
             if domain in counted:

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -32,6 +32,7 @@ from errors import (
     AppError,
     BlockedUrlError,
     ConflictError,
+    ExpiredRedirectError,
     ForbiddenError,
     GoneError,
     NotFoundError,
@@ -333,6 +334,21 @@ async def _handle_status(
         ops["status"] = request.status
 
 
+async def _handle_expired_redirect_url(
+    request: UpdateUrlRequest, existing: UrlV2Doc, ops: dict, service: UrlService
+) -> None:
+    if "expired_redirect_url" not in request.model_fields_set:
+        return
+    if not request.expired_redirect_url:
+        if existing.expired_redirect_url:
+            ops["expired_redirect_url"] = None
+        return
+    if request.expired_redirect_url == existing.expired_redirect_url:
+        return
+    await service.check_expired_redirect_url(request.expired_redirect_url)
+    ops["expired_redirect_url"] = request.expired_redirect_url
+
+
 async def _handle_geo_rules(
     request: UpdateUrlRequest, existing: UrlV2Doc, ops: dict, service: UrlService
 ) -> None:
@@ -435,6 +451,7 @@ FIELD_HANDLERS: dict[str, Callable[..., Awaitable[None]]] = {
     "status": _handle_status,
     "geo_rules": _handle_geo_rules,
     "tag_ids": _handle_tag_ids,
+    "expired_redirect_url": _handle_expired_redirect_url,
     # Must follow long_url — the handler validates against ops["long_url"]
     # when the destination changes in the same request.
     "meta_tags": _handle_meta_tags,
@@ -592,7 +609,7 @@ class UrlService:
                     schema=schema,
                     source="cache",
                 )
-                _raise_for_status(cached.url_status)
+                _raise_for_status(cached)
             await self._raise_if_time_expired(cached, schema, short_code, "cache")
             _raise_if_not_yet_live(cached, short_code, "cache")
             if should_sample("cache_operation"):
@@ -633,7 +650,7 @@ class UrlService:
                 schema=schema,
                 source="db",
             )
-            _raise_for_status(url_cache_data.url_status)
+            _raise_for_status(url_cache_data)
 
         # 4b. Raise for v1 URLs whose max-clicks have been exhausted
         if (
@@ -694,6 +711,8 @@ class UrlService:
                     event = build_link_expired(doc, "time_expired")
                     if event is not None:
                         await self._events.emit(event)
+        if data.expired_redirect_url:
+            raise ExpiredRedirectError(data.expired_redirect_url)
         raise GoneError("URL has expired (expiration time reached)")
 
     async def check_alias_available(
@@ -820,6 +839,15 @@ class UrlService:
             return meta.model_copy(update={"image": ingested.url}), ingested.image_meta
         return meta, None
 
+    async def check_expired_redirect_url(self, url: str) -> None:
+        """The fallback is a destination: it passes the same gate as long_url."""
+        rejection = await self._url_policy.check(url)
+        if rejection is not None:
+            log.info("url_expired_fallback_rejected", reason=rejection.code)
+            raise ValidationError(
+                rejection.public_message, field="expired_redirect_url"
+            )
+
     async def validate_meta_tags(self, meta: MetaTagsRequest, *, long_url: str) -> None:
         """Abuse checks for a meta_tags write.
 
@@ -907,6 +935,8 @@ class UrlService:
                     raise ValidationError(
                         geo_rejection.public_message, field=f"geo_rules.{geo_code}"
                     )
+        if request.expired_redirect_url:
+            await self.check_expired_redirect_url(request.expired_redirect_url)
         # Meta-tags: resolve data-URI uploads to R2 URLs, then run abuse
         # checks (the route layer already gated the feature itself).
         meta_req = request.meta_tags
@@ -987,6 +1017,7 @@ class UrlService:
                 request.long_url,
                 geo_rules=request.geo_rules,
                 pre_start_url=request.pre_start_url or None,
+                expired_redirect_url=request.expired_redirect_url or None,
             ),
             password=password_hash,
             block_bots=request.block_bots,
@@ -996,6 +1027,7 @@ class UrlService:
             pre_start_url=request.pre_start_url or None,
             geo_rules=request.geo_rules or None,
             tag_ids=tag_ids,
+            expired_redirect_url=request.expired_redirect_url or None,
             status=UrlStatus.ACTIVE,
             private_stats=private_stats,
             total_clicks=0,
@@ -1065,6 +1097,7 @@ class UrlService:
             domain=target_domain,
             geo_rules=len(request.geo_rules or {}),
             tags=len(tag_ids),
+            has_expired_fallback=bool(request.expired_redirect_url),
             has_meta_tags=bool(request.meta_tags),
         )
 
@@ -1207,11 +1240,19 @@ class UrlService:
             )
 
         # Any destination change re-stamps dest, secondary hosts included.
-        if {"long_url", "geo_rules", "pre_start_url"} & update_ops.keys():
+        if {
+            "long_url",
+            "geo_rules",
+            "pre_start_url",
+            "expired_redirect_url",
+        } & update_ops.keys():
             dest = UrlDestination.for_link(
                 update_ops.get("long_url", existing.long_url),
                 geo_rules=update_ops.get("geo_rules", existing.geo_rules),
                 pre_start_url=update_ops.get("pre_start_url", existing.pre_start_url),
+                expired_redirect_url=update_ops.get(
+                    "expired_redirect_url", existing.expired_redirect_url
+                ),
             )
             update_ops["dest"] = dest.to_doc() if dest else None
 
@@ -1835,9 +1876,11 @@ class UrlService:
 # ── Module-level helpers ──────────────────────────────────────────────────────
 
 
-def _raise_for_status(status: UrlStatus) -> None:
-    if status == UrlStatus.BLOCKED:
+def _raise_for_status(data: UrlCacheData) -> None:
+    if data.url_status == UrlStatus.BLOCKED:
         raise BlockedUrlError("URL is blocked")
+    if data.url_status == UrlStatus.EXPIRED and data.expired_redirect_url:
+        raise ExpiredRedirectError(data.expired_redirect_url)
     raise GoneError("URL has expired or is no longer active")
 
 

--- a/shared/url_utils.py
+++ b/shared/url_utils.py
@@ -95,10 +95,12 @@ def link_destination_urls(
     geo_rules: dict[str, str] | None = None,
     variants: Iterable[str] | None = None,
     pre_start_url: str | None = None,
+    expired_redirect_url: str | None = None,
 ) -> list[str]:
     """Every URL a link can send a visitor to: the main destination, geo
-    overrides, A/B variants, and the pre-start page a scheduled link shows
-    before it goes live. Distinct, first occurrence kept."""
+    overrides, A/B variants, the pre-start page a scheduled link shows before
+    it goes live, and the page an expired link falls back to. Distinct, first
+    occurrence kept."""
     seen: set[str] = set()
     out: list[str] = []
     for url in (
@@ -106,6 +108,7 @@ def link_destination_urls(
         *(geo_rules or {}).values(),
         *(variants or ()),
         pre_start_url,
+        expired_redirect_url,
     ):
         if isinstance(url, str) and url and url not in seen:
             seen.add(url)

--- a/shared/url_utils.py
+++ b/shared/url_utils.py
@@ -89,6 +89,27 @@ def parse_destination(url: str | None) -> dict | None:
     }
 
 
+# Single-URL fields besides long_url that send visitors somewhere. The Mongo
+# pipelines and the backfill derive their field lists from this tuple.
+SINGLE_DESTINATION_FIELDS: tuple[str, ...] = ("pre_start_url", "expired_redirect_url")
+
+
+def link_destination_urls_for(link: object) -> list[str]:
+    """Every URL a doc or request routes to, read off its fields.
+
+    The one place that knows which fields hold destinations. Readers that
+    enumerate by keyword drift the moment a field is added; they call this.
+    """
+    return link_destination_urls(
+        getattr(link, "long_url", None),
+        geo_rules=getattr(link, "geo_rules", None),
+        **{
+            field: getattr(link, field, None) or None
+            for field in SINGLE_DESTINATION_FIELDS
+        },
+    )
+
+
 def link_destination_urls(
     long_url: str | None,
     *,

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -63,6 +63,32 @@
                 <span class="url-label">Short URL:</span>
                 <div class="short-url">{{ short_url }}</div>
             </div>
+            {% if expired_destination %}
+            <div class="geo-banner">
+                <i class="ti ti-clock-off"></i>
+                This link has ended. Visitors are sent to the address below instead of the original destination.
+            </div>
+            <div class="url-display destination">
+                <span class="url-label">Visitors now go to:</span>
+                <div class="long-url">
+                    <div class="url-content">
+                        <div class="url-header">
+                            <img src="https://www.google.com/s2/favicons?domain={{ expired_destination.domain }}&sz=32" class="favicon"
+                                alt="favicon" onerror="this.style.display='none'">
+                            <span class="full-url">
+                                <span class="domain-name">{{ expired_destination.domain }}</span><span class="url-path">{{ expired_destination.path }}</span>
+                            </span>
+                            {% if expired_destination.is_https %}
+                            <span class="https-badge">
+                                <i class="ti ti-lock"></i>
+                                HTTPS
+                            </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
             {% if geo_destinations %}
             <div class="geo-banner">
                 <i class="ti ti-world"></i>
@@ -70,7 +96,7 @@
             </div>
             {% endif %}
             <div class="url-display destination">
-                <span class="url-label">{% if geo_destinations %}Default destination:{% else %}Redirects to:{% endif %}</span>
+                <span class="url-label">{% if expired_destination %}Original destination:{% elif geo_destinations %}Default destination:{% else %}Redirects to:{% endif %}</span>
                 <div class="long-url">
                     <div class="url-content">
                         <div class="url-header">

--- a/tests/integration/api_v1/test_management.py
+++ b/tests/integration/api_v1/test_management.py
@@ -310,6 +310,55 @@ class TestUpdateUrlGeoRules:
         assert resp.status_code == 403
         mock_svc.update.assert_not_called()
 
+    def test_set_expired_fallback_flag_off_returns_403(self):
+        user = _make_user()
+        mock_svc = AsyncMock()
+
+        application = self._app(user, mock_svc, self._flag_svc(False))
+        with TestClient(application, raise_server_exceptions=False) as client:
+            resp = client.patch(
+                f"/api/v1/urls/{ObjectId()}",
+                json={"expired_redirect_url": "https://example.com/ended"},
+            )
+
+        assert resp.status_code == 403
+        mock_svc.update.assert_not_called()
+
+    def test_set_expired_fallback_flag_on_returns_200(self):
+        user = _make_user()
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.expired_redirect_url = "https://example.com/ended"
+        url_doc.updated_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        mock_svc = AsyncMock()
+        mock_svc.update = AsyncMock(return_value=url_doc)
+
+        application = self._app(user, mock_svc, self._flag_svc(True))
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.patch(
+                f"/api/v1/urls/{ObjectId()}",
+                json={"expired_redirect_url": "https://example.com/ended"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["expired_redirect_url"] == "https://example.com/ended"
+
+    def test_clear_expired_fallback_bypasses_flag(self):
+        user = _make_user()
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.updated_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        mock_svc = AsyncMock()
+        mock_svc.update = AsyncMock(return_value=url_doc)
+        flag_svc = self._flag_svc(False)
+
+        application = self._app(user, mock_svc, flag_svc)
+        with TestClient(application, raise_server_exceptions=True) as client:
+            resp = client.patch(
+                f"/api/v1/urls/{ObjectId()}", json={"expired_redirect_url": None}
+            )
+
+        assert resp.status_code == 200
+        flag_svc.require.assert_not_awaited()
+
     def test_clear_geo_rules_bypasses_flag(self):
         """Rollback posture: a de-allowlisted owner must be able to remove
         their rules, so null-clear never consults the flag."""

--- a/tests/integration/api_v1/test_public_preview.py
+++ b/tests/integration/api_v1/test_public_preview.py
@@ -117,6 +117,7 @@ def test_v2_active_plain_full_body():
             "is_https": True,
         },
         "geo_destinations": None,
+        "expired_destination": None,
     }
 
 
@@ -223,6 +224,32 @@ def test_v2_active_with_past_expire_after_reads_expired():
     assert body["destination"] is None
 
 
+def test_v2_expired_with_fallback_names_where_visitors_go():
+    doc = _make_v2(
+        max_clicks=5,
+        total_clicks=5,
+        expired_redirect_url="https://ended.example/bye?x=1",
+    )
+    body = _get(_make_service(v2_docs=(doc,)), "testme").json()
+
+    assert body["status"] == "expired"
+    assert body["destination"] is None
+    assert body["expired_destination"] == {
+        "url": "https://ended.example/bye?x=1",
+        "domain": "ended.example",
+        "path": "/bye?x=1",
+        "is_https": True,
+    }
+
+
+def test_v2_active_with_fallback_keeps_it_out_of_the_preview():
+    doc = _make_v2(expired_redirect_url="https://ended.example/bye")
+    body = _get(_make_service(v2_docs=(doc,)), "testme").json()
+
+    assert body["status"] == "active"
+    assert body["expired_destination"] is None
+
+
 def test_v2_active_with_max_clicks_reached_reads_expired():
     doc = _make_v2(max_clicks=5, total_clicks=5)
     resp = _get(_make_service(v2_docs=(doc,)), "testme")
@@ -258,6 +285,7 @@ def test_v1_active_full_body():
             "is_https": True,
         },
         "geo_destinations": None,
+        "expired_destination": None,
     }
 
 

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -708,6 +708,32 @@ def test_v2_active_with_past_expire_after_reports_expired_and_hides_long_url():
     assert link["long_url"] is None
 
 
+def test_v2_expired_with_fallback_names_where_visitors_go():
+    doc = _make_v2_doc(
+        alias="capped2",
+        max_clicks=5,
+        total_clicks=5,
+        expired_redirect_url="https://ended.example/bye",
+    )
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service) as client:
+        link = client.get(_url("capped2")).json()["link"]
+
+    assert link["status"] == "expired"
+    assert link["long_url"] is None
+    assert link["expired_redirect_url"] == "https://ended.example/bye"
+
+
+def test_v2_active_with_fallback_keeps_it_off_the_stats_page():
+    doc = _make_v2_doc(alias="live1", expired_redirect_url="https://ended.example/bye")
+    service, _ = _build_service(v2_docs=[doc])
+    with _client(service) as client:
+        link = client.get(_url("live1")).json()["link"]
+
+    assert link["status"] == "active"
+    assert link["expired_redirect_url"] is None
+
+
 def test_v2_active_with_max_clicks_reached_reports_expired():
     doc = _make_v2_doc(alias="capped1", max_clicks=5, total_clicks=5)
     service, _ = _build_service(v2_docs=[doc])

--- a/tests/integration/api_v1/test_reports.py
+++ b/tests/integration/api_v1/test_reports.py
@@ -751,6 +751,29 @@ def test_reported_link_enqueues_every_destination_including_geo_rules():
     ]
 
 
+def test_reported_link_enqueues_the_after_expiry_fallback_too():
+    """A phish parked in the fallback of an expired link must be judged."""
+    doc = _make_v2_doc("fall123")
+    doc.long_url = "https://clean.example/"
+    doc.expired_redirect_url = "https://hidden.example/ended"
+    sink = _CapturingSafetySink()
+    service, _, _ = _build_service(v2_docs=[doc], safety_sink=sink)
+
+    with _client(service) as c:
+        resp = c.post(
+            _URL, json={"items": [{"code_or_url": "fall123", "reason": "phishing"}]}
+        )
+    assert resp.status_code == 200
+
+    by_host = {e.host: e for e in sink.events}
+    assert set(by_host) == {"clean.example", "hidden.example"}
+    assert by_host["hidden.example"].url == "https://hidden.example/ended"
+    assert by_host["hidden.example"].context["link_destinations"] == [
+        "https://clean.example/",
+        "https://hidden.example/ended",
+    ]
+
+
 def test_links_sharing_a_host_keep_every_links_destinations():
     """Two reported links land on one host event; the bundle must still see
     the geo destinations of BOTH, not only the first link's."""

--- a/tests/integration/api_v1/test_shorten.py
+++ b/tests/integration/api_v1/test_shorten.py
@@ -428,6 +428,75 @@ class TestCheckAliasWithCustomDomain:
         assert kwargs.get("domain") is None
 
 
+class TestShortenExpiredFallback:
+    """expired_redirect_url is authed-only and gated by the expired_fallback flag."""
+
+    BODY: typing.ClassVar[dict] = {
+        "long_url": "https://example.com",
+        "expired_redirect_url": "https://example.com/ended",
+    }
+
+    @staticmethod
+    def _flag_svc(enabled: bool) -> AsyncMock:
+        svc = AsyncMock()
+        svc.require = AsyncMock(
+            side_effect=None
+            if enabled
+            else ForbiddenError("Expired fallback is not enabled for this account")
+        )
+        return svc
+
+    def _app(self, user, mock_svc, flag_svc):
+        from dependencies import get_feature_flag_service
+
+        return _build_test_app(
+            {
+                get_current_user: lambda: user,
+                get_url_service: lambda: mock_svc,
+                get_feature_flag_service: lambda: flag_svc,
+            }
+        )
+
+    def test_anonymous_returns_401(self):
+        mock_svc = AsyncMock()
+        flag_svc = self._flag_svc(True)
+        with TestClient(
+            self._app(None, mock_svc, flag_svc), raise_server_exceptions=False
+        ) as client:
+            resp = client.post("/api/v1/shorten", json=self.BODY)
+
+        assert resp.status_code == 401
+        mock_svc.create.assert_not_called()
+        flag_svc.require.assert_not_awaited()
+
+    def test_flag_off_returns_403(self):
+        mock_svc = AsyncMock()
+        with TestClient(
+            self._app(_make_user(), mock_svc, self._flag_svc(False)),
+            raise_server_exceptions=False,
+        ) as client:
+            resp = client.post("/api/v1/shorten", json=self.BODY)
+
+        assert resp.status_code == 403
+        mock_svc.create.assert_not_called()
+
+    def test_flag_on_returns_201_and_echoes_field(self):
+        user = _make_user()
+        url_doc = _make_url_doc(owner_id=user.user_id)
+        url_doc.expired_redirect_url = "https://example.com/ended"
+        mock_svc = AsyncMock()
+        mock_svc.create = AsyncMock(return_value=(url_doc, None))
+
+        with TestClient(
+            self._app(user, mock_svc, self._flag_svc(True)),
+            raise_server_exceptions=True,
+        ) as client:
+            resp = client.post("/api/v1/shorten", json=self.BODY)
+
+        assert resp.status_code == 201
+        assert resp.json()["expired_redirect_url"] == "https://example.com/ended"
+
+
 class TestShortenGeoRules:
     """geo_rules is authed-only and gated by the geo_targeting feature flag."""
 

--- a/tests/integration/test_cache_resilience.py
+++ b/tests/integration/test_cache_resilience.py
@@ -134,6 +134,7 @@ def _make_v2_doc_mock(
     doc.pre_start_url = None
     doc.max_clicks = None
     doc.geo_rules = None
+    doc.expired_redirect_url = None
     doc.status = status
     doc.owner_id = ObjectId("000000000000000000000001")
     doc.total_clicks = 0

--- a/tests/integration/test_redirect.py
+++ b/tests/integration/test_redirect.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from dependencies import get_click_sink, get_url_service
 from errors import (
     BlockedUrlError,
+    ExpiredRedirectError,
     ForbiddenError,
     GoneError,
     NotFoundError,
@@ -282,6 +283,32 @@ def test_redirect_expired_url():
 
     assert resp.status_code == 410
     assert "text/html" in resp.headers.get("content-type", "")
+
+
+def test_redirect_expired_with_fallback_302s_and_records_no_click():
+    """resolve raises ExpiredRedirectError -> 302 to the owner's fallback,
+    uncacheable, and the click sink never hears about it."""
+    mock_url_svc = AsyncMock()
+    mock_url_svc.resolve = AsyncMock(
+        side_effect=ExpiredRedirectError("https://fallback.example/ended")
+    )
+    mock_click_sink = AsyncMock()
+
+    app = build_test_app(
+        redirect_router,
+        overrides={
+            get_url_service: lambda: mock_url_svc,
+            get_click_sink: lambda: mock_click_sink,
+        },
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/abc123", follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "https://fallback.example/ended"
+    assert resp.headers["Cache-Control"] == "no-store"
+    assert resp.headers["X-Robots-Tag"] == "noindex, nofollow, noarchive"
+    mock_click_sink.emit.assert_not_awaited()
 
 
 def test_redirect_inactive_url():

--- a/tests/unit/infrastructure/test_cache.py
+++ b/tests/unit/infrastructure/test_cache.py
@@ -137,6 +137,7 @@ class TestUrlCacheDataMetaFields:
         assert data.meta_color is None
         assert data.meta_image_width is None
         assert data.meta_image_height is None
+        assert data.expired_redirect_url is None
 
     def test_meta_fields_roundtrip_json(self):
         from infrastructure.cache.url_cache import UrlCacheData

--- a/tests/unit/repositories/test_url_repository.py
+++ b/tests/unit/repositories/test_url_repository.py
@@ -925,5 +925,10 @@ class TestSweepSampleUrls:
         assert urls[1]["$map"]["input"] == {
             "$objectToArray": {"$ifNull": ["$geo_rules", {}]}
         }
-        assert urls[2]["$cond"][1] == ["$pre_start_url"]
+        # One arm per single-URL destination field, in the shared list's order:
+        # a field missing here is a sweep that samples the wrong URL.
+        from shared.url_utils import SINGLE_DESTINATION_FIELDS
+
+        arms = [arm["$cond"][1] for arm in urls[2:]]
+        assert arms == [[f"${field}"] for field in SINGLE_DESTINATION_FIELDS]
         assert pipeline[3]["$group"]["urls"] == {"$first": "$urls"}

--- a/tests/unit/schemas/dto/test_url.py
+++ b/tests/unit/schemas/dto/test_url.py
@@ -83,6 +83,22 @@ class TestCreateUrlRequest:
         assert req.max_clicks == 100
 
 
+class TestCreateUrlRequestExpiredRedirectUrl:
+    def test_defaults_none(self):
+        assert CreateUrlRequest(long_url="https://x.com").expired_redirect_url is None
+
+    def test_accepts_url(self):
+        req = CreateUrlRequest(
+            long_url="https://x.com", expired_redirect_url="https://y.com/ended"
+        )
+        assert req.expired_redirect_url == "https://y.com/ended"
+
+    def test_update_null_lands_in_fields_set(self):
+        req = UpdateUrlRequest.model_validate({"expired_redirect_url": None})
+        assert "expired_redirect_url" in req.model_fields_set
+        assert req.expired_redirect_url is None
+
+
 class TestCreateUrlRequestAliasShape:
     """DTO-level alias gate: structural failures are 422; the emoji
     *policy* (qualification/version/grapheme caps) is service-enforced."""

--- a/tests/unit/schemas/models/test_url.py
+++ b/tests/unit/schemas/models/test_url.py
@@ -495,6 +495,15 @@ class TestUrlDestinationSecondaryHosts:
         assert dest is not None
         assert dest.secondary_hosts == ["v2.example"]
 
+    def test_expired_fallback_host_is_a_secondary_host(self):
+        dest = UrlDestination.for_link(
+            "https://main.example/",
+            geo_rules={"IN": "https://geo.example/"},
+            expired_redirect_url="https://fallback.example/ended",
+        )
+        assert dest is not None
+        assert dest.secondary_hosts == ["fallback.example", "geo.example"]
+
     def test_geo_hosts_survive_an_unparseable_main_destination(self):
         dest = UrlDestination.for_link(
             "nonsense", geo_rules={"IN": "https://geo.example/"}

--- a/tests/unit/scripts/test_backfill_url_dest.py
+++ b/tests/unit/scripts/test_backfill_url_dest.py
@@ -35,6 +35,18 @@ def test_secondary_hosts_mirror_the_shared_helper():
     assert backfill.secondary_urls({"geo_rules": None, "pre_start_url": None}) == []
 
 
+def test_single_destination_fields_mirror_the_shared_list():
+    from shared.url_utils import SINGLE_DESTINATION_FIELDS
+
+    assert backfill.SINGLE_DESTINATION_FIELDS == SINGLE_DESTINATION_FIELDS
+    assert backfill.secondary_urls(
+        {"expired_redirect_url": "https://ended.example/bye"}
+    ) == ["https://ended.example/bye"]
+    assert {"expired_redirect_url": {"$type": "string"}} in backfill._SECONDARY_FILTER[
+        "$and"
+    ][0]["$or"]
+
+
 def test_secondary_fields_are_index_aligned():
     fields = backfill.secondary_fields(
         ["https://shop.evil.co.uk/x", "https://a.evil.com/y"], "main.example"
@@ -97,6 +109,7 @@ def test_backfill_secondary_stamps_and_reports(capsys):
         "_id": 1,
         "geo_rules": {"IN": "https://geo.example/"},
         "pre_start_url": None,
+        "expired_redirect_url": None,
         "dest.host": "main.example",
         "dest.secondary_registrable": {"$exists": False},
     }

--- a/tests/unit/services/safety/test_hot.py
+++ b/tests/unit/services/safety/test_hot.py
@@ -130,3 +130,16 @@ class TestHotLinkScreenSecondaryDestinations:
         await screen.on_hot(_hot())
         hosts = [c.args[0].host for c in sink.emit.await_args_list]
         assert hosts == ["clean.example", "teaser.example"]
+
+    @pytest.mark.asyncio
+    async def test_after_expiry_destination_is_screened_too(self):
+        doc = MagicMock(
+            long_url="https://clean.example/",
+            geo_rules=None,
+            pre_start_url=None,
+            expired_redirect_url="https://ended.example/bye",
+        )
+        screen, _u, sink = _screen(v2_doc=doc)
+        await screen.on_hot(_hot())
+        hosts = [c.args[0].host for c in sink.emit.await_args_list]
+        assert hosts == ["clean.example", "ended.example"]

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -2401,6 +2401,20 @@ class TestUrlServiceExpiredFallback:
 
         url_repo.update.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_create_counts_the_fallback_in_l1(self):
+        svc, _, _ = self._svc()
+        svc._url_policy.record_create = AsyncMock()
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com", expired_redirect_url=self.FALLBACK
+        )
+        await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        recorded = [c.args[0] for c in svc._url_policy.record_create.await_args_list]
+        assert recorded == ["https://example.com", self.FALLBACK]
+
     def test_cache_projection_carries_fallback(self):
         doc = make_url_v2_doc(expired_redirect_url=self.FALLBACK)
         assert UrlCacheData.from_v2_doc(doc).expired_redirect_url == self.FALLBACK

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -20,6 +20,7 @@ from errors import (
     AppError,
     BlockedUrlError,
     ConflictError,
+    ExpiredRedirectError,
     ForbiddenError,
     GoneError,
     NotFoundError,
@@ -61,6 +62,7 @@ def make_url_v2_doc(
     starts_at: datetime | None = None,
     pre_start_url: str | None = None,
     tag_ids: list | None = None,
+    expired_redirect_url: str | None = None,
 ) -> UrlV2Doc:
     return UrlV2Doc.from_mongo(
         {
@@ -78,6 +80,7 @@ def make_url_v2_doc(
             "starts_at": starts_at,
             "pre_start_url": pre_start_url,
             "geo_rules": geo_rules,
+            "expired_redirect_url": expired_redirect_url,
             "status": status,
             "private_stats": True,
             "total_clicks": 0,
@@ -2288,6 +2291,169 @@ class TestGeoRulesFeatureGate:
             await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
         assert exc.value.field == "geo_rules"
         url_repo.insert.assert_not_awaited()
+
+
+class TestUrlServiceExpiredFallback:
+    """expired_redirect_url: validated like a destination, stamped as a
+    secondary host, and served instead of 410 once the link is EXPIRED."""
+
+    FALLBACK = "https://fallback.example/ended"
+
+    def _svc(self, patterns=()):
+        url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache = make_repos()
+        svc = make_service(
+            url_repo, legacy_repo, emoji_repo, blocked_url_repo, url_cache
+        )
+        blocked_url_repo.get_patterns.return_value = list(patterns)
+        url_repo.check_alias_exists.return_value = False
+        url_repo.insert.return_value = URL_OID
+        return svc, url_repo, url_cache
+
+    @pytest.mark.asyncio
+    async def test_create_persists_fallback_and_stamps_its_host(self):
+        svc, url_repo, _ = self._svc()
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com", expired_redirect_url=self.FALLBACK
+        )
+        result, _ = await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+
+        assert result.expired_redirect_url == self.FALLBACK
+        inserted = url_repo.insert.call_args[0][0]
+        assert inserted["expired_redirect_url"] == self.FALLBACK
+        assert inserted["dest"]["secondary_hosts"] == ["fallback.example"]
+
+    @pytest.mark.asyncio
+    async def test_create_blocked_fallback_rejected_with_field_path(self):
+        svc, url_repo, _ = self._svc(patterns=[r"https://evil\.com"])
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com",
+            expired_redirect_url="https://evil.com/landing",
+        )
+        with pytest.raises(ValidationError) as exc:
+            await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+        assert exc.value.field == "expired_redirect_url"
+        url_repo.insert.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_self_link_fallback_rejected(self):
+        svc, _, _ = self._svc()
+        from schemas.dto.requests.url import CreateUrlRequest
+
+        req = CreateUrlRequest(
+            long_url="https://example.com",
+            expired_redirect_url="https://spoo.me/other",
+        )
+        with pytest.raises(ValidationError) as exc:
+            await svc.create(req, owner_id=USER_OID, client_ip="1.2.3.4")
+        assert exc.value.field == "expired_redirect_url"
+
+    @pytest.mark.asyncio
+    async def test_update_sets_fallback_and_restamps_dest(self):
+        svc, url_repo, url_cache = self._svc()
+        url_repo.find_by_id.return_value = make_url_v2_doc()
+        url_repo.update.return_value = True
+
+        req = UpdateUrlRequest(expired_redirect_url=self.FALLBACK)
+        await svc.update(URL_OID, req, USER_OID)
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert update_doc["$set"]["expired_redirect_url"] == self.FALLBACK
+        assert update_doc["$set"]["dest"]["secondary_hosts"] == ["fallback.example"]
+        url_cache.invalidate.assert_called_once_with(ALIAS, SYSTEM_DEFAULT_DOMAIN)
+
+    @pytest.mark.asyncio
+    async def test_update_blocked_fallback_rejected(self):
+        svc, url_repo, _ = self._svc(patterns=[r"https://evil\.com"])
+        url_repo.find_by_id.return_value = make_url_v2_doc()
+
+        req = UpdateUrlRequest(expired_redirect_url="https://evil.com/x")
+        with pytest.raises(ValidationError) as exc:
+            await svc.update(URL_OID, req, USER_OID)
+        assert exc.value.field == "expired_redirect_url"
+        url_repo.update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_null_clears_fallback_and_its_host(self):
+        svc, url_repo, _ = self._svc()
+        url_repo.find_by_id.return_value = make_url_v2_doc(
+            expired_redirect_url=self.FALLBACK
+        )
+        url_repo.update.return_value = True
+
+        req = UpdateUrlRequest.model_validate({"expired_redirect_url": None})
+        await svc.update(URL_OID, req, USER_OID)
+
+        update_doc = url_repo.update.call_args[0][1]
+        assert update_doc["$set"]["expired_redirect_url"] is None
+        assert "secondary_hosts" not in update_doc["$set"]["dest"]
+
+    @pytest.mark.asyncio
+    async def test_update_null_on_unset_fallback_is_a_noop(self):
+        svc, url_repo, _ = self._svc()
+        url_repo.find_by_id.return_value = make_url_v2_doc()
+
+        req = UpdateUrlRequest.model_validate({"expired_redirect_url": None})
+        await svc.update(URL_OID, req, USER_OID)
+
+        url_repo.update.assert_not_awaited()
+
+    def test_cache_projection_carries_fallback(self):
+        doc = make_url_v2_doc(expired_redirect_url=self.FALLBACK)
+        assert UrlCacheData.from_v2_doc(doc).expired_redirect_url == self.FALLBACK
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_expired_with_fallback_raises_redirect(self):
+        svc, _, url_cache = self._svc()
+        url_cache.get.return_value = make_active_cache(url_status="EXPIRED").model_copy(
+            update={"expired_redirect_url": self.FALLBACK}
+        )
+
+        with pytest.raises(ExpiredRedirectError) as exc:
+            await svc.resolve(ALIAS)
+        assert exc.value.redirect_url == self.FALLBACK
+        assert isinstance(exc.value, GoneError)
+
+    @pytest.mark.asyncio
+    async def test_inactive_never_uses_the_fallback(self):
+        svc, _, url_cache = self._svc()
+        url_cache.get.return_value = make_active_cache(
+            url_status="INACTIVE"
+        ).model_copy(update={"expired_redirect_url": self.FALLBACK})
+
+        with pytest.raises(GoneError) as exc:
+            await svc.resolve(ALIAS)
+        assert not isinstance(exc.value, ExpiredRedirectError)
+
+    @pytest.mark.asyncio
+    async def test_time_expiry_with_fallback_flips_then_redirects(self):
+        svc, url_repo, url_cache = self._svc()
+        url_cache.get.return_value = make_active_cache(
+            expiration_time=int(time_module.time()) - 60
+        ).model_copy(update={"expired_redirect_url": self.FALLBACK})
+        url_repo.expire_if_time_reached.return_value = True
+
+        with pytest.raises(ExpiredRedirectError) as exc:
+            await svc.resolve(ALIAS)
+        assert exc.value.redirect_url == self.FALLBACK
+        url_repo.expire_if_time_reached.assert_awaited_once_with(URL_OID)
+        url_cache.invalidate.assert_awaited_once_with(ALIAS, SYSTEM_DEFAULT_DOMAIN)
+
+    @pytest.mark.asyncio
+    async def test_db_path_expired_with_fallback_raises_redirect(self):
+        svc, url_repo, url_cache = self._svc()
+        url_cache.get.return_value = None
+        url_repo.find_by_alias.return_value = make_url_v2_doc(
+            status="EXPIRED", expired_redirect_url=self.FALLBACK
+        )
+
+        with pytest.raises(ExpiredRedirectError) as exc:
+            await svc.resolve(ALIAS)
+        assert exc.value.redirect_url == self.FALLBACK
+        url_cache.set.assert_awaited_once()
 
 
 class TestUrlServiceGeoRules:

--- a/tests/unit/shared/test_url_utils.py
+++ b/tests/unit/shared/test_url_utils.py
@@ -175,3 +175,41 @@ class TestIsRegistrableApex:
 
     def test_bare_label_is_not_apex(self):
         assert is_registrable_apex("localhost") is False
+
+
+class TestLinkDestinationUrlsFor:
+    """The doc-shaped enumerator owns the field list; every reader uses it."""
+
+    def test_reads_every_destination_field_off_a_doc_shaped_object(self):
+        from types import SimpleNamespace
+
+        from shared.url_utils import (
+            SINGLE_DESTINATION_FIELDS,
+            link_destination_urls_for,
+        )
+
+        link = SimpleNamespace(
+            long_url="https://main.example/",
+            geo_rules={"IN": "https://geo.example/in"},
+            pre_start_url="https://teaser.example/soon",
+            expired_redirect_url="https://ended.example/bye",
+        )
+        assert link_destination_urls_for(link) == [
+            "https://main.example/",
+            "https://geo.example/in",
+            "https://teaser.example/soon",
+            "https://ended.example/bye",
+        ]
+        assert set(SINGLE_DESTINATION_FIELDS) == {
+            "pre_start_url",
+            "expired_redirect_url",
+        }
+
+    def test_missing_and_empty_fields_are_skipped(self):
+        from types import SimpleNamespace
+
+        from shared.url_utils import link_destination_urls_for
+
+        assert link_destination_urls_for(
+            SimpleNamespace(long_url="https://main.example/", expired_redirect_url="")
+        ) == ["https://main.example/"]

--- a/tests/unit/test_ab_testing_launch_guard.py
+++ b/tests/unit/test_ab_testing_launch_guard.py
@@ -27,7 +27,7 @@ Required before shipping them:
   3. stamp existing links: scripts/backfill_url_dest.py
   4. add the variant URLs to _ALL_URLS in repositories/url_repository.py so
      the sweeps sample a variant host's own URL (today: long_url, geo rules,
-     pre_start_url)
+     and every field in shared.url_utils.SINGLE_DESTINATION_FIELDS)
 """
 
 


### PR DESCRIPTION
## What

Owners can set `expired_redirect_url` on a link. Once the link has expired, by time or by click limit, the redirect answers 302 to that URL with `Cache-Control: no-store` instead of the 410 expired page. Blank keeps today's behaviour. INACTIVE and BLOCKED links never use it.

Dark behind the `expired_fallback` feature flag (a missing flag doc reads as off). Setting the field needs a signed-in account with the flag; clearing it never does. The flag is exposed on `GET /api/v1/me/features` so the frontend can show the field.

## Why

An expired link today dead-ends on our page. Owners running a promo or a limited drop want visitors to land on a page they control: sold out, the next offer, a waitlist. Short.io and Dub both offer this per link.

## How

- New `ExpiredRedirectError(GoneError)`, raised at the three places `resolve` finds a v2 link EXPIRED. Every existing `except GoneError` keeps working; only the redirect route catches the subclass first.
- The value passes the same policy gate as `long_url` (format, self-link, blocklist, feeds) and its host is stamped into `dest.secondary_hosts`, so enforcement, sweeps and report intake see it the way they see a geo host.
- A fallback hit records no click. The owner's limit was reached, and counting would push `total_clicks` past `max_clicks`. The route logs `url_expired_fallback` so the traffic stays countable.
- The edge cache never promotes links with `max_clicks` or `expire_after`, so there is nothing to purge when a link flips.
- Stacked on #342 because the secondary-hosts stamp lives there.

## Proof

- `uv run pytest`: 3756 passed, 5 skipped.
- Live against a throwaway database with the flag seeded:
  - link with `expire_after` three seconds out plus a fallback: 302 to the destination before, 302 to the fallback with `cache-control: no-store` after, from both the DB path and the cache path. Mongo shows `status: EXPIRED` and `dest.secondary_hosts: ["fallback.example"]`.
  - `max_clicks: 1` plus a fallback: click 1 goes to the destination, clicks 2 and 3 go to the fallback, `total_clicks` stays at 1.
  - fallback on a blocklisted host: 400 with `field: expired_redirect_url`. Self-link fallback: 400. Anonymous create with the field: 401. Flag off: 403.
  - PATCH set then clear: the secondary host appears on `dest` and disappears again.
- `openapi.json` regenerated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional expired-link fallback URLs for supported authenticated users.
  * Expired links can now redirect visitors to the configured fallback with a temporary redirect.
  * Added feature-flag visibility and controls for this capability.
  * URL responses now display the configured expired-link fallback.

* **Bug Fixes**
  * Expired-link fallback redirects are not cached or counted as clicks.
  * Clearing a fallback URL is supported when updating a link.

* **Tests**
  * Added coverage for validation, permissions, configuration, persistence, and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->