### PR TITLE
feat(webhooks): lag, pending depth and latency telemetry with dashboard

### DIFF
--- a/axiom/dashboards/spoo-webhooks.json
+++ b/axiom/dashboards/spoo-webhooks.json
@@ -1,8 +1,10 @@
 {
-  "name": "spoo · webhooks",
-  "description": "Webhook dispatch, delivery health, and endpoint lifecycle. Refresh 60s.",
+  "name": "spoo \u00b7 webhooks",
+  "description": "Webhook dispatch, consumer lag, pending depth, delivery latency and outcomes, endpoint lifecycle. Refresh 60s.",
   "owner": "X-AXIOM-EVERYONE",
-  "datasets": ["spoo-prod"],
+  "datasets": [
+    "spoo-prod"
+  ],
   "refreshTime": 60,
   "schemaVersion": 2,
   "timeWindowStart": "qr-now-6h",
@@ -34,10 +36,34 @@
     },
     {
       "id": "stat-p95-delivery",
-      "name": "p95 delivery (ms)",
+      "name": "p95 HTTP round trip (ms)",
       "type": "Statistic",
       "query": {
         "apl": "['spoo-prod']\n| where event == \"webhook_delivered\"\n| summarize p95 = percentile(duration_ms, 95)\n| project p95"
+      }
+    },
+    {
+      "id": "stat-consumer-lag",
+      "name": "Webhooks consumer lag (latest, both streams)",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"stream_group_stats\" and ['group'] == \"webhooks\"\n| summarize arg_max(_time, lag) by stream\n| summarize lag = sum(lag)\n| project lag"
+      }
+    },
+    {
+      "id": "stat-pending-depth",
+      "name": "Pending deliveries queued (latest)",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_pending_depth\"\n| summarize arg_max(_time, total_pending)\n| project total_pending"
+      }
+    },
+    {
+      "id": "stat-p95-latency",
+      "name": "p95 created to completed (ms)",
+      "type": "Statistic",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivered\" and is_test != true\n| summarize p95 = percentile(latency_ms, 95)\n| project p95"
       }
     },
     {
@@ -54,6 +80,38 @@
       "type": "TimeSeries",
       "query": {
         "apl": "['spoo-prod']\n| where event in (\"webhook_delivered\", \"webhook_delivery_attempt_failed\")\n| summarize count() by bin_auto(_time), event"
+      }
+    },
+    {
+      "id": "ts-consumer-lag",
+      "name": "Consumer lag on the webhooks group, by stream",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"stream_group_stats\" and ['group'] == \"webhooks\"\n| summarize max(lag) by bin_auto(_time), stream"
+      }
+    },
+    {
+      "id": "ts-pending-depth",
+      "name": "Pending depth: total queued and worst endpoint",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_pending_depth\"\n| summarize total = max(total_pending), worst_endpoint = max(max_pending) by bin_auto(_time)"
+      }
+    },
+    {
+      "id": "ts-latency-percentiles",
+      "name": "Delivery latency created to completed (ms)",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_delivered\" and is_test != true\n| summarize percentiles_array(latency_ms, 50, 95, 99) by bin_auto(_time)"
+      }
+    },
+    {
+      "id": "ts-outcomes-by-class",
+      "name": "Delivery outcomes by class",
+      "type": "TimeSeries",
+      "query": {
+        "apl": "['spoo-prod']\n| where event in (\"webhook_delivered\", \"webhook_delivery_failed\", \"webhook_delivery_rate_limited\", \"webhook_delivery_dropped_over_cap\") and is_test != true\n| extend outcome = case(event == \"webhook_delivered\", \"delivered\", event == \"webhook_delivery_failed\", strcat(\"failed:\", reason), event == \"webhook_delivery_rate_limited\", \"rate_limited\", \"dropped_over_cap\")\n| summarize count() by bin_auto(_time), outcome"
       }
     },
     {
@@ -89,6 +147,14 @@
       }
     },
     {
+      "id": "table-backlogged-endpoints",
+      "name": "Backlogged endpoints (latest pending depth)",
+      "type": "Table",
+      "query": {
+        "apl": "['spoo-prod']\n| where event == \"webhook_endpoint_depth\"\n| summarize pending = max(pending), last_seen = max(_time) by endpoint_id, status, user_id\n| sort by pending desc\n| take 10\n| project endpoint_id, pending, status, user_id, last_seen"
+      }
+    },
+    {
       "id": "table-slowest-endpoints",
       "name": "Slowest endpoints (p95 ms)",
       "type": "Table",
@@ -106,17 +172,145 @@
     }
   ],
   "layout": [
-    { "i": "stat-dispatched", "x": 0, "y": 0, "w": 3, "h": 2 },
-    { "i": "stat-delivered", "x": 3, "y": 0, "w": 3, "h": 2 },
-    { "i": "stat-delivery-success-rate", "x": 6, "y": 0, "w": 3, "h": 2 },
-    { "i": "stat-p95-delivery", "x": 9, "y": 0, "w": 3, "h": 2 },
-    { "i": "ts-dispatch-by-type", "x": 0, "y": 2, "w": 6, "h": 4 },
-    { "i": "ts-delivery-outcomes", "x": 6, "y": 2, "w": 6, "h": 4 },
-    { "i": "ts-attempt-failures-by-status", "x": 0, "y": 6, "w": 6, "h": 4 },
-    { "i": "ts-endpoints-disabled", "x": 6, "y": 6, "w": 6, "h": 4 },
-    { "i": "ts-drops-over-cap", "x": 0, "y": 10, "w": 6, "h": 4 },
-    { "i": "ts-pipeline-degradation", "x": 6, "y": 10, "w": 6, "h": 4 },
-    { "i": "table-slowest-endpoints", "x": 0, "y": 14, "w": 6, "h": 4 },
-    { "i": "table-failing-endpoints", "x": 6, "y": 14, "w": 6, "h": 4 }
+    {
+      "i": "stat-dispatched",
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "stat-delivered",
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "stat-delivery-success-rate",
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "stat-p95-delivery",
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "stat-consumer-lag",
+      "x": 0,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "stat-pending-depth",
+      "x": 4,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "stat-p95-latency",
+      "x": 8,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "ts-consumer-lag",
+      "x": 0,
+      "y": 4,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-pending-depth",
+      "x": 6,
+      "y": 4,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-latency-percentiles",
+      "x": 0,
+      "y": 8,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-outcomes-by-class",
+      "x": 6,
+      "y": 8,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-dispatch-by-type",
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-delivery-outcomes",
+      "x": 6,
+      "y": 12,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-attempt-failures-by-status",
+      "x": 0,
+      "y": 16,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-endpoints-disabled",
+      "x": 6,
+      "y": 16,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-drops-over-cap",
+      "x": 0,
+      "y": 20,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "ts-pipeline-degradation",
+      "x": 6,
+      "y": 20,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "table-backlogged-endpoints",
+      "x": 0,
+      "y": 24,
+      "w": 12,
+      "h": 4
+    },
+    {
+      "i": "table-slowest-endpoints",
+      "x": 0,
+      "y": 28,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "table-failing-endpoints",
+      "x": 6,
+      "y": 28,
+      "w": 6,
+      "h": 4
+    }
   ]
 }

