### PR TITLE
fix(links): normalise scheduling datetimes before comparing

### DIFF
--- a/infrastructure/cache/url_cache.py
+++ b/infrastructure/cache/url_cache.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from infrastructure.crypto import verify_password as verify_password_hash
 from infrastructure.logging import get_logger
-from shared.datetime_utils import to_unix_timestamp
+from shared.datetime_utils import to_unix_timestamp, to_unix_timestamp_ceil
 
 if TYPE_CHECKING:
     from schemas.models.url import UrlV2Doc
@@ -88,7 +88,8 @@ class UrlCacheData(BaseModel):
             meta_color=doc.meta_tags.color if doc.meta_tags else None,
             meta_image_width=im.width if im else None,
             meta_image_height=im.height if im else None,
-            start_time=to_unix_timestamp(doc.starts_at),
+            # Ceil: a fractional start must never read as live a moment early.
+            start_time=to_unix_timestamp_ceil(doc.starts_at),
             pre_start_url=doc.pre_start_url,
         )
 

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -89,7 +89,7 @@ from shared.alias_dispatch import (
     resolution_order,
     v2_lookup_code,
 )
-from shared.datetime_utils import parse_datetime, to_unix_timestamp
+from shared.datetime_utils import as_aware_utc, parse_datetime, to_unix_timestamp
 from shared.emoji_policy import (
     canonicalize_emoji_alias,
     check_emoji_alias,
@@ -321,6 +321,9 @@ def _check_start_before_expiry(
     starts_at: datetime | None, expire_after: datetime | None
 ) -> None:
     """A link that expires before it starts would never be live."""
+    # Stored values come back naive-UTC; the request side is aware.
+    starts_at = as_aware_utc(starts_at)
+    expire_after = as_aware_utc(expire_after)
     if starts_at is not None and expire_after is not None and starts_at >= expire_after:
         raise ValidationError(
             "starts_at must be before expire_after", field="starts_at"

--- a/shared/datetime_utils.py
+++ b/shared/datetime_utils.py
@@ -8,6 +8,7 @@ canonical implementation.
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timezone
 from typing import Any
 
@@ -60,6 +61,19 @@ def to_unix_timestamp(dt: datetime | None, default: int | None = None) -> int | 
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return int(dt.timestamp())
+
+
+def to_unix_timestamp_ceil(dt: datetime | None) -> int | None:
+    """Like ``to_unix_timestamp`` but rounds a fractional second UP.
+
+    For a moment something starts: truncating would let it read as begun
+    up to 999 ms early; rounding up errs on the side of not yet.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return math.ceil(dt.timestamp())
 
 
 def as_aware_utc(dt: Any) -> datetime | None:

--- a/tests/unit/infrastructure/test_cache.py
+++ b/tests/unit/infrastructure/test_cache.py
@@ -412,3 +412,28 @@ class TestUrlCacheDataIsNotYetLive:
         data = UrlCacheData.from_v2_doc(doc)
         assert data.start_time == int(starts.replace(tzinfo=timezone.utc).timestamp())
         assert data.pre_start_url == "https://example.org/soon"
+
+
+class TestFromV2DocFractionalStart:
+    def test_fractional_start_rounds_up_so_the_link_is_never_live_early(self):
+        from datetime import datetime, timezone
+
+        from schemas.models.url import UrlV2Doc
+
+        starts = datetime(2030, 6, 1, 12, 0, 0, 900_000, tzinfo=timezone.utc)
+        doc = UrlV2Doc.from_mongo(
+            {
+                "_id": ObjectId(),
+                "alias": "abc1234",
+                "domain": "spoo.me",
+                "created_at": starts,
+                "long_url": "https://example.com",
+                "starts_at": starts,
+            }
+        )
+        data = UrlCacheData.from_v2_doc(doc)
+        whole = int(starts.replace(microsecond=0).timestamp())
+        assert data.start_time == whole + 1
+        # At the floor second the link is still not live; one second on it is.
+        assert data.is_not_yet_live(whole) is True
+        assert data.is_not_yet_live(whole + 1) is False

--- a/tests/unit/services/test_url_service.py
+++ b/tests/unit/services/test_url_service.py
@@ -3872,7 +3872,9 @@ class TestUrlServiceScheduling:
     async def test_db_path_future_start_raises_after_recache(self):
         svc, url_repo, url_cache = self._svc()
         url_cache.get.return_value = None
-        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).replace(
+            microsecond=0
+        )
         url_repo.find_by_alias.return_value = make_url_v2_doc(starts_at=future)
 
         with pytest.raises(NotYetLiveError) as exc:
@@ -4000,6 +4002,36 @@ class TestUrlServiceScheduling:
         with pytest.raises(ValidationError, match="before expire_after"):
             await svc.update(
                 URL_OID, UpdateUrlRequest(starts_at=self.FUTURE_TS + 60), USER_OID
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_start_against_naive_stored_expiry_is_a_400_not_a_500(self):
+        """Mongo hands back naive UTC; the request side is aware. The order
+        check must normalise both or the comparison raises TypeError."""
+        svc, url_repo, _url_cache = self._svc()
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        naive_expiry = datetime.fromtimestamp(self.FUTURE_TS, tz=timezone.utc).replace(
+            tzinfo=None
+        )
+        url_repo.find_by_id.return_value = make_url_v2_doc(expire_after=naive_expiry)
+        with pytest.raises(ValidationError, match="before expire_after"):
+            await svc.update(
+                URL_OID, UpdateUrlRequest(starts_at=self.FUTURE_TS + 60), USER_OID
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_expiry_against_naive_stored_start_is_a_400_not_a_500(self):
+        svc, url_repo, _url_cache = self._svc()
+        from schemas.dto.requests.url import UpdateUrlRequest
+
+        naive_start = datetime.fromtimestamp(self.FUTURE_TS, tz=timezone.utc).replace(
+            tzinfo=None
+        )
+        url_repo.find_by_id.return_value = make_url_v2_doc(starts_at=naive_start)
+        with pytest.raises(ValidationError, match="before expire_after"):
+            await svc.update(
+                URL_OID, UpdateUrlRequest(expire_after=self.FUTURE_TS - 60), USER_OID
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/shared/test_datetime_utils.py
+++ b/tests/unit/shared/test_datetime_utils.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 
 import pytest
 
-from shared.datetime_utils import convert_to_gmt, parse_datetime
+from shared.datetime_utils import (
+    convert_to_gmt,
+    parse_datetime,
+    to_unix_timestamp,
+    to_unix_timestamp_ceil,
+)
 
 # ---------------------------------------------------------------------------
 # shared.datetime_utils — parse_datetime
@@ -69,3 +74,32 @@ def test_parse_datetime_naive_assumed_utc():
 )
 def test_convert_to_gmt(value, expected):
     assert convert_to_gmt(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# shared.datetime_utils — to_unix_timestamp_ceil
+# ---------------------------------------------------------------------------
+
+
+_WHOLE = datetime(2030, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_WHOLE_TS = int(_WHOLE.timestamp())
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        (_WHOLE, _WHOLE_TS),
+        (_WHOLE.replace(microsecond=900_000), _WHOLE_TS + 1),
+        (_WHOLE.replace(microsecond=1), _WHOLE_TS + 1),
+        # Naive is UTC, the same rule to_unix_timestamp applies.
+        (_WHOLE.replace(microsecond=900_000, tzinfo=None), _WHOLE_TS + 1),
+    ],
+)
+def test_to_unix_timestamp_ceil(value, expected):
+    assert to_unix_timestamp_ceil(value) == expected
+
+
+def test_ceil_agrees_with_floor_on_whole_seconds():
+    whole = datetime(2030, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert to_unix_timestamp_ceil(whole) == to_unix_timestamp(whole)


### PR DESCRIPTION
## What

Two small fixes to the link scheduling work that landed in #349.

- The start-before-expiry check compared an aware request datetime with the
  naive UTC datetime Mongo returns. A PATCH that changed only `starts_at` or
  only `expire_after` on a link that already had the other one set raised a
  TypeError and answered 500. Both sides are normalised to aware UTC now.
- The cache projection truncated a fractional `starts_at` to the second
  below, so a link could read as live up to 999 ms before its start. It now
  rounds up to the next whole second.

## Why

Both surfaced in review after the merge. The first is a real 500 on an
ordinary edit; the second is a sub-second inconsistency between the model's
derived status and the hot path.

## How proven

- New tests use naive stored values the way the real path does and assert
  a 400, not a TypeError, for both orderings.
- A test with a `.900` start asserts the cache rounds up and that the link
  is not live at the floor second.
- `uv run pytest` green, `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed URL cache scheduling so fractional start times do not become active before their intended second.
  - Improved handling of timestamps with and without timezone information during URL updates.
  - Requests with invalid start and expiration times now return a clear validation error instead of an unexpected server error.

- **Tests**
  - Added coverage for fractional start times and mixed timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->