--- a/axiom/monitors/webhook-endpoints-disabled.json
+++ b/axiom/monitors/webhook-endpoints-disabled.json
@@ -1,0 +1,14 @@
+{
+  "name": "Webhook endpoints auto-disabled",
+  "description": "Several subscriber endpoints were auto-disabled in a short window. One or two is normal churn; a spike points at our side (secret rotation, signing, SSRF policy) rather than theirs.",
+  "type": "Threshold",
+  "intervalMinutes": 5,
+  "rangeMinutes": 15,
+  "aplQuery": "['spoo-prod'] | where event == \"webhook_endpoint_disabled\" | summarize count() by bin(_time, 15m)",
+  "operator": "AboveOrEqual",
+  "threshold": 3,
+  "alertOnNoData": false,
+  "notifierIds": [
+    "xd9Sj0KGJ0e2TYPnl2"
+  ]
+}

--- a/axiom/monitors/webhooks-consumer-lag.json
+++ b/axiom/monitors/webhooks-consumer-lag.json
@@ -1,0 +1,14 @@
+{
+  "name": "Webhooks consumer lag",
+  "description": "The webhooks consumer group is falling behind on the click or domain stream: sustained lag means deliveries are being created late. Check the click worker is up and the executor is not saturated.",
+  "type": "Threshold",
+  "intervalMinutes": 5,
+  "rangeMinutes": 10,
+  "aplQuery": "['spoo-prod'] | where event == \"stream_group_stats\" and ['group'] == \"webhooks\" | summarize max(lag) by bin(_time, 5m)",
+  "operator": "AboveOrEqual",
+  "threshold": 5000,
+  "alertOnNoData": false,
+  "notifierIds": [
+    "xd9Sj0KGJ0e2TYPnl2"
+  ]
+}

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -42,6 +42,34 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
         ).to_list(length=None)
         return [WebhookEndpointDoc.from_mongo(d) for d in docs]
 
+    async def backlog_totals(self) -> tuple[int, int]:
+        """(endpoints with pending rows, pending rows across all of them)."""
+        cursor = await self._col.aggregate(
+            [
+                {"$match": {"pending_count": {"$gt": 0}}},
+                {
+                    "$group": {
+                        "_id": None,
+                        "endpoints": {"$sum": 1},
+                        "total": {"$sum": "$pending_count"},
+                    }
+                },
+            ]
+        )
+        rows = await cursor.to_list(length=1)
+        if not rows:
+            return 0, 0
+        return int(rows[0]["endpoints"]), int(rows[0]["total"])
+
+    async def find_backlogged(self, *, limit: int) -> list[WebhookEndpointDoc]:
+        docs = (
+            await self._col.find({"pending_count": {"$gt": 0}})
+            .sort("pending_count", -1)
+            .limit(limit)
+            .to_list(length=limit)
+        )
+        return [WebhookEndpointDoc.from_mongo(d) for d in docs]
+
     async def count_by_user(self, user_id: ObjectId) -> int:
         return await self._count({"user_id": user_id})
 

--- a/services/webhooks/executor.py
+++ b/services/webhooks/executor.py
@@ -52,6 +52,15 @@ RETRY_SCHEDULE_SECONDS = (0, 5, 300, 1800, 7200, 18000, 36000)
 RATE_LIMIT_FALLBACK_SECONDS = 60
 RATE_LIMIT_MAX_DEFER_SECONDS = 900
 
+
+def _since_ms(started: datetime | None) -> int | None:
+    if started is None:
+        return None
+    return int(
+        (datetime.now(timezone.utc) - as_aware_utc(started)).total_seconds() * 1000
+    )
+
+
 # Type of the on-disable hook — wiring plugs email notification in here so
 # the executor never grows an email dependency.
 OnDisabled = Callable[[WebhookEndpointDoc, str], Awaitable[None]]
@@ -242,6 +251,7 @@ class DeliveryExecutor:
                 webhook_id=row.webhook_id,
                 status_code=result.status_code,
                 duration_ms=duration_ms,
+                latency_ms=_since_ms(row.created_at),
                 attempt=row.attempt_count + 1,
                 is_test=row.is_test,
             )
@@ -280,23 +290,23 @@ class DeliveryExecutor:
             attempt=row.attempt_count + 1,
         )
 
+        failure = result.error or f"status {result.status_code}"
         if single_shot:
             # One recorded attempt, terminal, health untouched: the caller
             # (test send / manual retry) reads the outcome synchronously.
-            await self._finish(row, attempt, DeliveryStatus.FAILED)
+            await self._finish(row, attempt, DeliveryStatus.FAILED, reason=failure)
             return
 
         if result.status_code == 410:
-            await self._finish(row, attempt, DeliveryStatus.FAILED)
+            await self._finish(row, attempt, DeliveryStatus.FAILED, reason="gone")
             await self._disable(endpoint, EndpointDisabledReason.GONE)
             return
 
         # attempt_count on the claimed row predates this attempt.
         attempts_done = row.attempt_count + 1
         if attempts_done >= len(RETRY_SCHEDULE_SECONDS):
-            await self._finish(row, attempt, DeliveryStatus.FAILED)
-            reason = result.error or f"status {result.status_code}"
-            streak = await self._endpoints.record_exhausted(endpoint.id, reason)
+            await self._finish(row, attempt, DeliveryStatus.FAILED, reason="exhausted")
+            streak = await self._endpoints.record_exhausted(endpoint.id, failure)
             if streak >= self._max_consecutive:
                 await self._disable(
                     endpoint, EndpointDisabledReason.CONSECUTIVE_FAILURES
@@ -313,14 +323,34 @@ class DeliveryExecutor:
     # ── Terminal writes ──────────────────────────────────────────────────
 
     async def _finish(
-        self, row: WebhookDeliveryDoc, attempt: DeliveryAttempt, status: DeliveryStatus
+        self,
+        row: WebhookDeliveryDoc,
+        attempt: DeliveryAttempt,
+        status: DeliveryStatus,
+        *,
+        reason: str | None = None,
     ) -> None:
         if await self._deliveries.record_attempt_and_finish(row.id, attempt, status):
             await self._release_slot(row)
+        if status == DeliveryStatus.FAILED:
+            self._log_failed(row, reason or "failed")
 
     async def _fail(self, row: WebhookDeliveryDoc, reason: str) -> None:
         if await self._deliveries.mark_failed(row.id, reason):
             await self._release_slot(row)
+        self._log_failed(row, reason)
+
+    def _log_failed(self, row: WebhookDeliveryDoc, reason: str) -> None:
+        log.warning(
+            "webhook_delivery_failed",
+            endpoint_id=str(row.endpoint_id),
+            event_type=row.event_type,
+            webhook_id=row.webhook_id,
+            reason=reason,
+            attempts=row.attempt_count + 1,
+            latency_ms=_since_ms(row.created_at),
+            is_test=row.is_test,
+        )
 
     async def _release_slot(self, row: WebhookDeliveryDoc) -> None:
         # Test sends are inserted PENDING without a dispatch reservation.

--- a/tests/unit/repositories/test_webhook_endpoint_repository.py
+++ b/tests/unit/repositories/test_webhook_endpoint_repository.py
@@ -61,3 +61,43 @@ class TestPendingCounter:
         repo, col = _repo()
         col.find_one_and_update.return_value = {"_id": _EP}
         assert await repo.set_pending_count(_EP, 3) == 0
+
+
+class TestFindBacklogged:
+    @pytest.mark.asyncio
+    async def test_only_positive_counters_sorted_desc(self):
+        repo, col = _repo()
+        cursor = col.find.return_value
+        cursor.to_list.return_value = [
+            {
+                "_id": _EP,
+                "user_id": ObjectId(),
+                "url": "https://example.com/h",
+                "events": ["*"],
+                "pending_count": 5,
+            }
+        ]
+        rows = await repo.find_backlogged(limit=20)
+        assert [r.pending_count for r in rows] == [5]
+        assert col.find.call_args[0][0] == {"pending_count": {"$gt": 0}}
+        cursor.sort.assert_called_once_with("pending_count", -1)
+        cursor.limit.assert_called_once_with(20)
+
+
+class TestBacklogTotals:
+    @pytest.mark.asyncio
+    async def test_aggregates_over_every_backlogged_endpoint(self):
+        repo, col = _repo()
+        col.aggregate.return_value.to_list.return_value = [
+            {"_id": None, "endpoints": 23, "total": 4100}
+        ]
+        assert await repo.backlog_totals() == (23, 4100)
+        pipeline = col.aggregate.await_args[0][0]
+        assert pipeline[0] == {"$match": {"pending_count": {"$gt": 0}}}
+        assert pipeline[1]["$group"]["total"] == {"$sum": "$pending_count"}
+
+    @pytest.mark.asyncio
+    async def test_empty_backlog_is_zero_zero(self):
+        repo, col = _repo()
+        col.aggregate.return_value.to_list.return_value = []
+        assert await repo.backlog_totals() == (0, 0)

--- a/tests/unit/services/webhooks/test_executor.py
+++ b/tests/unit/services/webhooks/test_executor.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from bson import ObjectId
+from structlog.testing import capture_logs
 
 from infrastructure.crypto import encrypt_secret
 from infrastructure.safe_fetch import PostResult
@@ -663,3 +664,58 @@ class TestRunLoopEdges:
             await task
         await asyncio.sleep(0)
         assert cancelled.is_set()
+
+
+class TestObservabilityFields:
+    @pytest.mark.asyncio
+    async def test_delivered_carries_created_to_completed_latency(self):
+        endpoint = _endpoint()
+        executor, _, _, _ = _make(endpoint)
+        row = _delivery(
+            endpoint_id=endpoint.id,
+            created_at=datetime.now(timezone.utc) - timedelta(seconds=2),
+        )
+        with (
+            patch("services.webhooks.executor.post_public", _post(204)),
+            capture_logs() as logs,
+        ):
+            await executor.attempt(row)
+        delivered = next(e for e in logs if e["event"] == "webhook_delivered")
+        assert 1900 <= delivered["latency_ms"] <= 10_000
+        assert delivered["duration_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_terminal_failures_log_a_reason(self):
+        endpoint = _endpoint()
+        executor, _, endpoints, _ = _make(endpoint, max_consecutive=99)
+        last = len(RETRY_SCHEDULE_SECONDS) - 1
+        with (
+            patch("services.webhooks.executor.post_public", _post(500)),
+            capture_logs() as logs,
+        ):
+            await executor.attempt(
+                _delivery(endpoint_id=endpoint.id, attempt_count=last)
+            )
+        with (
+            patch("services.webhooks.executor.post_public", _post(410)),
+            capture_logs() as logs_gone,
+        ):
+            await executor.attempt(_delivery(endpoint_id=endpoint.id))
+        endpoints.find_by_id.return_value = None
+        with capture_logs() as logs_inactive:
+            await executor.attempt(_delivery(endpoint_id=endpoint.id))
+        reasons = [
+            next(e for e in batch if e["event"] == "webhook_delivery_failed")["reason"]
+            for batch in (logs, logs_gone, logs_inactive)
+        ]
+        assert reasons == ["exhausted", "gone", "endpoint_inactive"]
+
+    @pytest.mark.asyncio
+    async def test_reschedule_is_not_a_terminal_failure(self):
+        executor, _, _, _ = _make(_endpoint())
+        with (
+            patch("services.webhooks.executor.post_public", _post(500)),
+            capture_logs() as logs,
+        ):
+            await executor.attempt(_delivery())
+        assert not [e for e in logs if e["event"] == "webhook_delivery_failed"]

--- a/tests/unit/workers/test_click_worker_app.py
+++ b/tests/unit/workers/test_click_worker_app.py
@@ -228,3 +228,29 @@ class TestSafetyRuntime:
             runtime = await _build_runtime(settings, ["stats"], run_safety=True)
 
         assert runtime.deep_consumer is not None
+
+
+class TestWebhooksRuntime:
+    @pytest.mark.asyncio
+    async def test_builds_webhook_stack_with_reporters(self):
+        """With webhooks on, the runtime carries the click and domain
+        consumers, the executor task, the pending-depth reporter and a lag
+        reporter for the domain stream, and tears them all down."""
+        settings = _settings()
+        settings.webhooks.enabled = True
+        settings.secret_key = "s" * 32
+
+        with patch(
+            "workers.click_worker.create_redis_client", new=AsyncMock()
+        ) as redis_factory:
+            redis_factory.return_value = AsyncMock()
+            runtime = await _build_runtime(settings, ["stats"], run_webhooks=True)
+            try:
+                assert "webhooks" in runtime.consumers
+                assert runtime.webhook_domain_consumer is not None
+                names = {t.get_name() for t in runtime.telemetry_tasks}
+                assert {"webhook-delivery-executor", "webhook-depth-reporter"} <= names
+                # executor + depth reporter + click stream pair + domain stream
+                assert len(runtime.telemetry_tasks) == 5
+            finally:
+                await runtime.aclose()

--- a/tests/unit/workers/test_telemetry.py
+++ b/tests/unit/workers/test_telemetry.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
-from workers.telemetry import StaleConsumerJanitor, StreamMetricsReporter
+import pytest
+from bson import ObjectId
+from structlog.testing import capture_logs
+
+from schemas.models.webhook import WebhookEndpointDoc
+from workers.telemetry import (
+    StaleConsumerJanitor,
+    StreamMetricsReporter,
+    WebhookDepthReporter,
+)
 
 
 def _redis_with_groups(groups, consumers_by_group=None) -> AsyncMock:
@@ -68,3 +78,115 @@ class TestStaleConsumerJanitor:
             },
         )
         assert await self._janitor(redis).sweep_once() == 2
+
+
+class TestPerGroupLines:
+    @pytest.mark.asyncio
+    async def test_report_once_emits_one_flat_line_per_group(self):
+        redis = AsyncMock()
+        redis.xlen.return_value = 7
+        redis.xinfo_groups.return_value = [
+            {"name": "stats", "pending": 1, "lag": 2},
+            {"name": "webhooks", "pending": 0, "lag": 40},
+        ]
+        with capture_logs() as logs:
+            await StreamMetricsReporter(redis, "events:clicks", 30).report_once()
+        flat = [e for e in logs if e["event"] == "stream_group_stats"]
+        assert [(e["group"], e["lag"]) for e in flat] == [
+            ("stats", 2),
+            ("webhooks", 40),
+        ]
+        assert all(e["stream"] == "events:clicks" for e in flat)
+
+
+class TestWebhookDepthReporter:
+    @pytest.mark.asyncio
+    async def test_summary_and_per_endpoint_lines(self):
+        repo = AsyncMock()
+        eps = []
+        for pending in (900, 12):
+            ep = WebhookEndpointDoc(
+                user_id=ObjectId(),
+                url="https://example.com/h",
+                events=["*"],
+                pending_count=pending,
+            )
+            ep.id = ObjectId()
+            eps.append(ep)
+        repo.backlog_totals.return_value = (2, 912)
+        repo.find_backlogged.return_value = eps
+        with capture_logs() as logs:
+            await WebhookDepthReporter(repo, 30).report_once()
+        summary = next(e for e in logs if e["event"] == "webhook_pending_depth")
+        assert summary["backlogged_endpoints"] == 2
+        assert summary["total_pending"] == 912
+        assert summary["max_pending"] == 900
+        per_ep = [e for e in logs if e["event"] == "webhook_endpoint_depth"]
+        assert [e["pending"] for e in per_ep] == [900, 12]
+        assert per_ep[0]["endpoint_id"] == str(eps[0].id)
+
+    @pytest.mark.asyncio
+    async def test_summary_counts_beyond_the_top_list(self):
+        """The per-endpoint lines are capped; the totals must not be."""
+        repo = AsyncMock()
+        top = WebhookEndpointDoc(
+            user_id=ObjectId(),
+            url="https://example.com/h",
+            events=["*"],
+            pending_count=900,
+        )
+        top.id = ObjectId()
+        repo.backlog_totals.return_value = (2, 912)
+        repo.find_backlogged.return_value = [top]
+        with capture_logs() as logs:
+            await WebhookDepthReporter(repo, 30, top=1).report_once()
+        repo.find_backlogged.assert_awaited_once_with(limit=1)
+        summary = next(e for e in logs if e["event"] == "webhook_pending_depth")
+        assert summary["backlogged_endpoints"] == 2
+        assert summary["total_pending"] == 912
+        assert summary["max_pending"] == 900
+        assert len([e for e in logs if e["event"] == "webhook_endpoint_depth"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_backlog_still_reports_zero(self):
+        repo = AsyncMock()
+        repo.backlog_totals.return_value = (0, 0)
+        repo.find_backlogged.return_value = []
+        with capture_logs() as logs:
+            await WebhookDepthReporter(repo, 30).report_once()
+        summary = next(e for e in logs if e["event"] == "webhook_pending_depth")
+        assert summary["total_pending"] == 0 and summary["max_pending"] == 0
+
+
+class TestWebhookDepthReporterLoop:
+    @pytest.mark.asyncio
+    async def test_report_error_is_logged_and_loop_keeps_going(self):
+        repo = AsyncMock()
+        repo.backlog_totals.side_effect = [RuntimeError("mongo down"), (0, 0)]
+        repo.find_backlogged.return_value = []
+        reporter = WebhookDepthReporter(repo, 0.01)
+        with capture_logs() as logs:
+            task = asyncio.create_task(reporter.run_forever())
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        assert any(e["event"] == "webhook_pending_depth_failed" for e in logs)
+        assert repo.backlog_totals.await_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_report_propagates(self):
+        repo = AsyncMock()
+        started = asyncio.Event()
+
+        async def hang(*, limit):
+            started.set()
+            await asyncio.sleep(10)
+
+        repo.backlog_totals.return_value = (0, 0)
+        repo.find_backlogged.side_effect = hang
+        task = asyncio.create_task(WebhookDepthReporter(repo, 0.01).run_forever())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -117,7 +117,11 @@ from services.webhooks import (
 from services.webhooks.consumers import WebhookClickConsumer, WebhookDomainConsumer
 from services.webhooks.renderers import default_renderers
 from workers.dlq import ClaimDeadLetterGuard
-from workers.telemetry import StaleConsumerJanitor, StreamMetricsReporter
+from workers.telemetry import (
+    StaleConsumerJanitor,
+    StreamMetricsReporter,
+    WebhookDepthReporter,
+)
 
 log = get_logger(__name__)
 
@@ -247,8 +251,16 @@ async def _build_runtime(
             concurrency=wh.executor_concurrency,
             per_endpoint_concurrency=wh.executor_per_endpoint_concurrency,
         )
-        runtime.telemetry_tasks.append(
-            asyncio.create_task(executor.run(), name="webhook-delivery-executor")
+        runtime.telemetry_tasks.extend(
+            [
+                asyncio.create_task(executor.run(), name="webhook-delivery-executor"),
+                asyncio.create_task(
+                    WebhookDepthReporter(
+                        webhook_endpoint_repo, ce.stats_interval_seconds
+                    ).run_forever(),
+                    name="webhook-depth-reporter",
+                ),
+            ]
         )
         log.info("webhooks_worker_registered", stream=DOMAIN_EVENTS_STREAM)
 
@@ -602,6 +614,14 @@ async def _build_runtime(
                 ),
             ]
         )
+        if run_webhooks:
+            runtime.telemetry_tasks.append(
+                asyncio.create_task(
+                    StreamMetricsReporter(
+                        telemetry_redis, DOMAIN_EVENTS_STREAM, ce.stats_interval_seconds
+                    ).run_forever()
+                )
+            )
 
     return runtime
 

--- a/workers/telemetry.py
+++ b/workers/telemetry.py
@@ -6,6 +6,9 @@ to Axiom via the existing container-logs → Vector path, and the thing to
 alert on (lag growing = worker falling behind; alert BEFORE the buffer
 fills and the sink starts falling back inline).
 
+WebhookDepthReporter emits per-endpoint pending depth from the counter the
+dispatcher maintains — the queue-side view of a subscriber falling behind.
+
 StaleConsumerJanitor deletes consumer names that are long-dead with
 nothing pending — every worker restart registers fresh
 ``{group}-{host}-{pid}`` names and Redis keeps the old ones forever,
@@ -16,9 +19,12 @@ messages would orphan its PEL entries, so only pending==0 names go.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from infrastructure.logging import get_logger
+
+if TYPE_CHECKING:
+    from repositories.webhook_endpoint_repository import WebhookEndpointRepository
 
 log = get_logger(__name__)
 
@@ -65,6 +71,16 @@ class StreamMetricsReporter:
                 for g in groups
             ],
         )
+        # One flat line per group so lag can be charted and alerted on by
+        # group without unpacking the nested list above.
+        for g in groups:
+            log.info(
+                "stream_group_stats",
+                stream=self._stream,
+                group=g.get("name"),
+                pending=g.get("pending"),
+                lag=g.get("lag"),
+            )
 
 
 class StaleConsumerJanitor:
@@ -112,3 +128,47 @@ class StaleConsumerJanitor:
         if removed:
             log.info("stale_consumers_removed", stream=self._stream, removed=removed)
         return removed
+
+
+class WebhookDepthReporter:
+    def __init__(
+        self,
+        endpoint_repo: WebhookEndpointRepository,
+        interval_seconds: float,
+        top: int = 20,
+    ) -> None:
+        self._endpoints = endpoint_repo
+        self._interval = interval_seconds
+        self._top = top
+
+    async def run_forever(self) -> None:
+        while True:
+            try:
+                await self.report_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                log.warning(
+                    "webhook_pending_depth_failed",
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+            await asyncio.sleep(self._interval)
+
+    async def report_once(self) -> None:
+        endpoints, total = await self._endpoints.backlog_totals()
+        backlogged = await self._endpoints.find_backlogged(limit=self._top)
+        log.info(
+            "webhook_pending_depth",
+            backlogged_endpoints=endpoints,
+            total_pending=total,
+            max_pending=backlogged[0].pending_count if backlogged else 0,
+        )
+        for ep in backlogged:
+            log.info(
+                "webhook_endpoint_depth",
+                endpoint_id=str(ep.id),
+                user_id=str(ep.user_id),
+                pending=ep.pending_count,
+                status=ep.status.value,
+            )


### PR DESCRIPTION
Stacked on #348.

## What

New structured log events and fields, all from code that already runs in the click worker:

- `stream_group_stats`: one flat line per consumer group per stream (`stream`, `group`, `pending`, `lag`), emitted by the existing stream reporter next to its nested `click_stream_stats` line. The worker now also runs a reporter for the domain stream when webhooks are on, so both webhooks groups report lag.
- `webhook_pending_depth` and `webhook_endpoint_depth`: a depth reporter reads the pending counter from the endpoint documents every stats interval and logs the total, the worst endpoint, and one line per backlogged endpoint (top 20).
- `webhook_delivered` gains `latency_ms`, the time from the delivery row being created to the delivery completing. The existing `duration_ms` stays as the HTTP round trip.
- `webhook_delivery_failed`: every terminal failure now logs one line with a `reason` (`exhausted`, `gone`, `endpoint_inactive`, `event_expired`, `secret_unreadable`, `payload_over_cap`, or the single-shot error). Until now only per-attempt failures were logged, so a delivery that gave up was invisible.

Dashboard and monitors as code:

- `axiom/dashboards/spoo-webhooks.json` extended from the draft to 20 charts: consumer lag by stream, pending depth over time and a backlogged-endpoints table, created-to-completed latency percentiles, outcomes by class, plus the existing dispatch, attempt, disable and degradation panels. Deployed to Axiom as "spoo · webhooks".
- `axiom/monitors/webhooks-consumer-lag.json`: max lag on the webhooks group at or above 5000 over 10 minutes.
- `axiom/monitors/webhook-endpoints-disabled.json`: 3 or more endpoints auto-disabled in 15 minutes.
- Both monitors are live and notify the discord-ops notifier.

## Why

The flag stays off for real users until we can see the webhooks consumer group falling behind, subscribers backing up, how long a delivery takes end to end, and how deliveries end. None of that was visible from the logs the worker emitted before this change.

## How proven

Rig with the real dispatcher, executor, stream reporter and depth reporter against local Mongo and real Redis streams (consumer groups created and partly consumed so lag was real), a local receiver with instant, slow, failing and gone paths, JSON logs captured and ingested into a throwaway `spoo-rig` dataset (574 events, 0 failures). Every new panel query was then run against that dataset:

- lag by stream: 200 on the click stream, 15 on the domain stream, matching what the rig left unread
- pending depth: 120 total, worst endpoint 50, and the backlogged-endpoints table listed the five endpoints with their counts
- delivery latency percentiles over 56 deliveries: p50 1173ms, p95 4176ms, p99 6245ms
- outcomes by class: 56 delivered, 170 dropped over cap, 8 failed:endpoint_inactive, 4 failed:exhausted, 2 failed:gone
- endpoints disabled by reason: 2 gone, 2 consecutive_failures

Alert path: a temporary copy of the lag monitor pointed at `spoo-rig` with threshold 100 went to Triggered on the rig's lag of 200 within its first interval and posted to the ops notifier. It has been deleted.

Note: Axiom refuses a monitor whose query references a field the dataset has never seen, and prod has not logged `lag` yet, so one marked row (`schema_seed: true`, lag 0) was ingested into `spoo-prod` to create the lag monitor ahead of the deploy. The lag panels will show real data once the worker with this change is running.

`uv run pytest`: 3737 passed, 5 skipped.
