### PR TITLE
feat(entitlements): catalog, resolver, subscriptions, /me/entitlements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ HCAPTCHA_SITEKEY=""                    # hCaptcha site key (public, used in temp
 SECRET_KEY="" # To generate: python -c "import os; print(os.urandom(32).hex())"
 HOST_URI="127.0.0.1:8000"
 ENV="development"  # change to "production" in production
+# none = self-host (every account holds every feature); paddle = spoo.me cloud.
+# Production refuses to boot unless this is set explicitly.
+BILLING_PROVIDER="none"
 
 # CORS — allowed origins for private routes (auth, oauth, dashboard)
 # Public API routes (/api/v1/*) always allow all origins.

--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from infrastructure.logging import get_logger
 from infrastructure.oauth_clients import OAUTH_STATE_TTL_SECONDS, init_oauth
 from infrastructure.queue_redis import connect_queue_redis
 from infrastructure.templates import configure_template_globals, templates
+from middleware.entitlements import EntitlementsVersionMiddleware
 from middleware.error_handler import register_error_handlers
 from middleware.logging import RequestLoggingMiddleware
 from middleware.openapi import (
@@ -314,6 +315,9 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
     #    writes view_rate_limit into shared scope state during endpoint
     #    execution, before any response starts flowing outward
     app.add_middleware(RateLimitHeadersMiddleware)
+    # 8. Entitlement version header on authenticated responses; reads the
+    #    version the Entitled dependency stored, or one cache lookup.
+    app.add_middleware(EntitlementsVersionMiddleware)
 
     # ── Error handlers + rate limiter ────────────────────────────────────
     app.state.limiter = limiter

--- a/config.py
+++ b/config.py
@@ -664,6 +664,31 @@ class SchedulerSettings(BaseSettings):
     lease_seconds: int = Field(default=600, ge=30)
 
 
+class BillingSettings(BaseSettings):
+    """Billing provider and the display prices the plans endpoint shows.
+
+    ``BILLING_PROVIDER=none`` is self-host: no billing, and the resolver hands
+    every account the ``selfhost`` plan. Production must set it explicitly so
+    the cloud can never fall into self-host by omission. Prices are display
+    values only; the provider owns what is charged.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env", env_prefix="BILLING_", extra="ignore"
+    )
+
+    provider: Literal["none", "paddle"] = "none"
+    pro_monthly_usd: int = Field(default=15, ge=0)
+    pro_year_usd: int = Field(default=144, ge=0)
+    founding_monthly_usd: int = Field(default=9, ge=0)
+    founding_year_usd: int = Field(default=90, ge=0)
+    founding_seats: int = Field(default=100, ge=0)
+
+    @property
+    def selfhost(self) -> bool:
+        return self.provider == "none"
+
+
 class AppSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
@@ -859,6 +884,7 @@ class AppSettings(BaseSettings):
     scheduler: SchedulerSettings | None = None
     llm: LlmSettings | None = None
     posthog_erasure: PostHogErasureSettings | None = None
+    billing: BillingSettings | None = None
 
     @model_validator(mode="after")
     def _populate_sub_configs_and_secret(self) -> AppSettings:
@@ -908,6 +934,8 @@ class AppSettings(BaseSettings):
             self.scheduler = SchedulerSettings()
         if self.posthog_erasure is None:
             self.posthog_erasure = PostHogErasureSettings()
+        if self.billing is None:
+            self.billing = BillingSettings()
         if self.webhooks.enabled and not self.secret_key:
             # Signing secrets are encrypted with a key derived from
             # SECRET_KEY; an empty master would mean a predictable key.
@@ -925,6 +953,13 @@ class AppSettings(BaseSettings):
         # that in production would void the restore window. Refuse to boot.
         if self.env == "production" and self.account_deletion_grace_days < 1:
             raise ValueError("ACCOUNT_DELETION_GRACE_DAYS must be >= 1 in production")
+
+        # Unset means self-host, which hands every account every feature.
+        if self.env == "production" and "provider" not in self.billing.model_fields_set:
+            raise ValueError(
+                "BILLING_PROVIDER must be set explicitly in production: "
+                "none for self-host, paddle for the cloud"
+            )
 
         return self
 

--- a/dependencies/__init__.py
+++ b/dependencies/__init__.py
@@ -35,6 +35,12 @@ from dependencies.auth import (
     require_session_or_scopes,
     require_verified_email,
 )
+from dependencies.entitlements import (
+    Entitled,
+    EntitlementSvc,
+    get_entitlement_service,
+    get_entitlements,
+)
 from dependencies.infra import (
     AppRegistryDep,
     GeoIP,
@@ -132,6 +138,8 @@ __all__ = [
     "CustomDomainSvc",
     "DeviceAuthSvc",
     "DomainIntelSvc",
+    "Entitled",
+    "EntitlementSvc",
     "ExportSvc",
     "FeatureFlagSvc",
     "GeoIP",
@@ -175,6 +183,8 @@ __all__ = [
     "get_db",
     "get_device_auth_service",
     "get_email_provider",
+    "get_entitlement_service",
+    "get_entitlements",
     "get_export_service",
     "get_feature_flag_service",
     "get_geoip_service",

--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -64,10 +64,9 @@ class CurrentUser:
     # access tokens minted before the claim existed; those users match by
     # user_id only until their next token refresh.
     email: str | None = field(default=None)
-    # UserDoc.plan value (e.g. "FREE") — consumed by FeatureFlagService's
-    # TIER rollout via getattr(user, "tier"). Populated from the DB on the
-    # API-key path and from the (future) "plan" claim on the JWT path.
-    tier: str | None = field(default=None)
+    # The JWT "plan" claim: a hint for the fail mode only, never authority.
+    # None on the API-key path; the resolver reads the owner's plan by id.
+    plan_claim: str | None = field(default=None)
 
 
 async def get_current_user(
@@ -189,7 +188,6 @@ async def get_current_user(
                 # The owning UserDoc is already fetched above for
                 # email_verified — no extra DB hit to carry the email.
                 email=user.email.lower() if user and user.email else None,
-                tier=user.plan.value if user and user.plan else None,
             )
 
     # ── JWT path ──────────────────────────────────────────────────────────────
@@ -246,9 +244,7 @@ async def get_current_user(
             email_verified=email_verified,
             amr=amr,
             email=email,
-            # Not issued yet — the paid-plans launch adds the claim; TIER
-            # flag rollouts become a pure data change at that point.
-            tier=claims.get("plan"),
+            plan_claim=claims.get("plan"),
             scopes=scopes,
             app_id=claims.get("app_id"),
         )

--- a/dependencies/entitlements.py
+++ b/dependencies/entitlements.py
@@ -1,0 +1,38 @@
+"""
+``Entitled``: the resolved entitlements of the request's principal.
+
+Runs the resolver once per request (cache hit in the common case) and hands
+the map to routes and services. Nothing on the request path reads
+``subscriptions`` or overrides directly.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from dependencies.auth import CurrentUser, get_current_user
+from services.entitlements import EntitlementService, Resolved
+
+
+def get_entitlement_service(request: Request) -> EntitlementService:
+    return request.app.state.entitlement_service
+
+
+async def get_entitlements(
+    request: Request,
+    user: CurrentUser | None = Depends(get_current_user),
+    service: EntitlementService = Depends(get_entitlement_service),
+) -> Resolved:
+    resolved = await service.resolve_for(
+        user.user_id if user else None,
+        plan_hint=user.plan_claim if user else None,
+    )
+    if user is not None and not resolved.degraded:
+        request.state.entitlements_version = resolved.version
+    return resolved
+
+
+Entitled = Annotated[Resolved, Depends(get_entitlements)]
+EntitlementSvc = Annotated[EntitlementService, Depends(get_entitlement_service)]

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from config import AppSettings
+from infrastructure.cache.entitlement_cache import EntitlementCache
 from infrastructure.cache.feature_flag_cache import FeatureFlagCache
 from infrastructure.cache.meta_fetch_cache import MetaFetchCache
 from infrastructure.cache.onboarding_cache import OnboardingCache
@@ -37,6 +38,10 @@ from repositories.blocked_domain_repository import BlockedDomainRepository
 from repositories.blocked_url_repository import BlockedUrlRepository
 from repositories.click_repository import ClickRepository
 from repositories.custom_domain_repository import CustomDomainRepository
+from repositories.entitlement_event_repository import EntitlementEventRepository
+from repositories.entitlement_override_repository import (
+    EntitlementOverrideRepository,
+)
 from repositories.feature_flag_repository import FeatureFlagRepository
 from repositories.feed_domain_repository import FeedDomainRepository
 from repositories.legacy.emoji_url_repository import EmojiUrlRepository
@@ -47,6 +52,7 @@ from repositories.report_repository import (
     ReportSubmissionRepository,
 )
 from repositories.scheduled_task_repository import ScheduledTaskRepository
+from repositories.subscription_repository import SubscriptionRepository
 from repositories.tag_repository import TagRepository
 from repositories.token_repository import TokenRepository
 from repositories.url_repository import UrlRepository
@@ -79,6 +85,7 @@ from services.contact_service import ContactService
 from services.custom_domain_service import CustomDomainService
 from services.domain_intel_service import DomainIntelService
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
+from services.entitlements import EntitlementService
 from services.events.sinks import (
     InlineDomainEventSink,
     NullDomainEventSink,
@@ -87,6 +94,7 @@ from services.events.sinks import (
 from services.export.formatters import default_formatters
 from services.export.service import ExportService
 from services.feature_flag_service import FeatureFlagService
+from services.features.catalog import validate_override
 from services.meta_tags.sinks import NullMetaImageSink, RedisStreamMetaImageSink
 from services.mock_dcv_backend import MockDcvBackend
 from services.oauth_service import OAuthService
@@ -258,6 +266,49 @@ def build_posthog_eraser(settings: AppSettings, http_client) -> PostHogEraser:
     )
 
 
+def build_entitlement_store(
+    db, redis_client
+) -> tuple[
+    EntitlementCache,
+    EntitlementEventRepository,
+    SubscriptionRepository,
+    EntitlementOverrideRepository,
+]:
+    """The three entitlement repositories sharing one cache, so every write
+    to subscriptions or overrides invalidates the same ``ent:{id}`` key."""
+    cache = EntitlementCache(redis_client)
+    events = EntitlementEventRepository(db["entitlement_events"])
+    subscriptions = SubscriptionRepository(db["subscriptions"], events, cache)
+    overrides = EntitlementOverrideRepository(
+        db["entitlement_overrides"], events, cache, check=validate_override
+    )
+    return cache, events, subscriptions, overrides
+
+
+def build_entitlement_service(
+    db, settings: AppSettings, redis_client, *, store=None
+) -> EntitlementService:
+    cache, events, subscriptions, overrides = store or build_entitlement_store(
+        db, redis_client
+    )
+    return EntitlementService(
+        subscriptions,
+        overrides,
+        events,
+        cache,
+        selfhost=settings.billing.selfhost,
+        usage={
+            "custom_domains_max": CustomDomainRepository(
+                db["custom_domains"]
+            ).count_by_owner,
+            "webhook_endpoints_max": WebhookEndpointRepository(
+                db["webhook-endpoints"]
+            ).count_by_user,
+            "api_keys_max": ApiKeyRepository(db["api-keys"]).count_by_user,
+        },
+    )
+
+
 def build_account_erasure_service(
     db,
     settings: AppSettings,
@@ -355,6 +406,9 @@ def build_account_erasure_service(
         redis_client=redis_client,
         url_service=url_service,
     )
+    _, ent_events, subscription_repo, override_repo = build_entitlement_store(
+        db, redis_client
+    )
 
     return AccountErasureService(
         user_repo=user_repo,
@@ -372,6 +426,9 @@ def build_account_erasure_service(
         report_repo=ReportRepository(db["reports"]),
         report_submission_repo=ReportSubmissionRepository(db["report_submissions"]),
         feature_flag_repo=FeatureFlagRepository(db["feature_flags"]),
+        subscription_repo=subscription_repo,
+        override_repo=override_repo,
+        entitlement_event_repo=ent_events,
         r2_storage=r2_storage,
         posthog=build_posthog_eraser(settings, http_client),
         mailer=build_erasure_mailer(settings, http_client),
@@ -403,6 +460,11 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     blocked_url_repo = BlockedUrlRepository(db["blocked-urls"])
     app_grant_repo = AppGrantRepository(db["app-grants"])
     feature_flag_repo = FeatureFlagRepository(db["feature_flags"])
+    ent_store = build_entitlement_store(db, redis_client)
+    _, ent_events, subscription_repo, override_repo = ent_store
+    app.state.entitlement_service = build_entitlement_service(
+        db, settings, redis_client, store=ent_store
+    )
 
     # ── Infrastructure ───────────────────────────────────────────────────
     url_cache = UrlCache(redis_client, ttl_seconds=settings.redis.redis_ttl_seconds)
@@ -773,7 +835,9 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         max_active_keys=settings.max_active_api_keys,
     )
     app.state.page_layout_service = PageLayoutService(page_layout_repo)
-    token_factory = TokenFactory(settings.jwt)
+    token_factory = TokenFactory(
+        settings.jwt, plan_of=app.state.entitlement_service.plan_hint_for
+    )
     otp_service = OtpService(token_repo)
 
     app.state.user_repo = user_repo
@@ -1012,6 +1076,9 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         report_repo=report_repo,
         report_submission_repo=report_submission_repo,
         feature_flag_repo=feature_flag_repo,
+        subscription_repo=subscription_repo,
+        override_repo=override_repo,
+        entitlement_event_repo=ent_events,
         r2_storage=r2_storage,
         posthog=build_posthog_eraser(settings, http_client),
         mailer=erasure_mailer,

--- a/errors.py
+++ b/errors.py
@@ -28,6 +28,10 @@ ErrorBody = TypedDict(  # noqa: UP013 — class syntax loses the markers here
         "details": NotRequired[Any],
         "message": NotRequired[str],
         "hint": NotRequired[str],
+        "feature": NotRequired[str],
+        "limit": NotRequired[str],
+        "max": NotRequired[int],
+        "current": NotRequired[int],
     },
 )
 
@@ -119,6 +123,12 @@ class NotFoundError(AppError):
 class ConflictError(AppError):
     status_code = 409
     error_code = "conflict"
+
+
+class InvalidTransitionError(ConflictError):
+    """A subscription event arrived in a status it cannot legally change."""
+
+    error_code = "invalid_transition"
 
 
 class BlockedUrlError(AppError):

--- a/infrastructure/cache/entitlement_cache.py
+++ b/infrastructure/cache/entitlement_cache.py
@@ -1,0 +1,69 @@
+"""Per-owner resolved entitlements in Redis: ``ent:{user_id}``.
+
+The TTL is a safety net only. Every repository write to ``subscriptions``
+or ``entitlement_overrides`` deletes the key in the same operation, so a
+plan change is visible on the owner's next request. Tolerates a missing
+Redis client the same way ``UrlCache`` does: every read misses.
+"""
+
+from __future__ import annotations
+
+import redis.asyncio as aioredis
+from bson import ObjectId
+
+from infrastructure.logging import get_logger
+from services.entitlements.resolver import Resolved
+
+log = get_logger(__name__)
+
+
+class EntitlementCache:
+    def __init__(self, redis_client: aioredis.Redis | None, ttl_seconds: int = 600):
+        self._redis = redis_client
+        self.ttl_seconds = ttl_seconds
+
+    @staticmethod
+    def _key(user_id: ObjectId) -> str:
+        return f"ent:{user_id}"
+
+    async def get(self, user_id: ObjectId) -> Resolved | None:
+        if self._redis is None:
+            return None
+        try:
+            raw = await self._redis.get(self._key(user_id))
+        except Exception as e:
+            log.warning(
+                "entitlement_cache_get_error", user_id=str(user_id), error=str(e)
+            )
+            return None
+        if raw is None:
+            return None
+        try:
+            return Resolved.model_validate_json(raw)
+        except Exception as e:
+            log.warning(
+                "entitlement_cache_decode_error", user_id=str(user_id), error=str(e)
+            )
+            return None
+
+    async def set(self, user_id: ObjectId, resolved: Resolved) -> None:
+        if self._redis is None or resolved.degraded:
+            return
+        try:
+            await self._redis.setex(
+                self._key(user_id), self.ttl_seconds, resolved.model_dump_json()
+            )
+        except Exception as e:
+            log.warning(
+                "entitlement_cache_set_error", user_id=str(user_id), error=str(e)
+            )
+
+    async def invalidate(self, user_id: ObjectId) -> None:
+        if self._redis is None:
+            return
+        try:
+            await self._redis.delete(self._key(user_id))
+        except Exception as e:
+            log.error(
+                "entitlement_cache_invalidate_error", user_id=str(user_id), error=str(e)
+            )

--- a/middleware/entitlements.py
+++ b/middleware/entitlements.py
@@ -1,0 +1,56 @@
+"""Inject ``X-Entitlements-Version`` on every authenticated response.
+
+The ``Entitled`` dependency records the version it resolved on the request
+state; routes that never resolved it get one cache read here. Clients
+compare the header with the version they hold and refetch on a change, so
+an override, lapse, or payment lands on the user's very next request.
+Header failures are swallowed: the header is advisory and must never fail a
+response whose work already completed.
+"""
+
+from __future__ import annotations
+
+from bson import ObjectId
+from starlette.datastructures import MutableHeaders
+
+from infrastructure.logging import get_logger
+
+log = get_logger(__name__)
+
+HEADER = "X-Entitlements-Version"
+
+
+class EntitlementsVersionMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                version = await self._version(scope)
+                if version is not None:
+                    MutableHeaders(raw=message["headers"])[HEADER] = str(version)
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+    @staticmethod
+    async def _version(scope) -> int | None:
+        state = scope.get("state", {})
+        version = state.get("entitlements_version")
+        if version is not None:
+            return version
+        auth_ctx = state.get("auth_ctx")
+        if not auth_ctx:
+            return None
+        service = getattr(scope["app"].state, "entitlement_service", None)
+        if service is None:
+            return None
+        try:
+            return await service.version_for(ObjectId(auth_ctx["user_id"]))
+        except Exception:
+            log.warning("entitlements_version_header_failed", exc_info=True)
+            return None

--- a/middleware/security.py
+++ b/middleware/security.py
@@ -24,7 +24,8 @@ _ALLOWED_HEADERS = "Authorization, Content-Type, Accept, X-Request-ID, X-Spoo-Cl
 # Content-Type, Expires, Last-Modified, Pragma) is readable without it.
 _EXPOSED_HEADERS = (
     "X-Request-ID, X-Error-Code, X-Spoo-Hint, X-RateLimit-Limit, "
-    "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After"
+    "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After, "
+    "X-Entitlements-Version"
 )
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -7884,7 +7884,7 @@
           "Me"
         ],
         "summary": "Get Feature Availability",
-        "description": "Return the availability state of every gated feature for this account.\n\nStates: `enabled` (render it), `hidden` (the feature doesn't exist for\nthis account), `locked` (reserved \u2014 render as upgrade-gated once plans\nship). Treat features missing from the map as `hidden`. Never used for\nenforcement \u2014 the write endpoints enforce the same gates server-side.\n\n**Authentication**: Required.",
+        "description": "Return the availability state of every gated feature for this account.\n\nStates: `enabled` (render it), `hidden` (the feature doesn't exist for\nthis account), `locked` (render it upgrade-gated: the plan does not\ninclude it). Treat features missing from the map as `hidden`. Never used\nfor enforcement \u2014 the write endpoints enforce the same gates server-side.\n\n**Authentication**: Required.",
         "operationId": "getMyFeatures",
         "responses": {
           "200": {
@@ -7893,6 +7893,88 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FeaturesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request \u2014 invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized \u2014 missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 insufficient permissions or scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict \u2014 resource already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/me/entitlements": {
+      "get": {
+        "tags": [
+          "Me"
+        ],
+        "summary": "My Entitlements",
+        "description": "Return the account's plan, feature states, limits with live usage, and\nthe entitlement version.\n\n`version` changes on every subscription or override write. After a\ncheckout, poll until it changes; on every authenticated response,\ncompare it with the `X-Entitlements-Version` header and refetch when\nthey differ.\n\n**Authentication**: Required.",
+        "operationId": "getMyEntitlements",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitlementsResponse"
                 }
               }
             }
@@ -8643,6 +8725,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/plans": {
+      "get": {
+        "tags": [
+          "Plans"
+        ],
+        "summary": "List Plans",
+        "description": "Return the free and pro plans with their features, limits and prices.\n\nA self-hosted deployment has nothing to sell: `prices` is empty and\n`founding` is null there.\n\n**Authentication**: Not required.",
+        "operationId": "listPlans",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlansResponse"
                 }
               }
             }
@@ -12399,6 +12503,52 @@
         "title": "EmojiSetResponse",
         "description": "The accepted emoji catalogue and its policy caps.\n\nEmoji values are RAW characters in canonical form (no ``U+FE0F``). Each\ncarries its canonical Unicode category (``g``) and the array is ordered by\ncanonical group and within-group order, so a picker can render category\ntabs and open on Smileys rather than symbols."
       },
+      "EntitlementsResponse": {
+        "properties": {
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "description": "Owner entitlement version",
+            "examples": [
+              3
+            ]
+          },
+          "plan": {
+            "$ref": "#/components/schemas/PlanBlock"
+          },
+          "features": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FeatureState"
+            },
+            "type": "object",
+            "title": "Features",
+            "description": "Per-feature UI state; treat missing keys as hidden"
+          },
+          "limits": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/LimitBlock"
+            },
+            "type": "object",
+            "title": "Limits"
+          },
+          "over_limit": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/OverLimitBlock"
+            },
+            "type": "object",
+            "title": "Over Limit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "version",
+          "plan",
+          "features",
+          "limits"
+        ],
+        "title": "EntitlementsResponse",
+        "description": "Everything the dashboard needs to render plan state in one call.\n\n``version`` changes on every effective subscription or override write;\nclients poll it after checkout and compare it with the\n``X-Entitlements-Version`` header on every authenticated response."
+      },
       "ErrorResponse": {
         "properties": {
           "error": {
@@ -12582,6 +12732,51 @@
         "title": "FeaturesResponse",
         "description": "Per-feature availability for the authenticated account.\n\nKeys are the exposed feature names (``services.feature_flag_service.\nEXPOSED_FEATURES``); values tell the client what to render. Clients\nmust treat unknown keys as informational and missing keys as HIDDEN,\nso the feature list can grow without breaking older frontends."
       },
+      "FoundingBlock": {
+        "properties": {
+          "monthly": {
+            "$ref": "#/components/schemas/PriceBlock"
+          },
+          "year": {
+            "$ref": "#/components/schemas/PriceBlock"
+          },
+          "seats_total": {
+            "type": "integer",
+            "title": "Seats Total"
+          },
+          "seats_left": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seats Left",
+            "description": "Null until billing reports the count"
+          },
+          "until": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Until",
+            "description": "Null until the checkout window opens"
+          }
+        },
+        "type": "object",
+        "required": [
+          "monthly",
+          "year",
+          "seats_total"
+        ],
+        "title": "FoundingBlock"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -12665,6 +12860,38 @@
         },
         "type": "object",
         "title": "LayoutResponse"
+      },
+      "LimitBlock": {
+        "properties": {
+          "max": {
+            "type": "integer",
+            "title": "Max",
+            "description": "Plan maximum; -1 means unlimited",
+            "examples": [
+              5
+            ]
+          },
+          "used": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Used",
+            "description": "Live count for countable limits; null for windows and rates",
+            "examples": [
+              2
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "max"
+        ],
+        "title": "LimitBlock"
       },
       "LinkStatsResponse": {
         "properties": {
@@ -13377,6 +13604,141 @@
         "title": "OnboardingStateResponse",
         "description": "Response body for GET/PUT /auth/onboarding (200).\n\nA resume pointer, nothing more. Empty (step=null) means nothing to\nresume: never started, expired, or already completed \u2014 completion is\na permanent account fact exposed as ``user.onboarded_at`` on\n/auth/me, not part of this cache."
       },
+      "OverLimitBlock": {
+        "properties": {
+          "paused": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Paused",
+            "description": "Ids of items paused because the limit shrank below them"
+          }
+        },
+        "type": "object",
+        "required": [
+          "paused"
+        ],
+        "title": "OverLimitBlock"
+      },
+      "PlanBlock": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Effective plan",
+            "examples": [
+              "pro"
+            ]
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status",
+            "description": "Subscription status; null on the free plan",
+            "examples": [
+              "active"
+            ]
+          },
+          "until": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Until",
+            "description": "Term end, or the grace end while in grace; null when nothing ends"
+          },
+          "founding": {
+            "type": "boolean",
+            "title": "Founding",
+            "description": "Founding cohort member",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "PlanBlock"
+      },
+      "PlanEntry": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "examples": [
+              "pro"
+            ]
+          },
+          "features": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object",
+            "title": "Features"
+          },
+          "limits": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Limits",
+            "description": "-1 means unlimited"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "features",
+          "limits"
+        ],
+        "title": "PlanEntry"
+      },
+      "PlansResponse": {
+        "properties": {
+          "plans": {
+            "items": {
+              "$ref": "#/components/schemas/PlanEntry"
+            },
+            "type": "array",
+            "title": "Plans"
+          },
+          "prices": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PriceBlock"
+            },
+            "type": "object",
+            "title": "Prices",
+            "description": "Keyed by cadence: monthly (recurring), year (one-time); empty on a self-hosted deployment"
+          },
+          "founding": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundingBlock"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "plans"
+        ],
+        "title": "PlansResponse",
+        "description": "Public projection of the feature catalog plus display prices."
+      },
       "PreviewDestination": {
         "properties": {
           "url": {
@@ -13476,6 +13838,31 @@
         ],
         "title": "PreviewVariantDestination",
         "description": "One A/B variant destination with its traffic share in percent."
+      },
+      "PriceBlock": {
+        "properties": {
+          "amount": {
+            "type": "integer",
+            "title": "Amount",
+            "description": "Whole units",
+            "examples": [
+              15
+            ]
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency",
+            "examples": [
+              "USD"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "amount",
+          "currency"
+        ],
+        "title": "PriceBlock"
       },
       "ProfilePictureMessageResponse": {
         "properties": {
@@ -16026,7 +16413,7 @@
           "plan": {
             "type": "string",
             "title": "Plan",
-            "description": "Subscription plan",
+            "description": "Effective plan",
             "examples": [
               "free"
             ]

--- a/repositories/entitlement_event_repository.py
+++ b/repositories/entitlement_event_repository.py
@@ -1,0 +1,25 @@
+"""Repository for the append-only ``entitlement_events`` audit collection."""
+
+from __future__ import annotations
+
+from bson import ObjectId
+
+from repositories.base import BaseRepository
+from schemas.models.entitlement_event import EntitlementEventDoc, EntitlementEventKind
+
+_VERSIONLESS_KINDS = (EntitlementEventKind.REMINDER_SENT.value,)
+
+
+class EntitlementEventRepository(BaseRepository[EntitlementEventDoc]):
+    async def append(self, event: EntitlementEventDoc) -> ObjectId:
+        return await self._insert(event.to_mongo())
+
+    async def count_for(self, user_id: ObjectId) -> int:
+        """The user's entitlement version: one per write that changed what
+        they hold. Reminder events are audit only and do not bump it."""
+        return await self._count(
+            {"user_id": user_id, "kind": {"$nin": list(_VERSIONLESS_KINDS)}}
+        )
+
+    async def delete_by_user(self, user_id: ObjectId) -> int:
+        return await self._delete_many({"user_id": user_id})

--- a/repositories/entitlement_override_repository.py
+++ b/repositories/entitlement_override_repository.py
@@ -1,0 +1,160 @@
+"""
+Repository for ``entitlement_overrides``: one document per (user, key).
+
+Grant and revoke each write the audit event and drop the owner's cached
+entitlements in the same operation as the document change.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from infrastructure.cache.entitlement_cache import EntitlementCache
+from repositories.base import BaseRepository
+from repositories.entitlement_event_repository import EntitlementEventRepository
+from schemas.models.entitlement_event import EntitlementEventDoc, EntitlementEventKind
+from schemas.models.entitlement_override import EntitlementOverrideDoc, OverrideKind
+from shared.datetime_utils import as_aware_utc
+
+OverrideCheck = Callable[[str, bool | int], None]
+
+
+def _snapshot(doc: EntitlementOverrideDoc) -> dict:
+    return {
+        "key": doc.key,
+        "value": doc.value,
+        "kind": doc.kind.value,
+        "expires_at": as_aware_utc(doc.expires_at),
+    }
+
+
+class EntitlementOverrideRepository(BaseRepository[EntitlementOverrideDoc]):
+    def __init__(
+        self,
+        collection,
+        events: EntitlementEventRepository,
+        cache: EntitlementCache,
+        *,
+        check: OverrideCheck | None = None,
+    ) -> None:
+        super().__init__(collection)
+        self._events = events
+        self._cache = cache
+        # The catalog's validator, injected so this layer never imports services.
+        self._check = check
+
+    async def list_active(
+        self, user_id: ObjectId, now: datetime
+    ) -> list[EntitlementOverrideDoc]:
+        cursor = self._col.find(
+            {
+                "user_id": user_id,
+                "$or": [{"expires_at": None}, {"expires_at": {"$gt": now}}],
+            }
+        )
+        docs = await cursor.to_list(length=None)
+        return [EntitlementOverrideDoc.from_mongo(d) for d in docs]  # type: ignore[misc]
+
+    async def list_for(self, user_id: ObjectId) -> list[EntitlementOverrideDoc]:
+        docs = await self._col.find({"user_id": user_id}).to_list(length=None)
+        return [EntitlementOverrideDoc.from_mongo(d) for d in docs]  # type: ignore[misc]
+
+    async def grant(
+        self,
+        user_id: ObjectId,
+        key: str,
+        value: bool | int,
+        *,
+        kind: OverrideKind,
+        reason: str,
+        granted_by: str,
+        expires_at: datetime | None = None,
+        now: datetime | None = None,
+    ) -> EntitlementOverrideDoc:
+        if self._check is not None:
+            self._check(key, value)
+        now = now or datetime.now(timezone.utc)
+        existing = await self._find_one({"user_id": user_id, "key": key})
+        if (
+            existing is not None
+            and existing.value == value
+            and existing.kind is kind
+            and as_aware_utc(existing.expires_at) == as_aware_utc(expires_at)
+        ):
+            return existing
+
+        fields = {
+            "value": value,
+            "kind": kind.value,
+            "reason": reason,
+            "granted_by": granted_by,
+            "expires_at": expires_at,
+            "updated_at": now,
+        }
+        await self._col.update_one(
+            {"user_id": user_id, "key": key},
+            {"$set": fields, "$setOnInsert": {"created_at": now}},
+            upsert=True,
+        )
+        doc = EntitlementOverrideDoc(
+            user_id=user_id,
+            key=key,
+            value=value,
+            kind=kind,
+            reason=reason,
+            granted_by=granted_by,
+            expires_at=expires_at,
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+        await self._events.append(
+            EntitlementEventDoc(
+                user_id=user_id,
+                kind=EntitlementEventKind.OVERRIDE_GRANTED,
+                actor=granted_by,
+                reason=reason,
+                before=_snapshot(existing) if existing else None,
+                after=_snapshot(doc),
+                at=now,
+            )
+        )
+        await self._cache.invalidate(user_id)
+        return doc
+
+    async def revoke(
+        self,
+        user_id: ObjectId,
+        key: str,
+        *,
+        actor: str,
+        reason: str,
+        now: datetime | None = None,
+    ) -> bool:
+        now = now or datetime.now(timezone.utc)
+        existing = await self._find_one({"user_id": user_id, "key": key})
+        if existing is None:
+            return False
+        if not await self._delete({"_id": existing.id}):
+            return False
+        await self._events.append(
+            EntitlementEventDoc(
+                user_id=user_id,
+                kind=EntitlementEventKind.OVERRIDE_REVOKED,
+                actor=actor,
+                reason=reason,
+                before=_snapshot(existing),
+                after=None,
+                at=now,
+            )
+        )
+        await self._cache.invalidate(user_id)
+        return True
+
+    async def delete_by_user(self, user_id: ObjectId) -> int:
+        deleted = await self._delete_many({"user_id": user_id})
+        if deleted:
+            await self._cache.invalidate(user_id)
+        return deleted

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -187,6 +187,19 @@ async def ensure_indexes(
     feature_flags_col = db["feature_flags"]
     await feature_flags_col.create_index([("name", 1)], unique=True)
 
+    # ── entitlements ───────────────────────────────────────────────────
+    # One per user; the status+date pairs are the lifecycle job's query shape.
+    subscriptions_col = db["subscriptions"]
+    await subscriptions_col.create_index([("user_id", 1)], unique=True)
+    await subscriptions_col.create_index([("status", 1), ("current_period_end", 1)])
+    await subscriptions_col.create_index([("status", 1), ("prepaid_until", 1)])
+    await subscriptions_col.create_index([("status", 1), ("grace_until", 1)])
+    overrides_col = db["entitlement_overrides"]
+    await overrides_col.create_index([("user_id", 1), ("key", 1)], unique=True)
+    await overrides_col.create_index([("expires_at", 1)], sparse=True)
+    ent_events_col = db["entitlement_events"]
+    await ent_events_col.create_index([("user_id", 1), ("at", -1)])
+
     # ── reports ────────────────────────────────────────────────────────
     # One doc per reported (domain, code) — domain is null for the system
     # default, so the compound unique still keys correctly. Velocity

--- a/repositories/subscription_repository.py
+++ b/repositories/subscription_repository.py
@@ -1,0 +1,152 @@
+"""
+Repository for the ``subscriptions`` collection.
+
+A status change is one operation here: the compare-and-set write, the audit
+event, and the owner's cache invalidation happen inside ``write_transition``
+so no caller can change a status without the other two.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+from errors import ConflictError
+from infrastructure.cache.entitlement_cache import EntitlementCache
+from repositories.base import BaseRepository
+from repositories.entitlement_event_repository import EntitlementEventRepository
+from schemas.models.entitlement_event import EntitlementEventDoc, EntitlementEventKind
+from schemas.models.subscription import SubscriptionDoc, SubscriptionStatus
+from shared.datetime_utils import as_aware_utc
+
+_SNAPSHOT_FIELDS = (
+    "status",
+    "kind",
+    "provider",
+    "current_period_end",
+    "prepaid_until",
+    "grace_until",
+    "founding",
+    "founding_streak_ok",
+)
+
+_EVENT_KIND_FOR_STATUS = {
+    SubscriptionStatus.GRACE: EntitlementEventKind.GRACE_STARTED,
+    SubscriptionStatus.LAPSED: EntitlementEventKind.LAPSED,
+}
+
+
+def _snapshot(doc: SubscriptionDoc | None) -> dict[str, Any] | None:
+    if doc is None:
+        return None
+    out: dict[str, Any] = {}
+    for f in _SNAPSHOT_FIELDS:
+        v = getattr(doc, f)
+        if isinstance(v, datetime):
+            v = as_aware_utc(v)
+        out[f] = v.value if hasattr(v, "value") else v
+    return out
+
+
+def _normalise(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return as_aware_utc(value)
+    return value.value if hasattr(value, "value") else value
+
+
+class SubscriptionRepository(BaseRepository[SubscriptionDoc]):
+    def __init__(
+        self,
+        collection,
+        events: EntitlementEventRepository,
+        cache: EntitlementCache,
+    ) -> None:
+        super().__init__(collection)
+        self._events = events
+        self._cache = cache
+
+    async def find_by_user(self, user_id: ObjectId) -> SubscriptionDoc | None:
+        return await self._find_one({"user_id": user_id})
+
+    async def write_transition(
+        self,
+        user_id: ObjectId,
+        *,
+        before: SubscriptionDoc | None,
+        after_status: SubscriptionStatus,
+        fields: dict[str, Any],
+        actor: str,
+        reason: str,
+        now: datetime | None = None,
+    ) -> SubscriptionDoc:
+        """Persist ``after_status`` plus ``fields`` for the user's subscription.
+
+        ``before`` is the document the caller decided the transition from; the
+        write is conditional on the stored status still matching it, so two
+        concurrent transitions cannot both win. A write that changes nothing
+        returns the current document and records no event.
+        """
+        now = now or datetime.now(timezone.utc)
+        changes = {k: v for k, v in fields.items() if k not in ("user_id", "status")}
+        if before is not None:
+            unchanged = before.status == after_status and all(
+                _normalise(getattr(before, k, None)) == _normalise(v)
+                for k, v in changes.items()
+            )
+            if unchanged:
+                return before
+
+        if before is None:
+            doc = SubscriptionDoc(
+                user_id=user_id,
+                status=after_status,
+                created_at=now,
+                updated_at=now,
+                **changes,
+            )
+            try:
+                inserted = await self._insert(doc.to_mongo())
+            except DuplicateKeyError:
+                raise ConflictError("subscription changed concurrently") from None
+            after = doc.model_copy(update={"id": inserted})
+        else:
+            matched = await self._update(
+                {"user_id": user_id, "status": before.status.value},
+                {"$set": {**changes, "status": after_status.value, "updated_at": now}},
+            )
+            if not matched:
+                raise ConflictError("subscription changed concurrently")
+            after = SubscriptionDoc.model_validate(
+                {
+                    **before.model_dump(),
+                    **changes,
+                    "status": after_status,
+                    "updated_at": now,
+                }
+            )
+
+        kind = EntitlementEventKind.SUBSCRIPTION_CHANGED
+        if before is None or before.status != after_status:
+            kind = _EVENT_KIND_FOR_STATUS.get(after_status, kind)
+        await self._events.append(
+            EntitlementEventDoc(
+                user_id=user_id,
+                kind=kind,
+                actor=actor,
+                reason=reason,
+                before=_snapshot(before),
+                after=_snapshot(after),
+                at=now,
+            )
+        )
+        await self._cache.invalidate(user_id)
+        return after
+
+    async def delete_by_user(self, user_id: ObjectId) -> int:
+        deleted = await self._delete_many({"user_id": user_id})
+        if deleted:
+            await self._cache.invalidate(user_id)
+        return deleted

--- a/routes/api_v1/__init__.py
+++ b/routes/api_v1/__init__.py
@@ -14,6 +14,7 @@ from routes.api_v1 import (
     management,
     me,
     metadata,
+    plans,
     public_preview,
     public_stats,
     reports,
@@ -41,6 +42,7 @@ router.include_router(metadata.router)
 router.include_router(expand.router)
 router.include_router(domain_intel.router)
 router.include_router(me.router)
+router.include_router(plans.router)
 router.include_router(public_preview.router)
 router.include_router(reports.router)
 router.include_router(webhooks.router)

--- a/routes/api_v1/me.py
+++ b/routes/api_v1/me.py
@@ -1,6 +1,7 @@
 """
 DELETE /api/v1/me                — request account deletion (grace period)
-GET    /api/v1/me/features       — per-account feature availability
+GET    /api/v1/me/entitlements   — plan, feature states, limits, version
+GET    /api/v1/me/features       — the features map alone
 GET    /api/v1/me/layouts/{page} — fetch the saved dashboard layout (null = default)
 PUT    /api/v1/me/layouts/{page} — save the layout document verbatim
 DELETE /api/v1/me/layouts/{page} — reset to default (idempotent)
@@ -23,6 +24,8 @@ from fastapi import APIRouter, Path, Request
 
 from dependencies import (
     AccountDeletionSvc,
+    Entitled,
+    EntitlementSvc,
     FeatureFlagSvc,
     JwtUser,
     PageLayoutSvc,
@@ -37,12 +40,18 @@ from schemas.dto.requests.profile_pictures import (
     UploadProfilePictureRequest,
 )
 from schemas.dto.responses.account import AccountDeletionResponse
+from schemas.dto.responses.entitlements import (
+    EntitlementsResponse,
+    LimitBlock,
+    PlanBlock,
+)
 from schemas.dto.responses.features import FeaturesResponse
 from schemas.dto.responses.layouts import LayoutResponse
 from schemas.dto.responses.profile_pictures import (
     AvailablePicturesResponse,
     ProfilePictureMessageResponse,
 )
+from services.features.catalog import int_features
 
 router = APIRouter(prefix="/me", tags=["Me"])
 
@@ -103,17 +112,60 @@ async def get_my_features(
     request: Request,
     user: JwtUser,
     flag_service: FeatureFlagSvc,
+    entitlements: Entitled,
 ) -> FeaturesResponse:
     """Return the availability state of every gated feature for this account.
 
     States: `enabled` (render it), `hidden` (the feature doesn't exist for
-    this account), `locked` (reserved — render as upgrade-gated once plans
-    ship). Treat features missing from the map as `hidden`. Never used for
-    enforcement — the write endpoints enforce the same gates server-side.
+    this account), `locked` (render it upgrade-gated: the plan does not
+    include it). Treat features missing from the map as `hidden`. Never used
+    for enforcement — the write endpoints enforce the same gates server-side.
 
     **Authentication**: Required.
     """
-    return FeaturesResponse(features=await flag_service.states_for(user))
+    return FeaturesResponse(features=await flag_service.states_for(user, entitlements))
+
+
+@router.get(
+    "/entitlements",
+    responses=AUTH_RESPONSES,
+    operation_id="getMyEntitlements",
+    summary="My Entitlements",
+)
+@limiter.limit(Limits.DASHBOARD_READ)
+async def get_my_entitlements(
+    request: Request,
+    user: JwtUser,
+    flag_service: FeatureFlagSvc,
+    entitlements: Entitled,
+    entitlement_service: EntitlementSvc,
+) -> EntitlementsResponse:
+    """Return the account's plan, feature states, limits with live usage, and
+    the entitlement version.
+
+    `version` changes on every subscription or override write. After a
+    checkout, poll until it changes; on every authenticated response,
+    compare it with the `X-Entitlements-Version` header and refetch when
+    they differ.
+
+    **Authentication**: Required.
+    """
+    features = await flag_service.states_for(user, entitlements)
+    used = await entitlement_service.usage_for(user.user_id)
+    return EntitlementsResponse(
+        version=entitlements.version,
+        plan=PlanBlock(
+            name=entitlements.plan.value,
+            status=entitlements.status.value if entitlements.status else None,
+            until=entitlements.until,
+            founding=entitlements.founding,
+        ),
+        features=features,
+        limits={
+            f.key: LimitBlock(max=entitlements.limit(f.key), used=used.get(f.key))
+            for f in int_features()
+        },
+    )
 
 
 # Closed set: every dashboard board the frontend actually renders. An

--- a/routes/api_v1/plans.py
+++ b/routes/api_v1/plans.py
@@ -1,0 +1,64 @@
+"""
+GET /api/v1/plans — public projection of the feature catalog with display prices.
+
+The pricing page and the upgrade page both read this, so marketing copy and
+enforcement come from the same table.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from dependencies import Settings
+from middleware.rate_limiter import Limits, limiter
+from schemas.dto.responses.entitlements import (
+    FoundingBlock,
+    PlanEntry,
+    PlansResponse,
+    PriceBlock,
+)
+from services.features.catalog import Plan, bool_features, int_features
+
+router = APIRouter(prefix="/plans", tags=["Plans"])
+
+_PUBLIC_PLANS = (Plan.FREE, Plan.PRO)
+_CURRENCY = "USD"
+
+
+@router.get(
+    "",
+    operation_id="listPlans",
+    summary="List Plans",
+)
+@limiter.limit(Limits.API_ANON)
+async def list_plans(request: Request, settings: Settings) -> PlansResponse:
+    """Return the free and pro plans with their features, limits and prices.
+
+    A self-hosted deployment has nothing to sell: `prices` is empty and
+    `founding` is null there.
+
+    **Authentication**: Not required.
+    """
+    billing = settings.billing
+    plans = [
+        PlanEntry(
+            name=plan.value,
+            features={f.key: bool(f.plans[plan]) for f in bool_features()},
+            limits={f.key: int(f.plans[plan]) for f in int_features()},
+        )
+        for plan in _PUBLIC_PLANS
+    ]
+    if billing.selfhost:
+        return PlansResponse(plans=plans)
+    return PlansResponse(
+        plans=plans,
+        prices={
+            "monthly": PriceBlock(amount=billing.pro_monthly_usd, currency=_CURRENCY),
+            "year": PriceBlock(amount=billing.pro_year_usd, currency=_CURRENCY),
+        },
+        founding=FoundingBlock(
+            monthly=PriceBlock(amount=billing.founding_monthly_usd, currency=_CURRENCY),
+            year=PriceBlock(amount=billing.founding_year_usd, currency=_CURRENCY),
+            seats_total=billing.founding_seats,
+        ),
+    )

--- a/routes/auth/device.py
+++ b/routes/auth/device.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from dependencies import (
     AppGrantRepo,
     DeviceAuthSvc,
+    EntitlementSvc,
     JwtConfig,
     JwtUser,
     OptionalUser,
@@ -269,6 +270,7 @@ async def device_token(
     request: Request,
     body: DeviceTokenRequest,
     device_auth_service: DeviceAuthSvc,
+    entitlement_service: EntitlementSvc,
 ) -> DeviceTokenResponse:
     """Exchange a one-time device auth code for JWT tokens.
 
@@ -288,7 +290,9 @@ async def device_token(
     return DeviceTokenResponse(
         access_token=result.access_token,
         refresh_token=result.refresh_token,
-        user=UserProfileResponse.from_user(result.user),
+        user=UserProfileResponse.from_user(
+            result.user, plan=await entitlement_service.plan_hint_for(result.user.id)
+        ),
     )
 
 

--- a/routes/auth/routes.py
+++ b/routes/auth/routes.py
@@ -24,6 +24,8 @@ from dependencies import (
     AccountDeletionSvc,
     AuthUser,
     CredentialSvc,
+    Entitled,
+    EntitlementSvc,
     JwtConfig,
     JwtUser,
     PasswordSvc,
@@ -96,6 +98,7 @@ async def login(
     response: Response,
     body: LoginRequest,
     credential_service: CredentialSvc,
+    entitlement_service: EntitlementSvc,
     jwt_cfg: JwtConfig,
 ) -> LoginResponse:
     """Authenticate with email and password.
@@ -116,7 +119,9 @@ async def login(
     set_auth_cookies(response, result.access_token, result.refresh_token, jwt_cfg)
     return LoginResponse(
         access_token=result.access_token,
-        user=UserProfileResponse.from_user(result.user),
+        user=UserProfileResponse.from_user(
+            result.user, plan=await entitlement_service.plan_hint_for(result.user.id)
+        ),
     )
 
 
@@ -134,6 +139,7 @@ async def register(
     response: Response,
     body: RegisterRequest,
     credential_service: CredentialSvc,
+    entitlement_service: EntitlementSvc,
     jwt_cfg: JwtConfig,
 ) -> RegisterResponse:
     """Create a new user account with email and password.
@@ -158,7 +164,9 @@ async def register(
     set_auth_cookies(response, result.access_token, result.refresh_token, jwt_cfg)
     return RegisterResponse(
         access_token=result.access_token,
-        user=UserProfileResponse.from_user(result.user),
+        user=UserProfileResponse.from_user(
+            result.user, plan=await entitlement_service.plan_hint_for(result.user.id)
+        ),
         requires_verification=True,
         verification_sent=result.verification_sent,
     )
@@ -306,6 +314,7 @@ async def me(
     request: Request,
     user: AuthUser,
     user_repo: UserRepo,
+    entitlements: Entitled,
 ) -> MeResponse:
     """Return the authenticated user's full profile.
 
@@ -318,7 +327,9 @@ async def me(
     **Rate Limits**: 60/min
     """
     profile = await fetch_user_profile(user_repo, ObjectId(str(user.user_id)))
-    return MeResponse(user=UserProfileResponse.from_user(profile))
+    return MeResponse(
+        user=UserProfileResponse.from_user(profile, plan=entitlements.plan.value)
+    )
 
 
 @router.patch(
@@ -333,6 +344,7 @@ async def update_me(
     body: UpdateProfileRequest,
     user: JwtUser,
     profile_service: ProfilePictureSvc,
+    entitlements: Entitled,
 ) -> MeResponse:
     """Update the authenticated user's profile.
 
@@ -349,7 +361,9 @@ async def update_me(
     updated = await profile_service.update_user_name(
         ObjectId(str(user.user_id)), user_name
     )
-    return MeResponse(user=UserProfileResponse.from_user(updated))
+    return MeResponse(
+        user=UserProfileResponse.from_user(updated, plan=entitlements.plan.value)
+    )
 
 
 @router.post(

--- a/schemas/dto/responses/auth.py
+++ b/schemas/dto/responses/auth.py
@@ -70,7 +70,7 @@ class UserProfileResponse(ResponseBase):
     user_name: str | None = Field(
         default=None, description="Display name", examples=["Jane Doe"]
     )
-    plan: str = Field(description="Subscription plan", examples=["free"])
+    plan: str = Field(description="Effective plan", examples=["free"])
     password_set: bool = Field(description="Whether the user has set a password")
     onboarded_at: UtcDatetime | None = Field(
         default=None,
@@ -83,8 +83,8 @@ class UserProfileResponse(ResponseBase):
     )
 
     @classmethod
-    def from_user(cls, user: UserDoc) -> UserProfileResponse:
-        """Build a UserProfileResponse from a UserDoc.
+    def from_user(cls, user: UserDoc, *, plan: str) -> UserProfileResponse:
+        """Build a UserProfileResponse from a UserDoc and the resolved plan.
 
         This is the single authoritative place for the profile response shape,
         replacing the old AuthService.get_user_profile() static helper.
@@ -94,7 +94,7 @@ class UserProfileResponse(ResponseBase):
             email=user.email,
             email_verified=user.email_verified,
             user_name=user.user_name,
-            plan=user.plan,
+            plan=plan,
             password_set=user.password_set,
             onboarded_at=user.onboarded_at,
             auth_providers=[

--- a/schemas/dto/responses/entitlements.py
+++ b/schemas/dto/responses/entitlements.py
@@ -1,0 +1,89 @@
+"""Response DTOs for GET /api/v1/me/entitlements and GET /api/v1/plans."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from schemas.dto.base import ResponseBase, UtcDatetime
+from schemas.enums.feature_state import FeatureState
+
+
+class PlanBlock(ResponseBase):
+    name: str = Field(description="Effective plan", examples=["pro"])
+    status: str | None = Field(
+        default=None,
+        description="Subscription status; null on the free plan",
+        examples=["active"],
+    )
+    until: UtcDatetime | None = Field(
+        default=None,
+        description="Term end, or the grace end while in grace; null when nothing ends",
+    )
+    founding: bool = Field(default=False, description="Founding cohort member")
+
+
+class LimitBlock(ResponseBase):
+    max: int = Field(description="Plan maximum; -1 means unlimited", examples=[5])
+    used: int | None = Field(
+        default=None,
+        description="Live count for countable limits; null for windows and rates",
+        examples=[2],
+    )
+
+
+class OverLimitBlock(ResponseBase):
+    paused: list[str] = Field(
+        description="Ids of items paused because the limit shrank below them"
+    )
+
+
+class EntitlementsResponse(ResponseBase):
+    """Everything the dashboard needs to render plan state in one call.
+
+    ``version`` changes on every effective subscription or override write;
+    clients poll it after checkout and compare it with the
+    ``X-Entitlements-Version`` header on every authenticated response.
+    """
+
+    version: int = Field(description="Owner entitlement version", examples=[3])
+    plan: PlanBlock
+    features: dict[str, FeatureState] = Field(
+        description="Per-feature UI state; treat missing keys as hidden"
+    )
+    limits: dict[str, LimitBlock]
+    over_limit: dict[str, OverLimitBlock] = Field(default_factory=dict)
+
+
+class PlanEntry(ResponseBase):
+    name: str = Field(examples=["pro"])
+    features: dict[str, bool]
+    limits: dict[str, int] = Field(description="-1 means unlimited")
+
+
+class PriceBlock(ResponseBase):
+    amount: int = Field(description="Whole units", examples=[15])
+    currency: str = Field(examples=["USD"])
+
+
+class FoundingBlock(ResponseBase):
+    monthly: PriceBlock
+    year: PriceBlock
+    seats_total: int
+    seats_left: int | None = Field(
+        default=None, description="Null until billing reports the count"
+    )
+    until: UtcDatetime | None = Field(
+        default=None, description="Null until the checkout window opens"
+    )
+
+
+class PlansResponse(ResponseBase):
+    """Public projection of the feature catalog plus display prices."""
+
+    plans: list[PlanEntry]
+    prices: dict[str, PriceBlock] = Field(
+        default_factory=dict,
+        description="Keyed by cadence: monthly (recurring), year (one-time); "
+        "empty on a self-hosted deployment",
+    )
+    founding: FoundingBlock | None = None

--- a/schemas/enums/plan.py
+++ b/schemas/enums/plan.py
@@ -1,0 +1,10 @@
+"""The plan a principal resolves to; the catalog keys its defaults by it."""
+
+from enum import Enum
+
+
+class Plan(str, Enum):
+    ANONYMOUS = "anonymous"
+    FREE = "free"
+    PRO = "pro"
+    SELFHOST = "selfhost"

--- a/schemas/enums/rollout_type.py
+++ b/schemas/enums/rollout_type.py
@@ -24,4 +24,3 @@ class RolloutType(str, Enum):
     ALLOWLIST = "allowlist"
     PERCENTAGE = "percentage"
     HEX_DIGIT = "hex_digit"
-    TIER = "tier"

--- a/schemas/models/entitlement_event.py
+++ b/schemas/models/entitlement_event.py
@@ -1,0 +1,35 @@
+"""
+Entitlement audit event: append-only record of every subscription
+transition, override write, and lifecycle action for a user.
+
+The count of a user's entitlement-changing events is their entitlement
+version: every effective write appends exactly one, so the version changes
+on grants and revokes alike, and never when a write changed nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from schemas.models.base import MongoBaseModel, PyObjectId
+
+
+class EntitlementEventKind(str, Enum):
+    SUBSCRIPTION_CHANGED = "subscription_changed"
+    OVERRIDE_GRANTED = "override_granted"
+    OVERRIDE_REVOKED = "override_revoked"
+    LAPSED = "lapsed"
+    GRACE_STARTED = "grace_started"
+    REMINDER_SENT = "reminder_sent"
+
+
+class EntitlementEventDoc(MongoBaseModel):
+    user_id: PyObjectId
+    kind: EntitlementEventKind
+    actor: str
+    reason: str
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    at: datetime

--- a/schemas/models/entitlement_override.py
+++ b/schemas/models/entitlement_override.py
@@ -1,0 +1,38 @@
+"""
+Entitlement override document: one per (user, feature key).
+
+The single mechanism for comps, beta access, abuse throttles, and custom
+limits. Values are absolute, never deltas: an override replaces the plan
+default for that key until it expires or is revoked.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from schemas.models.base import MongoBaseModel, PyObjectId
+from shared.datetime_utils import as_aware_utc
+
+
+class OverrideKind(str, Enum):
+    COMP = "comp"
+    BETA = "beta"
+    ABUSE = "abuse"
+    CUSTOM = "custom"
+
+
+class EntitlementOverrideDoc(MongoBaseModel):
+    user_id: PyObjectId
+    key: str
+    value: bool | int
+    kind: OverrideKind
+    reason: str
+    granted_by: str
+    expires_at: datetime | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def is_expired(self, now: datetime) -> bool:
+        exp = as_aware_utc(self.expires_at)
+        return exp is not None and exp <= now

--- a/schemas/models/feature_flag.py
+++ b/schemas/models/feature_flag.py
@@ -40,10 +40,6 @@ class FeatureFlagDoc(MongoBaseModel):
     # users. Stable hash places each user in exactly one bucket per flag.
     enabled_digits: list[str] = Field(default_factory=list)
 
-    # TIER field — defensive lookup via ``getattr(user, "tier", None)``.
-    # Null when not in TIER mode.
-    tier: str | None = None
-
     # Free-form note for the engineer editing Mongo. Not surfaced to users.
     description: str = ""
 

--- a/schemas/models/subscription.py
+++ b/schemas/models/subscription.py
@@ -1,0 +1,79 @@
+"""
+Subscription document model: the ``subscriptions`` collection, one per user.
+
+A missing document means the free plan. ``status`` is the only fact readers
+use to decide the plan; dates exist for the lifecycle job and the UI, and no
+request-path code does date math on them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import Field
+
+from schemas.enums.plan import Plan
+from schemas.models.base import MongoBaseModel, PyObjectId
+
+
+class SubscriptionStatus(str, Enum):
+    ACTIVE = "active"
+    PAST_DUE = "past_due"
+    CANCEL_AT_PERIOD_END = "cancel_at_period_end"
+    GRACE = "grace"
+    LAPSED = "lapsed"
+
+
+PRO_STATUSES: frozenset[SubscriptionStatus] = frozenset(
+    {
+        SubscriptionStatus.ACTIVE,
+        SubscriptionStatus.PAST_DUE,
+        SubscriptionStatus.CANCEL_AT_PERIOD_END,
+        SubscriptionStatus.GRACE,
+    }
+)
+
+
+class SubscriptionKind(str, Enum):
+    RECURRING = "recurring"
+    PREPAID = "prepaid"
+
+
+class SubscriptionProvider(str, Enum):
+    PADDLE = "paddle"
+    MANUAL = "manual"
+
+
+class SubscriptionDoc(MongoBaseModel):
+    user_id: PyObjectId
+    provider: SubscriptionProvider
+    provider_ids: dict[str, str] = Field(default_factory=dict)
+    plan: str = Plan.PRO.value
+    kind: SubscriptionKind
+    status: SubscriptionStatus
+    current_period_end: datetime | None = None
+    prepaid_until: datetime | None = None
+    grace_until: datetime | None = None
+    founding: bool = False
+    founding_streak_ok: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @property
+    def effective_plan(self) -> Plan:
+        return Plan.PRO if self.status in PRO_STATUSES else Plan.FREE
+
+    @property
+    def term_end(self) -> datetime | None:
+        """When the paid term stops: the prepaid end, or the current period end."""
+        if self.kind is SubscriptionKind.PREPAID:
+            return self.prepaid_until
+        return self.current_period_end
+
+    @property
+    def until(self) -> datetime | None:
+        """The date the UI shows next to the status."""
+        if self.status is SubscriptionStatus.GRACE:
+            return self.grace_until
+        return self.term_end

--- a/schemas/models/user.py
+++ b/schemas/models/user.py
@@ -39,12 +39,6 @@ class OAuthAction(str, Enum):
     LINK = "link"
 
 
-class UserPlan(str, Enum):
-    """User subscription plans."""
-
-    FREE = "free"
-
-
 class OAuthProvider(str, Enum):
     """Supported OAuth providers."""
 
@@ -104,7 +98,6 @@ class UserDoc(MongoBaseModel):
     Document model for the `users` collection.
 
     status: UserStatus enum (ACTIVE, INACTIVE, PENDING_DELETION)
-    plan: UserPlan enum (FREE)
     """
 
     email: str
@@ -114,7 +107,6 @@ class UserDoc(MongoBaseModel):
     user_name: str | None = None
     pfp: ProfilePicture | None = None
     auth_providers: list[AuthProviderEntry] = []  # noqa: RUF012
-    plan: UserPlan = UserPlan.FREE
     signup_ip: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/scripts/drop_users_plan.py
+++ b/scripts/drop_users_plan.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env -S uv run --script
+
+# PEP 723 metadata so this runs standalone via `uv run --script` (keep)
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pymongo>=4.6",
+# ]
+# ///
+"""One-shot migration: remove the retired ``users.plan`` field.
+
+The plan is now the status on the user's ``subscriptions`` document; a
+stored ``plan`` on the user is dead data that nothing reads. Also clears
+the retired ``tier`` field and ``rollout_type: "tier"`` on feature flags,
+which the app no longer recognises.
+
+Reads ``MONGODB_URI`` and (optional) ``DB_NAME`` from the environment.
+
+Usage::
+
+    uv run --env-file .env.production scripts/drop_users_plan.py
+    uv run --env-file .env.production scripts/drop_users_plan.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from pymongo import MongoClient
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    uri = os.environ.get("MONGODB_URI")
+    if not uri:
+        print("MONGODB_URI is not set", file=sys.stderr)
+        return 2
+    db = MongoClient(uri)[os.environ.get("DB_NAME", "url-shortener")]
+
+    users_with_plan = db["users"].count_documents({"plan": {"$exists": True}})
+    flags_with_tier = db["feature_flags"].count_documents(
+        {"$or": [{"tier": {"$exists": True}}, {"rollout_type": "tier"}]}
+    )
+    print(f"users with plan: {users_with_plan}, flags with tier: {flags_with_tier}")
+    if args.dry_run:
+        return 0
+
+    r1 = db["users"].update_many({"plan": {"$exists": True}}, {"$unset": {"plan": ""}})
+    r2 = db["feature_flags"].update_many(
+        {"tier": {"$exists": True}}, {"$unset": {"tier": ""}}
+    )
+    r3 = db["feature_flags"].update_many(
+        {"rollout_type": "tier"}, {"$set": {"rollout_type": "off"}}
+    )
+    print(
+        f"users updated: {r1.modified_count}, flags untiered: {r2.modified_count}, "
+        f"tier rollouts turned off: {r3.modified_count}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/account_erasure_service.py
+++ b/services/account_erasure_service.py
@@ -35,12 +35,19 @@ if TYPE_CHECKING:
     from repositories.api_key_repository import ApiKeyRepository
     from repositories.app_grant_repository import AppGrantRepository
     from repositories.click_repository import ClickRepository
+    from repositories.entitlement_event_repository import (
+        EntitlementEventRepository,
+    )
+    from repositories.entitlement_override_repository import (
+        EntitlementOverrideRepository,
+    )
     from repositories.feature_flag_repository import FeatureFlagRepository
     from repositories.page_layout_repository import PageLayoutRepository
     from repositories.report_repository import (
         ReportRepository,
         ReportSubmissionRepository,
     )
+    from repositories.subscription_repository import SubscriptionRepository
     from repositories.token_repository import TokenRepository
     from repositories.user_repository import UserRepository
     from repositories.webhook_delivery_repository import WebhookDeliveryRepository
@@ -130,6 +137,9 @@ class AccountErasureService:
         report_repo: ReportRepository,
         report_submission_repo: ReportSubmissionRepository,
         feature_flag_repo: FeatureFlagRepository,
+        subscription_repo: SubscriptionRepository,
+        override_repo: EntitlementOverrideRepository,
+        entitlement_event_repo: EntitlementEventRepository,
         r2_storage: R2StorageClient | None = None,
         posthog: PostHogEraser | None = None,
         mailer: ErasureMailer | None = None,
@@ -153,6 +163,9 @@ class AccountErasureService:
         self._report_repo = report_repo
         self._report_submission_repo = report_submission_repo
         self._feature_flag_repo = feature_flag_repo
+        self._subscription_repo = subscription_repo
+        self._override_repo = override_repo
+        self._entitlement_event_repo = entitlement_event_repo
         # None ⇒ no R2 on this deployment; the sweep step counts 0.
         self._r2_storage = r2_storage
         self._posthog = posthog or NoopPostHogEraser()
@@ -249,6 +262,13 @@ class AccountErasureService:
         counts["feature_flags_pulled"] = await self._feature_flag_repo.pull_allowlisted(
             user_id, email
         )
+        counts["subscriptions"] = await self._subscription_repo.delete_by_user(user_id)
+        counts["entitlement_overrides"] = await self._override_repo.delete_by_user(
+            user_id
+        )
+        counts[
+            "entitlement_events"
+        ] = await self._entitlement_event_repo.delete_by_user(user_id)
         counts["r2_objects"] = await self._sweep_r2(r2_prefixes)
         # External systems, then the doc itself — LAST among deletes.
         await self._erase_posthog(user_id)

--- a/services/auth/credentials.py
+++ b/services/auth/credentials.py
@@ -24,7 +24,7 @@ from infrastructure.email.protocol import EmailProvider
 from infrastructure.logging import get_logger
 from repositories.user_repository import UserRepository
 from schemas.models.token import TOKEN_TYPE_EMAIL_VERIFY
-from schemas.models.user import UserDoc, UserPlan, UserStatus
+from schemas.models.user import UserDoc, UserStatus
 from schemas.results import AuthResult
 from services.auth.otp import OtpService
 from services.token_factory import TokenFactory
@@ -97,7 +97,7 @@ class CredentialService:
             raise AccountPendingDeletionError("this account is scheduled for deletion")
 
         svc_log.info("login_success", user_id=str(user.id), auth_method="password")
-        access_token, refresh_token = self._tokens.issue_tokens(user, "pwd")
+        access_token, refresh_token = await self._tokens.issue_tokens(user, "pwd")
         return AuthResult(
             user=user, access_token=access_token, refresh_token=refresh_token
         )
@@ -143,7 +143,6 @@ class CredentialService:
             user_name=user_name,
             pfp=None,
             auth_providers=[],
-            plan=UserPlan.FREE,
             signup_ip=signup_ip,
             created_at=now,
             updated_at=now,
@@ -166,7 +165,7 @@ class CredentialService:
             has_username=bool(user_name),
         )
 
-        access_token, refresh_token = self._tokens.issue_tokens(user_doc, "pwd")
+        access_token, refresh_token = await self._tokens.issue_tokens(user_doc, "pwd")
 
         # Send verification email — non-fatal, do not fail registration on error
         verification_sent = False
@@ -232,7 +231,7 @@ class CredentialService:
         amr = claims.get("amr", ["pwd"])[0]
 
         svc_log.info("token_refreshed", user_id=user_id, amr=amr)
-        new_access, new_refresh = self._tokens.issue_tokens(user, amr)
+        new_access, new_refresh = await self._tokens.issue_tokens(user, amr)
         return AuthResult(
             user=user,
             access_token=new_access,

--- a/services/auth/device.py
+++ b/services/auth/device.py
@@ -210,7 +210,7 @@ class DeviceAuthService:
             app_id=app_id,
             scopes=scopes,
         )
-        access_token, refresh_token = self._tokens.issue_tokens(
+        access_token, refresh_token = await self._tokens.issue_tokens(
             user, "ext", app_id=app_id, scopes=scopes
         )
         return AuthResult(
@@ -264,7 +264,7 @@ class DeviceAuthService:
             app_id=app_id,
             scopes=scopes,
         )
-        access_token, refresh_token = self._tokens.issue_tokens(
+        access_token, refresh_token = await self._tokens.issue_tokens(
             user, amr, app_id=app_id, scopes=scopes
         )
         return AuthResult(

--- a/services/auth/verification.py
+++ b/services/auth/verification.py
@@ -97,7 +97,7 @@ class EmailVerificationService:
         user_data["email_verified"] = True
         updated_user = UserDoc.model_validate(user_data)
 
-        access_token, refresh_token = self._tokens.issue_tokens(updated_user, amr)
+        access_token, refresh_token = await self._tokens.issue_tokens(updated_user, amr)
 
         # Send welcome email — best-effort, do not fail verification on error
         try:

--- a/services/entitlements/__init__.py
+++ b/services/entitlements/__init__.py
@@ -1,0 +1,15 @@
+"""Entitlements: who holds which feature or limit right now."""
+
+from services.entitlements.resolver import ANONYMOUS, Resolved, for_plan, resolve
+from services.entitlements.service import EntitlementService
+from services.entitlements.state_machine import SubscriptionEvent, next_status
+
+__all__ = [
+    "ANONYMOUS",
+    "EntitlementService",
+    "Resolved",
+    "SubscriptionEvent",
+    "for_plan",
+    "next_status",
+    "resolve",
+]

--- a/services/entitlements/resolver.py
+++ b/services/entitlements/resolver.py
@@ -1,0 +1,66 @@
+"""
+Pure resolution: plan defaults with overrides applied on top.
+
+No I/O. ``resolve`` is the one rule (override beats plan default beats
+system default) and ``Resolved`` is the shape every reader consumes and
+the cache stores.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from infrastructure.logging import get_logger
+from schemas.models.entitlement_override import EntitlementOverrideDoc
+from schemas.models.subscription import SubscriptionStatus
+from services.features.catalog import FEATURES, UNLIMITED, Kind, Plan, plan_defaults
+
+log = get_logger(__name__)
+
+
+class Resolved(BaseModel):
+    plan: Plan
+    status: SubscriptionStatus | None = None
+    until: datetime | None = None
+    founding: bool = False
+    values: dict[str, bool | int]
+    version: int
+    # True when this answer came from a fallback because the stores were
+    # unreachable. Never cached, never sent as a version header.
+    degraded: bool = Field(default=False, exclude=True)
+
+    def has(self, key: str) -> bool:
+        return bool(self.values.get(key, False))
+
+    def limit(self, key: str) -> int:
+        value = self.values.get(key, 0)
+        return int(value) if not isinstance(value, bool) else 0
+
+    def is_unlimited(self, key: str) -> bool:
+        return self.limit(key) == UNLIMITED
+
+    def within_limit(self, key: str, current: int) -> bool:
+        return self.is_unlimited(key) or current < self.limit(key)
+
+
+def resolve(
+    plan: Plan, overrides: Iterable[EntitlementOverrideDoc] = ()
+) -> dict[str, bool | int]:
+    values = plan_defaults(plan)
+    for o in overrides:
+        feature = FEATURES.get(o.key)
+        if feature is None:
+            log.warning("entitlement_override_unknown_key", key=o.key)
+            continue
+        values[o.key] = bool(o.value) if feature.kind is Kind.BOOL else int(o.value)
+    return values
+
+
+def for_plan(plan: Plan, *, version: int = 0) -> Resolved:
+    return Resolved(plan=plan, values=plan_defaults(plan), version=version)
+
+
+ANONYMOUS: Resolved = for_plan(Plan.ANONYMOUS)

--- a/services/entitlements/service.py
+++ b/services/entitlements/service.py
@@ -1,0 +1,161 @@
+"""
+Entitlement resolution for a principal, with the per-owner versioned cache.
+
+``resolve_for`` is the one entry point for both read paths: the request
+path (user id from the token or API key) and the redirect path (owner id
+from the URL document). It never raises: when the stores are unreachable
+it returns the cached map, else the caller's plan hint, else free defaults,
+marked ``degraded`` so nothing writes it back to the cache.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+
+from infrastructure.cache.entitlement_cache import EntitlementCache
+from infrastructure.logging import get_logger
+from repositories.entitlement_event_repository import EntitlementEventRepository
+from repositories.entitlement_override_repository import (
+    EntitlementOverrideRepository,
+)
+from repositories.subscription_repository import SubscriptionRepository
+from schemas.models.subscription import SubscriptionDoc, SubscriptionStatus
+from services.entitlements.resolver import ANONYMOUS, Resolved, for_plan, resolve
+from services.entitlements.state_machine import SubscriptionEvent, next_status
+from services.features.catalog import Plan
+
+log = get_logger(__name__)
+
+UsageCounter = Callable[[ObjectId], Awaitable[int]]
+
+
+class EntitlementService:
+    def __init__(
+        self,
+        subscriptions: SubscriptionRepository,
+        overrides: EntitlementOverrideRepository,
+        events: EntitlementEventRepository,
+        cache: EntitlementCache,
+        *,
+        selfhost: bool,
+        usage: dict[str, UsageCounter] | None = None,
+    ) -> None:
+        self._subs = subscriptions
+        self._overrides = overrides
+        self._events = events
+        self._cache = cache
+        self._selfhost = selfhost
+        self._usage = usage or {}
+
+    @property
+    def selfhost(self) -> bool:
+        return self._selfhost
+
+    # ── Read ─────────────────────────────────────────────────────────────
+
+    async def resolve_for(
+        self, user_id: ObjectId | None, *, plan_hint: str | None = None
+    ) -> Resolved:
+        if user_id is None:
+            return ANONYMOUS
+        if self._selfhost:
+            return for_plan(Plan.SELFHOST)
+
+        cached = await self._cache.get(user_id)
+        if cached is not None:
+            return cached
+
+        try:
+            resolved, settled = await self._compute(user_id)
+        except Exception as e:
+            log.error("entitlements_degraded", user_id=str(user_id), error=str(e))
+            return self._fallback(plan_hint)
+
+        if settled:
+            await self._cache.set(user_id, resolved)
+        return resolved
+
+    async def _compute(self, user_id: ObjectId) -> tuple[Resolved, bool]:
+        """The resolved map, and whether it is safe to cache.
+
+        A write landing between the two version reads would leave the cache
+        holding the old map under the new version for a full TTL, so that
+        answer is returned but not stored.
+        """
+        now = datetime.now(timezone.utc)
+        version = await self._events.count_for(user_id)
+        sub = await self._subs.find_by_user(user_id)
+        overrides = await self._overrides.list_active(user_id, now)
+        settled = await self._events.count_for(user_id) == version
+        plan = sub.effective_plan if sub else Plan.FREE
+        resolved = Resolved(
+            plan=plan,
+            status=sub.status if sub else None,
+            until=sub.until if sub else None,
+            founding=bool(sub and sub.founding),
+            values=resolve(plan, overrides),
+            version=version,
+        )
+        return resolved, settled
+
+    @staticmethod
+    def _fallback(plan_hint: str | None) -> Resolved:
+        # A hint can only ever downgrade the answer: pro is the ceiling and
+        # anything unrecognised is free.
+        plan = Plan.PRO if plan_hint == Plan.PRO.value else Plan.FREE
+        fallback = for_plan(plan)
+        return fallback.model_copy(update={"degraded": True})
+
+    async def plan_hint_for(self, user_id: ObjectId) -> str:
+        """Plan name for the JWT claim. Never raises."""
+        try:
+            return (await self.resolve_for(user_id)).plan.value
+        except Exception:
+            return Plan.FREE.value
+
+    async def version_for(self, user_id: ObjectId) -> int | None:
+        resolved = await self.resolve_for(user_id)
+        return None if resolved.degraded else resolved.version
+
+    async def usage_for(self, user_id: ObjectId) -> dict[str, int]:
+        """Live ``used`` counts for the limits that count something."""
+        out: dict[str, int] = {}
+        for key, counter in self._usage.items():
+            out[key] = await counter(user_id)
+        return out
+
+    # ── Write ────────────────────────────────────────────────────────────
+
+    async def transition(
+        self,
+        user_id: ObjectId,
+        event: SubscriptionEvent,
+        *,
+        actor: str,
+        reason: str,
+        now: datetime | None = None,
+        **fields: Any,
+    ) -> SubscriptionDoc:
+        """Apply ``event`` to the user's subscription.
+
+        The state machine decides the next status; the repository writes it
+        with the audit event and cache invalidation. Raises
+        ``InvalidTransitionError`` for an event the current status rejects.
+        """
+        before = await self._subs.find_by_user(user_id)
+        after_status = next_status(before.status if before else None, event)
+        if after_status is SubscriptionStatus.GRACE and "grace_until" not in fields:
+            raise ValueError("a transition to grace needs grace_until")
+        return await self._subs.write_transition(
+            user_id,
+            before=before,
+            after_status=after_status,
+            fields=fields,
+            actor=actor,
+            reason=reason,
+            now=now,
+        )

--- a/services/entitlements/state_machine.py
+++ b/services/entitlements/state_machine.py
@@ -1,0 +1,79 @@
+"""
+Subscription status state machine.
+
+``next_status(current, event)`` is the only place a status may change. It
+returns the status after the event, the same status when the event is a
+no-op in that state, and raises ``InvalidTransitionError`` when the event
+cannot legally arrive in that state. Backward moves from payment events
+(a late ``payment_succeeded`` on a grace or lapsed subscription) are
+rejections, not transitions: only ``GRANTED`` reactivates.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from errors import InvalidTransitionError
+from schemas.models.subscription import SubscriptionStatus as S
+
+
+class SubscriptionEvent(str, Enum):
+    # A new checkout, a repurchase, or a manual grant.
+    GRANTED = "granted"
+    PAYMENT_SUCCEEDED = "payment_succeeded"
+    PAYMENT_FAILED = "payment_failed"
+    CANCEL_SCHEDULED = "cancel_scheduled"
+    CANCEL_REVOKED = "cancel_revoked"
+    TERM_ENDED = "term_ended"
+    GRACE_ENDED = "grace_ended"
+    PAST_DUE_CEILING = "past_due_ceiling"
+    # Immediate end with no grace: a full refund or a manual end.
+    ENDED = "ended"
+
+
+E = SubscriptionEvent
+
+# (current status, event) -> next status. Absent pairs are rejected.
+# ``None`` as the current status means no subscription exists yet.
+_TRANSITIONS: dict[tuple[S | None, E], S] = {
+    (None, E.GRANTED): S.ACTIVE,
+    (S.ACTIVE, E.GRANTED): S.ACTIVE,
+    (S.PAST_DUE, E.GRANTED): S.ACTIVE,
+    (S.CANCEL_AT_PERIOD_END, E.GRANTED): S.ACTIVE,
+    (S.GRACE, E.GRANTED): S.ACTIVE,
+    (S.LAPSED, E.GRANTED): S.ACTIVE,
+    (S.ACTIVE, E.PAYMENT_SUCCEEDED): S.ACTIVE,
+    (S.PAST_DUE, E.PAYMENT_SUCCEEDED): S.ACTIVE,
+    (S.CANCEL_AT_PERIOD_END, E.PAYMENT_SUCCEEDED): S.CANCEL_AT_PERIOD_END,
+    (S.ACTIVE, E.PAYMENT_FAILED): S.PAST_DUE,
+    (S.PAST_DUE, E.PAYMENT_FAILED): S.PAST_DUE,
+    (S.CANCEL_AT_PERIOD_END, E.PAYMENT_FAILED): S.PAST_DUE,
+    (S.ACTIVE, E.CANCEL_SCHEDULED): S.CANCEL_AT_PERIOD_END,
+    (S.PAST_DUE, E.CANCEL_SCHEDULED): S.CANCEL_AT_PERIOD_END,
+    (S.CANCEL_AT_PERIOD_END, E.CANCEL_SCHEDULED): S.CANCEL_AT_PERIOD_END,
+    (S.ACTIVE, E.CANCEL_REVOKED): S.ACTIVE,
+    (S.CANCEL_AT_PERIOD_END, E.CANCEL_REVOKED): S.ACTIVE,
+    (S.ACTIVE, E.TERM_ENDED): S.GRACE,
+    (S.CANCEL_AT_PERIOD_END, E.TERM_ENDED): S.GRACE,
+    (S.GRACE, E.TERM_ENDED): S.GRACE,
+    (S.LAPSED, E.TERM_ENDED): S.LAPSED,
+    (S.GRACE, E.GRACE_ENDED): S.LAPSED,
+    (S.LAPSED, E.GRACE_ENDED): S.LAPSED,
+    (S.PAST_DUE, E.PAST_DUE_CEILING): S.LAPSED,
+    (S.LAPSED, E.PAST_DUE_CEILING): S.LAPSED,
+    (S.ACTIVE, E.ENDED): S.LAPSED,
+    (S.PAST_DUE, E.ENDED): S.LAPSED,
+    (S.CANCEL_AT_PERIOD_END, E.ENDED): S.LAPSED,
+    (S.GRACE, E.ENDED): S.LAPSED,
+    (S.LAPSED, E.ENDED): S.LAPSED,
+}
+
+
+def next_status(current: S | None, event: E) -> S:
+    try:
+        return _TRANSITIONS[(current, event)]
+    except KeyError:
+        raise InvalidTransitionError(
+            f"event {event.value!r} cannot apply to status "
+            f"{current.value if current else 'none'!r}"
+        ) from None

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -1,20 +1,25 @@
 """
-Feature flag service.
+Feature flag service: the deployment-level evaluator.
 
-Public API is one method: ``is_enabled(name, user) -> bool``. Default-deny
-on every error path:
+Answers one question per catalog feature: is its rollout on in this
+deployment for this user. ``FEATURES[key].rollout`` names the
+``feature_flags`` document; ``None`` means the rollout is finished and the
+answer is always True. Default-deny on every error path:
 
+  - Key not in the catalog          → False
   - Doc missing                     → False (forces explicit registration)
   - Doc.enabled = False             → False
   - rollout_type = OFF              → False (kill switch)
   - user is None on a non-EVERYONE  → False
   - Cache + repo failure            → False (with logged error)
 
+Plans are not this service's business. ``states_for`` joins its answer with
+the entitlement resolver's: flag off is hidden, flag on and entitled is
+enabled, flag on and not entitled is locked.
+
 The service consults a read-through Redis cache (60s positive TTL, 30s
 negative TTL). Flag mutations happen via direct mongosh edits with no app
-event, so changes propagate within the cache TTL window. This is acceptable
-for non-emergency rollouts; admin scripts can call ``cache.invalidate(name)``
-for an immediate flush after a hot edit.
+event, so changes propagate within the cache TTL window.
 
 Stable hashing uses ``blake2b(salt=name + user_id)`` so the same user gets
 different positions in different flags' rollouts, enabling independent
@@ -39,6 +44,7 @@ from repositories.feature_flag_repository import FeatureFlagRepository
 from schemas.enums.feature_state import FeatureState
 from schemas.enums.rollout_type import RolloutType
 from schemas.models.feature_flag import FeatureFlagDoc
+from services.features.catalog import FEATURES, bool_features
 
 if TYPE_CHECKING:
     # CurrentUser lives in dependencies.auth which imports back through
@@ -46,33 +52,23 @@ if TYPE_CHECKING:
     # type only for type-checking. ``__future__ annotations`` makes the
     # runtime annotation a string so the import is never resolved at runtime.
     from dependencies.auth import CurrentUser
+    from services.entitlements.resolver import Resolved
 
 log = get_logger(__name__)
 
-# Known flag names. Flag docs are edited directly in Mongo, so these
-# constants are the closest thing to a registry — code references flags
-# through them, never through bare string literals at call sites.
+# Catalog keys referenced by routes. Code names features through these,
+# never through bare string literals at call sites.
 CUSTOM_DOMAINS_FLAG = "custom_domains"
 GEO_TARGETING_FLAG = "geo_targeting"
 META_TAGS_FLAG = "custom_meta_tags"
-AB_TESTING_FLAG = "ab_testing"
+AB_TESTING_FLAG = "ab_variants"
 WEBHOOKS_FLAG = "webhooks"
 EXPIRED_FALLBACK_FLAG = "expired_fallback"
 LINK_SCHEDULING_FLAG = "link_scheduling"
 
-# Flags whose per-user answer is exposed to clients via GET /api/v1/me/
-# features, so frontends can decide what to render. Enforcement stays on
-# the API endpoints — this list only mirrors those gates as data. A flag
-# absent here is invisible to clients even when it gates an endpoint.
-EXPOSED_FEATURES: tuple[str, ...] = (
-    CUSTOM_DOMAINS_FLAG,
-    GEO_TARGETING_FLAG,
-    META_TAGS_FLAG,
-    AB_TESTING_FLAG,
-    WEBHOOKS_FLAG,
-    EXPIRED_FALLBACK_FLAG,
-    LINK_SCHEDULING_FLAG,
-)
+# Every BOOL feature in the catalog is exposed to clients via
+# GET /api/v1/me/entitlements so frontends can decide what to render.
+EXPOSED_FEATURES: tuple[str, ...] = tuple(f.key for f in bool_features())
 
 
 def _stable_hash(user_id: ObjectId, salt: str) -> int:
@@ -103,12 +99,19 @@ class FeatureFlagService:
         self._repo = repo
         self._cache = cache
 
-    async def is_enabled(self, name: str, user: CurrentUser | None) -> bool:
-        """Return whether ``name`` is enabled for ``user``.
+    async def is_enabled(self, key: str, user: CurrentUser | None) -> bool:
+        """Return whether the catalog feature ``key`` is rolled out to ``user``.
 
-        Default-deny on any error or unregistered flag.
+        Default-deny on any error or unknown key.
         """
-        flag = await self._lookup(name)
+        feature = FEATURES.get(key)
+        if feature is None:
+            log.warning("feature_flag_unknown_key", key=key)
+            return False
+        if feature.rollout is None:
+            return True
+
+        flag = await self._lookup(feature.rollout)
         if flag is None or not flag.enabled:
             return False
 
@@ -133,42 +136,42 @@ class FeatureFlagService:
         if rollout == RolloutType.HEX_DIGIT:
             return _digit_bucket(user.user_id, salt=flag.name) in flag.enabled_digits
 
-        if rollout == RolloutType.TIER:
-            # Default-deny when flag.tier is unset — None == None would
-            # otherwise enable for every user with no tier attribute.
-            if flag.tier is None:
-                return False
-            return getattr(user, "tier", None) == flag.tier
-
         # Unreachable today — Pydantic validates rollout_type against the
         # RolloutType enum. Kept as default-deny if the field is ever widened.
-        log.warning("feature_flag_unknown_rollout", name=name, rollout=str(rollout))
+        log.warning(
+            "feature_flag_unknown_rollout", name=flag.name, rollout=str(rollout)
+        )
         return False
 
-    async def states_for(self, user: CurrentUser | None) -> dict[str, FeatureState]:
+    async def states_for(
+        self, user: CurrentUser | None, entitlements: Resolved
+    ) -> dict[str, FeatureState]:
         """Per-user state of every client-exposed feature.
 
-        Today the policy is binary: enabled → ENABLED, everything else →
-        HIDDEN (a gated feature simply doesn't exist for accounts without
-        it). LOCKED enters the policy when paid plans ship — non-entitled
-        accounts flip from HIDDEN to LOCKED server-side, and clients that
-        already render all three states need no deploy.
+        Flag off → HIDDEN (the feature does not exist here yet). Flag on and
+        entitled → ENABLED. Flag on and not entitled → LOCKED, so the client
+        renders the upsell instead of nothing.
 
         Inherits ``is_enabled``'s default-deny: unregistered flags, cache
         and repo failures all read as HIDDEN.
         """
         answers = await asyncio.gather(
-            *(self.is_enabled(name, user) for name in EXPOSED_FEATURES)
+            *(self.is_enabled(key, user) for key in EXPOSED_FEATURES)
         )
-        return {
-            name: FeatureState.ENABLED if enabled else FeatureState.HIDDEN
-            for name, enabled in zip(EXPOSED_FEATURES, answers, strict=True)
-        }
+        states: dict[str, FeatureState] = {}
+        for key, rolled_out in zip(EXPOSED_FEATURES, answers, strict=True):
+            if not rolled_out:
+                states[key] = FeatureState.HIDDEN
+            elif entitlements.has(key):
+                states[key] = FeatureState.ENABLED
+            else:
+                states[key] = FeatureState.LOCKED
+        return states
 
     async def require(
-        self, name: str, user: CurrentUser | None, *, hide: bool = False
+        self, key: str, user: CurrentUser | None, *, hide: bool = False
     ) -> None:
-        """Raise unless ``name`` is enabled for ``user``.
+        """Raise unless ``key`` is rolled out to ``user``.
 
         403 by default — the right signal for flag-gated FIELDS on shared
         endpoints, which appear in public OpenAPI docs and can't be
@@ -176,11 +179,11 @@ class FeatureFlagService:
         existence is itself gated (the custom-domains pattern): 404, so
         non-allowlisted callers can't tell the feature exists.
         """
-        if await self.is_enabled(name, user):
+        if await self.is_enabled(key, user):
             return
         if hide:
             raise NotFoundError("not found")
-        feature = name.replace("_", " ").capitalize()
+        feature = key.replace("_", " ").capitalize()
         raise ForbiddenError(f"{feature} is not enabled for this account")
 
     async def _lookup(self, name: str) -> FeatureFlagDoc | None:

--- a/services/features/__init__.py
+++ b/services/features/__init__.py
@@ -1,0 +1,27 @@
+"""One catalog of features: rollout spec and plan defaults, declared once."""
+
+from services.features.catalog import (
+    FEATURES,
+    Feature,
+    Kind,
+    Lapse,
+    OverLimit,
+    Plan,
+    bool_features,
+    int_features,
+    plan_defaults,
+    validate_override,
+)
+
+__all__ = [
+    "FEATURES",
+    "Feature",
+    "Kind",
+    "Lapse",
+    "OverLimit",
+    "Plan",
+    "bool_features",
+    "int_features",
+    "plan_defaults",
+    "validate_override",
+]

--- a/services/features/catalog.py
+++ b/services/features/catalog.py
@@ -1,0 +1,181 @@
+"""
+Feature catalog: every gated capability and limit, declared exactly once.
+
+Two evaluators read this table and nothing else declares a feature:
+
+- the flag service answers "is this feature rolled out in this deployment"
+  from ``rollout`` (the ``feature_flags`` document name; ``None`` means the
+  rollout is finished and the feature is always on)
+- the entitlement resolver answers "does this principal hold it" from
+  ``plans``
+
+A finished rollout is retired by setting ``rollout=None``, never by removing
+the entry, so a flag reaching 100% can never delete a paid gate. Limits are
+``INT`` and never have a rollout; ``-1`` means unlimited.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from schemas.enums.plan import Plan
+
+
+class Kind(str, Enum):
+    BOOL = "bool"
+    INT = "int"
+
+
+class Lapse(str, Enum):
+    """What existing data does when its owner loses a BOOL feature."""
+
+    DISABLE = "disable"
+    KEEP = "keep"
+    READONLY = "readonly"
+
+
+class OverLimit(str, Enum):
+    """What happens to existing items when an INT limit shrinks below them.
+
+    ``None`` on a limit means nothing is paused (windows, rates, batch sizes).
+    """
+
+    PAUSE_NEWEST = "pause_newest"
+    PAUSE_ALL = "pause_all"
+
+
+UNLIMITED = -1
+
+
+@dataclass(frozen=True)
+class Feature:
+    key: str
+    kind: Kind
+    rollout: str | None
+    plans: dict[Plan, bool | int]
+    lapse: Lapse | None = None
+    over_limit: OverLimit | None = None
+
+
+def _bool(
+    key: str, *, rollout: str | None, free: bool, lapse: Lapse, anonymous: bool = False
+) -> Feature:
+    return Feature(
+        key=key,
+        kind=Kind.BOOL,
+        rollout=rollout,
+        plans={
+            Plan.ANONYMOUS: anonymous,
+            Plan.FREE: free,
+            Plan.PRO: True,
+            Plan.SELFHOST: True,
+        },
+        lapse=lapse,
+    )
+
+
+def _int(
+    key: str, *, anonymous: int, free: int, pro: int, over_limit: OverLimit | None
+) -> Feature:
+    return Feature(
+        key=key,
+        kind=Kind.INT,
+        rollout=None,
+        plans={
+            Plan.ANONYMOUS: anonymous,
+            Plan.FREE: free,
+            Plan.PRO: pro,
+            Plan.SELFHOST: UNLIMITED,
+        },
+        over_limit=over_limit,
+    )
+
+
+_ENTRIES: tuple[Feature, ...] = (
+    _bool("geo_targeting", rollout="geo_targeting", free=False, lapse=Lapse.DISABLE),
+    _bool(
+        "custom_meta_tags", rollout="custom_meta_tags", free=False, lapse=Lapse.DISABLE
+    ),
+    _bool("ab_variants", rollout="ab_testing", free=False, lapse=Lapse.DISABLE),
+    _bool(
+        "expired_fallback", rollout="expired_fallback", free=False, lapse=Lapse.DISABLE
+    ),
+    _bool("link_scheduling", rollout="link_scheduling", free=False, lapse=Lapse.KEEP),
+    _bool("custom_domains", rollout="custom_domains", free=False, lapse=Lapse.DISABLE),
+    _bool("domain_polish", rollout="domain_polish", free=False, lapse=Lapse.DISABLE),
+    _bool("qr_custom_logo", rollout="qr_custom_logo", free=False, lapse=Lapse.KEEP),
+    _bool(
+        "live_click_stream",
+        rollout="live_click_stream",
+        free=False,
+        lapse=Lapse.DISABLE,
+    ),
+    _bool(
+        "analytics_extra_views",
+        rollout="analytics_extra_views",
+        free=False,
+        lapse=Lapse.DISABLE,
+    ),
+    _bool(
+        "viral_full_tracking",
+        rollout="viral_full_tracking",
+        free=False,
+        lapse=Lapse.DISABLE,
+    ),
+    # Rollout-only: every plan has webhooks, the endpoint count is the limit.
+    _bool("webhooks", rollout="webhooks", free=True, lapse=Lapse.KEEP),
+    _int(
+        "custom_domains_max",
+        anonymous=0,
+        free=0,
+        pro=5,
+        over_limit=OverLimit.PAUSE_NEWEST,
+    ),
+    _int(
+        "webhook_endpoints_max",
+        anonymous=0,
+        free=1,
+        pro=10,
+        over_limit=OverLimit.PAUSE_NEWEST,
+    ),
+    _int(
+        "api_keys_max", anonymous=0, free=20, pro=20, over_limit=OverLimit.PAUSE_NEWEST
+    ),
+    _int(
+        "analytics_window_days",
+        anonymous=90,
+        free=90,
+        pro=730,
+        over_limit=None,
+    ),
+    _int("api_rate_multiplier", anonymous=1, free=1, pro=5, over_limit=None),
+    _int("bulk_batch_max", anonymous=0, free=100, pro=1000, over_limit=None),
+)
+
+FEATURES: dict[str, Feature] = {f.key: f for f in _ENTRIES}
+
+
+def bool_features() -> tuple[Feature, ...]:
+    return tuple(f for f in FEATURES.values() if f.kind is Kind.BOOL)
+
+
+def int_features() -> tuple[Feature, ...]:
+    return tuple(f for f in FEATURES.values() if f.kind is Kind.INT)
+
+
+def plan_defaults(plan: Plan) -> dict[str, bool | int]:
+    return {key: f.plans[plan] for key, f in FEATURES.items()}
+
+
+def validate_override(key: str, value: bool | int) -> None:
+    """Reject an override the resolver would ignore or misread."""
+    feature = FEATURES.get(key)
+    if feature is None:
+        raise ValueError(f"unknown entitlement {key!r}")
+    if feature.kind is Kind.BOOL and not isinstance(value, bool):
+        raise ValueError(f"{key} takes a bool, got {value!r}")
+    if feature.kind is Kind.INT and (
+        isinstance(value, bool) or not isinstance(value, int)
+    ):
+        raise ValueError(f"{key} takes an int, got {value!r}")

--- a/services/oauth_service.py
+++ b/services/oauth_service.py
@@ -40,7 +40,6 @@ from schemas.models.user import (
     ProviderInfo,
     ProviderProfile,
     UserDoc,
-    UserPlan,
     UserStatus,
 )
 from schemas.results import AuthResult
@@ -180,7 +179,6 @@ class OAuthService:
                     linked_at=now,
                 )
             ],
-            plan=UserPlan.FREE,
             signup_ip=signup_ip,
             created_at=now,
             updated_at=now,
@@ -215,9 +213,9 @@ class OAuthService:
                 error_type=type(exc).__name__,
             )
 
-    def _make_tokens(self, user: UserDoc, provider_key: str) -> tuple[str, str]:
+    async def _make_tokens(self, user: UserDoc, provider_key: str) -> tuple[str, str]:
         """Issue access + refresh tokens for an OAuth user."""
-        return self._token_factory.issue_tokens(user, provider_key)
+        return await self._token_factory.issue_tokens(user, provider_key)
 
     @staticmethod
     def _ensure_not_pending_deletion(user: UserDoc, provider_key: str) -> None:
@@ -341,7 +339,9 @@ class OAuthService:
                 "oauth_account_linked", user_id=link_user_id, provider=provider_key
             )
             updated_user = await self._user_repo.find_by_id(ObjectId(link_user_id))
-            access_token, refresh_token = self._make_tokens(updated_user, provider_key)
+            access_token, refresh_token = await self._make_tokens(
+                updated_user, provider_key
+            )
             return AuthResult(
                 user=updated_user,
                 access_token=access_token,
@@ -361,7 +361,7 @@ class OAuthService:
                 provider=provider_key,
                 action="login",
             )
-            access_token, refresh_token = self._make_tokens(
+            access_token, refresh_token = await self._make_tokens(
                 existing_oauth_user, provider_key
             )
             return AuthResult(
@@ -399,7 +399,7 @@ class OAuthService:
                     provider=provider_key,
                 )
                 updated_user = await self._user_repo.find_by_id(existing_email_user.id)
-                access_token, refresh_token = self._make_tokens(
+                access_token, refresh_token = await self._make_tokens(
                     updated_user, provider_key
                 )
                 return AuthResult(
@@ -444,7 +444,7 @@ class OAuthService:
             )
 
         new_user = await self._user_repo.find_by_id(new_user_id)
-        access_token, refresh_token = self._make_tokens(new_user, provider_key)
+        access_token, refresh_token = await self._make_tokens(new_user, provider_key)
         return AuthResult(
             user=new_user,
             access_token=access_token,

--- a/services/profile_picture_service.py
+++ b/services/profile_picture_service.py
@@ -74,7 +74,6 @@ class ProfilePictureService:
             "email": user_doc.email,
             "email_verified": user_doc.email_verified,
             "user_name": user_doc.user_name,
-            "plan": user_doc.plan,
             "password_set": user_doc.password_set,
             "auth_providers": [
                 {

--- a/services/token_factory.py
+++ b/services/token_factory.py
@@ -7,6 +7,7 @@ and the PyJWT library. No database or email I/O happens here.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -22,10 +23,17 @@ class TokenFactory:
 
     Args:
         settings: JWT configuration (issuer, audience, keys, TTLs).
+        plan_of:  Async lookup of the user's plan name for the ``plan``
+                  claim. Optional; ``"free"`` when absent or failing.
     """
 
-    def __init__(self, settings: JWTSettings) -> None:
+    def __init__(
+        self,
+        settings: JWTSettings,
+        plan_of: Callable[[Any], Awaitable[str]] | None = None,
+    ) -> None:
         self._settings = settings
+        self._plan_of = plan_of
 
     # ── Key / algorithm helpers ───────────────────────────────────────────────
 
@@ -55,6 +63,7 @@ class TokenFactory:
         amr: str,
         app_id: str | None = None,
         scopes: list[str] | None = None,
+        plan: str = "free",
     ) -> str:
         """Issue a signed JWT access token for *user*.
 
@@ -68,6 +77,8 @@ class TokenFactory:
             email          — lowercased email from the user document (consumed
                              by feature-flag email allowlists via CurrentUser)
             email_verified — bool from the user document
+            plan           — plan name at issue time; a hint for the client
+                             and the resolver's last fallback, never authority
             app_id         — connected-app id (device auth flow only)
             scp            — granted scope slugs (device auth flow only;
                              omitted entirely for unrestricted tokens)
@@ -82,6 +93,7 @@ class TokenFactory:
             "amr": [amr],
             "email": user.email.lower(),
             "email_verified": user.email_verified,
+            "plan": plan,
         }
         if app_id:
             payload["app_id"] = app_id
@@ -115,7 +127,7 @@ class TokenFactory:
             payload["app_id"] = app_id
         return pyjwt.encode(payload, self._signing_key(), algorithm=self._algorithm())
 
-    def issue_tokens(
+    async def issue_tokens(
         self,
         user: UserDoc,
         amr: str,
@@ -132,8 +144,16 @@ class TokenFactory:
         Returns:
             (access_token, refresh_token)
         """
+        plan = "free"
+        if self._plan_of is not None:
+            try:
+                plan = await self._plan_of(user.id)
+            except Exception:
+                plan = "free"
         return (
-            self.generate_access_token(user, amr=amr, app_id=app_id, scopes=scopes),
+            self.generate_access_token(
+                user, amr=amr, app_id=app_id, scopes=scopes, plan=plan
+            ),
             self.generate_refresh_token(user, amr=amr, app_id=app_id),
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,8 @@ if not os.environ.get("JWT_SECRET"):
 from config import AppSettings
 from middleware.error_handler import register_error_handlers
 from middleware.rate_limiter import limiter
+from services.entitlements import for_plan
+from services.features.catalog import Plan
 
 _STATIC_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "static"
@@ -99,6 +101,12 @@ def build_test_app(
         app.state.app_grant_repo = AsyncMock()
         app.state.custom_domain_service = AsyncMock()
         app.state.feature_flag_service = AsyncMock()
+        app.state.entitlement_service = AsyncMock()
+        app.state.entitlement_service.resolve_for = AsyncMock(
+            return_value=for_plan(Plan.FREE)
+        )
+        app.state.entitlement_service.usage_for = AsyncMock(return_value={})
+        app.state.entitlement_service.plan_hint_for = AsyncMock(return_value="free")
         app.state.tenant_resolver = AsyncMock()
         # A REAL permissive L0 gate (no providers): valid URLs pass,
         # invalid/self-links reject — matches the pre-gate route behavior.

--- a/tests/db/test_erasure_cascade.py
+++ b/tests/db/test_erasure_cascade.py
@@ -211,6 +211,9 @@ async def test_erase_retains_blocked_links_through_domain_cascade(
         "report_submissions": 0,
         "reports_pulled": 0,
         "feature_flags_pulled": 0,
+        "subscriptions": 0,
+        "entitlement_overrides": 0,
+        "entitlement_events": 0,
         "r2_objects": 0,
     }
 

--- a/tests/integration/api_v1/test_me_entitlements.py
+++ b/tests/integration/api_v1/test_me_entitlements.py
@@ -1,0 +1,155 @@
+"""GET /api/v1/me/entitlements — plan block, features, limits with live usage,
+version; and the X-Entitlements-Version header contract."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from dependencies import (
+    get_current_user,
+    get_entitlement_service,
+    get_entitlements,
+    get_feature_flag_service,
+    require_jwt,
+)
+from schemas.models.subscription import SubscriptionStatus
+from services.entitlements import Resolved, for_plan
+from services.features.catalog import Plan, int_features, plan_defaults
+
+from .conftest import _build_test_app, _make_user
+from .test_me_features import _flag_svc
+
+
+def _app(user, resolved: Resolved, *, enabled: set[str] = frozenset(), used=None):
+    ent_service = AsyncMock()
+    ent_service.usage_for = AsyncMock(return_value=used or {})
+    return _build_test_app(
+        {
+            require_jwt: lambda: user,
+            get_current_user: lambda: user,
+            get_feature_flag_service: lambda: _flag_svc(set(enabled)),
+            get_entitlements: lambda: resolved,
+            get_entitlement_service: lambda: ent_service,
+        }
+    )
+
+
+def test_requires_auth():
+    app = _build_test_app({})
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v1/me/entitlements")
+    assert resp.status_code == 401
+
+
+def test_free_shape():
+    user = _make_user()
+    resolved = for_plan(Plan.FREE, version=0)
+    with TestClient(_app(user, resolved, enabled={"geo_targeting"})) as client:
+        resp = client.get("/api/v1/me/entitlements")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == 0
+    assert body["plan"] == {
+        "name": "free",
+        "status": None,
+        "until": None,
+        "founding": False,
+    }
+    assert body["features"]["geo_targeting"] == "locked"
+    assert set(body["limits"]) == {f.key for f in int_features()}
+    assert body["limits"]["custom_domains_max"] == {"max": 0, "used": None}
+    assert body["limits"]["webhook_endpoints_max"]["max"] == 1
+    assert body["over_limit"] == {}
+
+
+def test_pro_in_grace_carries_status_date_and_live_usage():
+    user = _make_user()
+    until = datetime(2026, 10, 1, tzinfo=timezone.utc)
+    resolved = Resolved(
+        plan=Plan.PRO,
+        status=SubscriptionStatus.GRACE,
+        until=until,
+        founding=True,
+        values=plan_defaults(Plan.PRO),
+        version=7,
+    )
+    used = {"custom_domains_max": 2, "webhook_endpoints_max": 3, "api_keys_max": 1}
+    with TestClient(
+        _app(user, resolved, enabled={"geo_targeting", "custom_domains"}, used=used)
+    ) as client:
+        resp = client.get("/api/v1/me/entitlements")
+    body = resp.json()
+    assert body["version"] == 7
+    assert body["plan"]["name"] == "pro"
+    assert body["plan"]["status"] == "grace"
+    assert body["plan"]["until"] == "2026-10-01T00:00:00+00:00"
+    assert body["plan"]["founding"] is True
+    assert body["features"]["geo_targeting"] == "enabled"
+    assert body["features"]["custom_domains"] == "enabled"
+    assert body["features"]["ab_variants"] == "hidden"
+    assert body["limits"]["custom_domains_max"] == {"max": 5, "used": 2}
+    assert body["limits"]["webhook_endpoints_max"] == {"max": 10, "used": 3}
+    assert body["limits"]["analytics_window_days"] == {"max": 730, "used": None}
+
+
+def test_version_header_is_set_from_the_dependency():
+    """Through the real dependency: the service resolves, the dependency
+    stores the version, the middleware emits it."""
+    from middleware.entitlements import HEADER, EntitlementsVersionMiddleware
+
+    user = _make_user()
+    resolved = for_plan(Plan.PRO, version=5)
+    ent_service = AsyncMock()
+    ent_service.resolve_for = AsyncMock(return_value=resolved)
+    ent_service.usage_for = AsyncMock(return_value={})
+    app = _build_test_app(
+        {
+            require_jwt: lambda: user,
+            get_current_user: lambda: user,
+            get_feature_flag_service: lambda: _flag_svc(set()),
+            get_entitlement_service: lambda: ent_service,
+        }
+    )
+    app.add_middleware(EntitlementsVersionMiddleware)
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/me/entitlements")
+    assert resp.status_code == 200
+    assert resp.headers[HEADER] == "5"
+    ent_service.resolve_for.assert_awaited_once_with(user.user_id, plan_hint=None)
+
+
+def test_dependency_passes_the_jwt_plan_hint():
+    user = _make_user()
+    user.plan_claim = "pro"
+    ent_service = AsyncMock()
+    ent_service.resolve_for = AsyncMock(return_value=for_plan(Plan.FREE))
+    ent_service.usage_for = AsyncMock(return_value={})
+    app = _build_test_app(
+        {
+            require_jwt: lambda: user,
+            get_current_user: lambda: user,
+            get_feature_flag_service: lambda: _flag_svc(set()),
+            get_entitlement_service: lambda: ent_service,
+        }
+    )
+    with TestClient(app) as client:
+        client.get("/api/v1/me/entitlements")
+    ent_service.resolve_for.assert_awaited_once_with(user.user_id, plan_hint="pro")
+
+
+def test_until_is_the_prepaid_end_for_an_active_prepaid():
+    user = _make_user()
+    end = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(days=300)
+    resolved = Resolved(
+        plan=Plan.PRO,
+        status=SubscriptionStatus.ACTIVE,
+        until=end,
+        values=plan_defaults(Plan.PRO),
+        version=1,
+    )
+    with TestClient(_app(user, resolved)) as client:
+        body = client.get("/api/v1/me/entitlements").json()
+    assert body["plan"]["until"] == end.isoformat()

--- a/tests/integration/api_v1/test_me_features.py
+++ b/tests/integration/api_v1/test_me_features.py
@@ -1,4 +1,4 @@
-"""GET /api/v1/me/features — per-account feature availability."""
+"""GET /api/v1/me/features — the features map: flag state joined with the plan."""
 
 from __future__ import annotations
 
@@ -8,25 +8,29 @@ from fastapi.testclient import TestClient
 
 from dependencies import (
     get_current_user,
+    get_entitlements,
     get_feature_flag_service,
     require_auth,
     require_jwt,
 )
+from services.entitlements import for_plan
 from services.feature_flag_service import (
     AB_TESTING_FLAG,
     CUSTOM_DOMAINS_FLAG,
     EXPOSED_FEATURES,
     GEO_TARGETING_FLAG,
     META_TAGS_FLAG,
+    WEBHOOKS_FLAG,
     FeatureFlagService,
 )
+from services.features.catalog import Plan
 
 from .conftest import _build_test_app, _make_api_key_doc, _make_user
 
 
 def _flag_svc(enabled_names: set[str]) -> FeatureFlagService:
     """A real service instance with only ``is_enabled`` faked, so the test
-    exercises the real ``states_for`` policy (enabled vs hidden)."""
+    exercises the real ``states_for`` join (hidden, locked, enabled)."""
     svc = FeatureFlagService.__new__(FeatureFlagService)
 
     async def _is_enabled(name: str, user) -> bool:
@@ -36,12 +40,13 @@ def _flag_svc(enabled_names: set[str]) -> FeatureFlagService:
     return svc
 
 
-def _app(user, enabled_names: set[str]):
+def _app(user, enabled_names: set[str], plan: Plan = Plan.FREE):
     return _build_test_app(
         {
             require_jwt: lambda: user,
             get_current_user: lambda: user,
             get_feature_flag_service: lambda: _flag_svc(enabled_names),
+            get_entitlements: lambda: for_plan(plan),
         }
     )
 
@@ -70,10 +75,9 @@ def test_api_key_rejected():
     assert resp.status_code == 403
 
 
-def test_all_hidden_by_default():
-    # No flags registered → default-deny → every exposed feature is hidden.
+def test_all_hidden_when_nothing_is_rolled_out():
     user = _make_user()
-    with TestClient(_app(user, set())) as client:
+    with TestClient(_app(user, set(), Plan.PRO)) as client:
         resp = client.get("/api/v1/me/features")
     assert resp.status_code == 200
     features = resp.json()["features"]
@@ -81,23 +85,36 @@ def test_all_hidden_by_default():
     assert set(features.values()) == {"hidden"}
 
 
-def test_enabled_flags_surface_as_enabled():
+def test_rolled_out_but_not_entitled_is_locked():
+    user = _make_user()
+    enabled = {GEO_TARGETING_FLAG, CUSTOM_DOMAINS_FLAG, WEBHOOKS_FLAG}
+    with TestClient(_app(user, enabled, Plan.FREE)) as client:
+        resp = client.get("/api/v1/me/features")
+    features = resp.json()["features"]
+    assert features[GEO_TARGETING_FLAG] == "locked"
+    assert features[CUSTOM_DOMAINS_FLAG] == "locked"
+    # Free holds webhooks, so a rolled-out flag reads enabled.
+    assert features[WEBHOOKS_FLAG] == "enabled"
+    assert features[META_TAGS_FLAG] == "hidden"
+    assert features[AB_TESTING_FLAG] == "hidden"
+
+
+def test_rolled_out_and_entitled_is_enabled():
     user = _make_user()
     enabled = {GEO_TARGETING_FLAG, CUSTOM_DOMAINS_FLAG}
-    with TestClient(_app(user, enabled)) as client:
+    with TestClient(_app(user, enabled, Plan.PRO)) as client:
         resp = client.get("/api/v1/me/features")
     features = resp.json()["features"]
     assert features[GEO_TARGETING_FLAG] == "enabled"
     assert features[CUSTOM_DOMAINS_FLAG] == "enabled"
     assert features[META_TAGS_FLAG] == "hidden"
-    assert features[AB_TESTING_FLAG] == "hidden"
 
 
 def test_response_covers_every_exposed_feature():
-    # The contract clients rely on: the map always carries the full registry,
+    # The contract clients rely on: the map always carries the full catalog,
     # so a frontend can treat "missing" as hidden without ever hitting it.
     user = _make_user()
-    with TestClient(_app(user, set(EXPOSED_FEATURES))) as client:
+    with TestClient(_app(user, set(EXPOSED_FEATURES), Plan.PRO)) as client:
         resp = client.get("/api/v1/me/features")
     features = resp.json()["features"]
     assert set(features) == set(EXPOSED_FEATURES)

--- a/tests/integration/api_v1/test_plans.py
+++ b/tests/integration/api_v1/test_plans.py
@@ -1,0 +1,72 @@
+"""GET /api/v1/plans — public catalog projection with display prices."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from services.features.catalog import Plan, bool_features, int_features, plan_defaults
+
+from .conftest import _build_test_app
+
+
+def test_public_and_shaped_from_the_catalog():
+    with TestClient(_build_test_app({})) as client:
+        resp = client.get("/api/v1/plans")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [p["name"] for p in body["plans"]] == ["free", "pro"]
+    free, pro = body["plans"]
+    assert set(free["features"]) == {f.key for f in bool_features()}
+    assert set(free["limits"]) == {f.key for f in int_features()}
+    assert pro["features"]["geo_targeting"] is True
+    assert free["features"]["geo_targeting"] is False
+    assert (
+        pro["limits"]["custom_domains_max"]
+        == plan_defaults(Plan.PRO)["custom_domains_max"]
+    )
+    assert free["limits"]["webhook_endpoints_max"] == 1
+
+
+def test_prices_come_from_config():
+    with patch.dict(
+        os.environ,
+        {
+            "BILLING_PROVIDER": "paddle",
+            "BILLING_PRO_MONTHLY_USD": "20",
+            "BILLING_PRO_YEAR_USD": "200",
+            "BILLING_FOUNDING_MONTHLY_USD": "11",
+        },
+    ):
+        app = _build_test_app({})
+    with TestClient(app) as client:
+        body = client.get("/api/v1/plans").json()
+    assert body["prices"]["monthly"] == {"amount": 20, "currency": "USD"}
+    assert body["prices"]["year"] == {"amount": 200, "currency": "USD"}
+    assert body["founding"]["monthly"]["amount"] == 11
+    assert body["founding"]["seats_total"] == 100
+    assert body["founding"]["seats_left"] is None
+    assert body["founding"]["until"] is None
+
+
+def test_default_prices_are_the_locked_ones():
+    with patch.dict(os.environ, {"BILLING_PROVIDER": "paddle"}):
+        app = _build_test_app({})
+    with TestClient(app) as client:
+        body = client.get("/api/v1/plans").json()
+    assert body["prices"]["monthly"]["amount"] == 15
+    assert body["prices"]["year"]["amount"] == 144
+    assert body["founding"]["monthly"]["amount"] == 9
+    assert body["founding"]["year"]["amount"] == 90
+
+
+def test_selfhost_has_nothing_to_sell():
+    with patch.dict(os.environ, {"BILLING_PROVIDER": "none"}):
+        app = _build_test_app({})
+    with TestClient(app) as client:
+        body = client.get("/api/v1/plans").json()
+    assert [p["name"] for p in body["plans"]] == ["free", "pro"]
+    assert body["prices"] == {}
+    assert body["founding"] is None

--- a/tests/integration/test_device_auth.py
+++ b/tests/integration/test_device_auth.py
@@ -170,6 +170,8 @@ def _app_factory():
             app.state.http_client = MagicMock()
             app.state.oauth_providers = {}
             app.state.app_registry = _TEST_APP_REGISTRY
+            app.state.entitlement_service = AsyncMock()
+            app.state.entitlement_service.plan_hint_for = AsyncMock(return_value="free")
             yield
 
         app = FastAPI(lifespan=lifespan)

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -255,7 +255,8 @@ def test_cors_public_route_exposes_headers():
         )
     assert resp.headers.get("access-control-expose-headers") == (
         "X-Request-ID, X-Error-Code, X-Spoo-Hint, X-RateLimit-Limit, "
-        "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After"
+        "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After, "
+        "X-Entitlements-Version"
     )
 
 
@@ -274,7 +275,8 @@ def test_cors_private_route_exposes_headers():
         )
     assert resp.headers.get("access-control-expose-headers") == (
         "X-Request-ID, X-Error-Code, X-Spoo-Hint, X-RateLimit-Limit, "
-        "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After"
+        "X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After, "
+        "X-Entitlements-Version"
     )
 
 

--- a/tests/smoke/test_click_sink_wiring.py
+++ b/tests/smoke/test_click_sink_wiring.py
@@ -37,6 +37,9 @@ _COLLECTIONS = (
     "safety_verdicts",
     "safety_feed_domains",
     "scheduled_tasks",
+    "subscriptions",
+    "entitlement_overrides",
+    "entitlement_events",
 )
 
 

--- a/tests/smoke/test_config_defaults.py
+++ b/tests/smoke/test_config_defaults.py
@@ -104,7 +104,11 @@ def test_is_production_true_for_production() -> None:
     """is_production should return True when env is 'production'."""
     with patch.dict(
         os.environ,
-        {"ENV": "production", "CUSTOM_DOMAINS_MOCK_DCV": "false"},
+        {
+            "ENV": "production",
+            "CUSTOM_DOMAINS_MOCK_DCV": "false",
+            "BILLING_PROVIDER": "none",
+        },
         clear=False,
     ):
         settings = AppSettings()

--- a/tests/smoke/test_custom_domain_cf_wiring.py
+++ b/tests/smoke/test_custom_domain_cf_wiring.py
@@ -47,6 +47,9 @@ def _wire(custom_domains: CustomDomainSettings):
         "safety_verdicts": MagicMock(name="safety_verdicts"),
         "safety_feed_domains": MagicMock(name="safety_feed_domains"),
         "scheduled_tasks": MagicMock(name="scheduled_tasks"),
+        "subscriptions": MagicMock(name="subscriptions"),
+        "entitlement_overrides": MagicMock(name="entitlement_overrides"),
+        "entitlement_events": MagicMock(name="entitlement_events"),
     }
     app.state.http_client = MagicMock()
     app.state.geoip = MagicMock()

--- a/tests/unit/middleware/test_entitlements_header.py
+++ b/tests/unit/middleware/test_entitlements_header.py
@@ -1,0 +1,72 @@
+"""X-Entitlements-Version rides every authenticated response."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from bson import ObjectId
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from middleware.entitlements import HEADER, EntitlementsVersionMiddleware
+
+UID = ObjectId()
+
+
+def _app(service=None):
+    app = FastAPI()
+    app.add_middleware(EntitlementsVersionMiddleware)
+    if service is not None:
+        app.state.entitlement_service = service
+
+    @app.get("/anon")
+    async def anon():
+        return {"ok": True}
+
+    @app.get("/resolved")
+    async def resolved(request: Request):
+        request.state.auth_ctx = {"user_id": str(UID)}
+        request.state.entitlements_version = 12
+        return {"ok": True}
+
+    @app.get("/authed")
+    async def authed(request: Request):
+        request.state.auth_ctx = {"user_id": str(UID)}
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_anonymous_response_has_no_header():
+    resp = _app().get("/anon")
+    assert HEADER not in resp.headers
+
+
+def test_version_from_the_dependency_is_used_verbatim():
+    service = AsyncMock()
+    resp = _app(service).get("/resolved")
+    assert resp.headers[HEADER] == "12"
+    service.version_for.assert_not_awaited()
+
+
+def test_authenticated_route_without_dependency_gets_one_lookup():
+    service = AsyncMock()
+    service.version_for = AsyncMock(return_value=4)
+    resp = _app(service).get("/authed")
+    assert resp.headers[HEADER] == "4"
+    service.version_for.assert_awaited_once_with(UID)
+
+
+def test_degraded_lookup_omits_the_header():
+    service = AsyncMock()
+    service.version_for = AsyncMock(return_value=None)
+    resp = _app(service).get("/authed")
+    assert HEADER not in resp.headers
+
+
+def test_lookup_failure_never_breaks_the_response():
+    service = AsyncMock()
+    service.version_for = AsyncMock(side_effect=RuntimeError("redis"))
+    resp = _app(service).get("/authed")
+    assert resp.status_code == 200
+    assert HEADER not in resp.headers

--- a/tests/unit/repositories/test_entitlement_repositories.py
+++ b/tests/unit/repositories/test_entitlement_repositories.py
@@ -1,0 +1,393 @@
+"""Subscription and override repositories: every effective write appends one
+audit event and drops the owner's cache; a no-op write does neither."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+from errors import ConflictError
+from repositories.entitlement_override_repository import (
+    EntitlementOverrideRepository,
+)
+from repositories.subscription_repository import SubscriptionRepository
+from schemas.models.entitlement_event import EntitlementEventKind
+from schemas.models.entitlement_override import OverrideKind
+from schemas.models.subscription import (
+    SubscriptionDoc,
+    SubscriptionKind,
+    SubscriptionProvider,
+    SubscriptionStatus,
+)
+from services.features.catalog import validate_override
+
+UID = ObjectId()
+NOW = datetime(2026, 9, 4, tzinfo=timezone.utc)
+
+
+def _col(name="subscriptions"):
+    col = MagicMock()
+    col.name = name
+    col.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    col.update_one = AsyncMock(
+        return_value=MagicMock(matched_count=1, modified_count=1)
+    )
+    col.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+    col.delete_many = AsyncMock(return_value=MagicMock(deleted_count=1))
+    col.find_one = AsyncMock(return_value=None)
+    return col
+
+
+def _events_and_cache():
+    events = AsyncMock()
+    events.append = AsyncMock()
+    cache = AsyncMock()
+    cache.invalidate = AsyncMock()
+    return events, cache
+
+
+def _sub_raw(status="active", **extra):
+    return {
+        "_id": ObjectId(),
+        "user_id": UID,
+        "provider": "paddle",
+        "kind": "recurring",
+        "status": status,
+        "current_period_end": NOW + timedelta(days=10),
+        "created_at": NOW,
+        "updated_at": NOW,
+        **extra,
+    }
+
+
+class TestSubscriptionRepository:
+    @pytest.mark.asyncio
+    async def test_first_grant_inserts_and_records_subscription_changed(self):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        doc = await repo.write_transition(
+            UID,
+            before=None,
+            after_status=SubscriptionStatus.ACTIVE,
+            fields={
+                "provider": SubscriptionProvider.PADDLE,
+                "kind": SubscriptionKind.RECURRING,
+                "current_period_end": NOW + timedelta(days=30),
+            },
+            actor="paddle",
+            reason="subscription.activated",
+            now=NOW,
+        )
+        assert doc.status is SubscriptionStatus.ACTIVE
+        assert doc.id is not None
+        col.insert_one.assert_awaited_once()
+        event = events.append.await_args.args[0]
+        assert event.kind is EntitlementEventKind.SUBSCRIPTION_CHANGED
+        assert event.before is None
+        assert event.after["status"] == "active"
+        cache.invalidate.assert_awaited_once_with(UID)
+
+    @pytest.mark.asyncio
+    async def test_status_change_is_a_compare_and_set(self):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        col.find_one.return_value = _sub_raw("active")
+        before = await repo.find_by_user(UID)
+        await repo.write_transition(
+            UID,
+            before=before,
+            after_status=SubscriptionStatus.PAST_DUE,
+            fields={},
+            actor="paddle",
+            reason="payment failed",
+            now=NOW,
+        )
+        query, ops = col.update_one.await_args.args
+        assert query == {"user_id": UID, "status": "active"}
+        assert ops["$set"]["status"] == "past_due"
+        assert ops["$set"]["updated_at"] == NOW
+
+    @pytest.mark.asyncio
+    async def test_lost_cas_raises_conflict_without_event(self):
+        col = _col()
+        col.update_one.return_value = MagicMock(matched_count=0)
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        col.find_one.return_value = _sub_raw("active")
+        before = await repo.find_by_user(UID)
+        with pytest.raises(ConflictError):
+            await repo.write_transition(
+                UID,
+                before=before,
+                after_status=SubscriptionStatus.PAST_DUE,
+                fields={},
+                actor="paddle",
+                reason="x",
+            )
+        events.append.assert_not_awaited()
+        cache.invalidate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_insert_raises_conflict(self):
+        col = _col()
+        col.insert_one.side_effect = DuplicateKeyError("dup")
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        with pytest.raises(ConflictError):
+            await repo.write_transition(
+                UID,
+                before=None,
+                after_status=SubscriptionStatus.ACTIVE,
+                fields={
+                    "provider": SubscriptionProvider.PADDLE,
+                    "kind": SubscriptionKind.RECURRING,
+                },
+                actor="paddle",
+                reason="x",
+            )
+        events.append.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_write_records_nothing(self):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        col.find_one.return_value = _sub_raw("active")
+        before = await repo.find_by_user(UID)
+        after = await repo.write_transition(
+            UID,
+            before=before,
+            after_status=SubscriptionStatus.ACTIVE,
+            fields={"current_period_end": before.current_period_end},
+            actor="paddle",
+            reason="duplicate delivery",
+        )
+        assert after is before
+        col.update_one.assert_not_awaited()
+        events.append.assert_not_awaited()
+        cache.invalidate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returned_doc_is_validated_like_a_read(self):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        before = SubscriptionDoc.from_mongo(_sub_raw("active"))
+        after = await repo.write_transition(
+            UID,
+            before=before,
+            after_status=SubscriptionStatus.ACTIVE,
+            fields={"kind": "prepaid", "prepaid_until": NOW + timedelta(days=365)},
+            actor="paddle",
+            reason="year purchased",
+            now=NOW,
+        )
+        assert after.kind is SubscriptionKind.PREPAID
+        assert after.term_end == NOW + timedelta(days=365)
+
+    @pytest.mark.asyncio
+    async def test_same_status_with_new_period_end_is_a_change(self):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        col.find_one.return_value = _sub_raw("active")
+        before = await repo.find_by_user(UID)
+        renewed = NOW + timedelta(days=40)
+        after = await repo.write_transition(
+            UID,
+            before=before,
+            after_status=SubscriptionStatus.ACTIVE,
+            fields={"current_period_end": renewed},
+            actor="paddle",
+            reason="renewal",
+        )
+        assert after.current_period_end == renewed
+        events.append.assert_awaited_once()
+        cache.invalidate.assert_awaited_once_with(UID)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("after_status", "kind"),
+        [
+            (SubscriptionStatus.GRACE, EntitlementEventKind.GRACE_STARTED),
+            (SubscriptionStatus.LAPSED, EntitlementEventKind.LAPSED),
+            (SubscriptionStatus.PAST_DUE, EntitlementEventKind.SUBSCRIPTION_CHANGED),
+        ],
+    )
+    async def test_event_kind_names_grace_and_lapse(self, after_status, kind):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        col.find_one.return_value = _sub_raw("active")
+        before = await repo.find_by_user(UID)
+        await repo.write_transition(
+            UID,
+            before=before,
+            after_status=after_status,
+            fields={"grace_until": NOW + timedelta(days=14)},
+            actor="job",
+            reason="clock",
+        )
+        assert events.append.await_args.args[0].kind is kind
+
+    @pytest.mark.asyncio
+    async def test_delete_by_user_invalidates_cache(self):
+        col = _col()
+        events, cache = _events_and_cache()
+        repo = SubscriptionRepository(col, events, cache)
+        assert await repo.delete_by_user(UID) == 1
+        cache.invalidate.assert_awaited_once_with(UID)
+
+
+class TestOverrideRepository:
+    @pytest.mark.asyncio
+    async def test_grant_upserts_records_event_and_invalidates(self):
+        col = _col("entitlement_overrides")
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(col, events, cache)
+        doc = await repo.grant(
+            UID,
+            "geo_targeting",
+            True,
+            kind=OverrideKind.BETA,
+            reason="beta cohort",
+            granted_by="ops:zingzy",
+            now=NOW,
+        )
+        assert doc.value is True
+        query, ops = col.update_one.await_args.args
+        assert query == {"user_id": UID, "key": "geo_targeting"}
+        assert ops["$set"]["kind"] == "beta"
+        assert col.update_one.await_args.kwargs["upsert"] is True
+        event = events.append.await_args.args[0]
+        assert event.kind is EntitlementEventKind.OVERRIDE_GRANTED
+        assert event.before is None
+        assert event.after["value"] is True
+        cache.invalidate.assert_awaited_once_with(UID)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [("geo_targetting", True), ("geo_targeting", 5), ("custom_domains_max", True)],
+        ids=["unknown_key", "int_for_bool", "bool_for_int"],
+    )
+    async def test_grant_rejects_unknown_key_or_wrong_type(self, key, value):
+        col = _col("entitlement_overrides")
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(
+            col, events, cache, check=validate_override
+        )
+        with pytest.raises(ValueError):
+            await repo.grant(
+                UID, key, value, kind=OverrideKind.COMP, reason="r", granted_by="ops"
+            )
+        col.update_one.assert_not_awaited()
+        events.append.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_identical_regrant_is_a_noop(self):
+        col = _col("entitlement_overrides")
+        col.find_one.return_value = {
+            "_id": ObjectId(),
+            "user_id": UID,
+            "key": "geo_targeting",
+            "value": True,
+            "kind": "beta",
+            "reason": "beta cohort",
+            "granted_by": "ops",
+            "expires_at": None,
+            "created_at": NOW,
+            "updated_at": NOW,
+        }
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(col, events, cache)
+        await repo.grant(
+            UID,
+            "geo_targeting",
+            True,
+            kind=OverrideKind.BETA,
+            reason="again",
+            granted_by="ops",
+        )
+        col.update_one.assert_not_awaited()
+        events.append.assert_not_awaited()
+        cache.invalidate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_changed_value_regrant_records_before_and_after(self):
+        col = _col("entitlement_overrides")
+        col.find_one.return_value = {
+            "_id": ObjectId(),
+            "user_id": UID,
+            "key": "custom_domains_max",
+            "value": 3,
+            "kind": "custom",
+            "reason": "x",
+            "granted_by": "ops",
+            "expires_at": None,
+        }
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(col, events, cache)
+        await repo.grant(
+            UID,
+            "custom_domains_max",
+            8,
+            kind=OverrideKind.CUSTOM,
+            reason="bigger",
+            granted_by="ops",
+        )
+        event = events.append.await_args.args[0]
+        assert event.before["value"] == 3
+        assert event.after["value"] == 8
+
+    @pytest.mark.asyncio
+    async def test_revoke_deletes_records_and_invalidates(self):
+        col = _col("entitlement_overrides")
+        oid = ObjectId()
+        col.find_one.return_value = {
+            "_id": oid,
+            "user_id": UID,
+            "key": "geo_targeting",
+            "value": True,
+            "kind": "beta",
+            "reason": "x",
+            "granted_by": "ops",
+        }
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(col, events, cache)
+        assert await repo.revoke(UID, "geo_targeting", actor="ops", reason="done")
+        col.delete_one.assert_awaited_once_with({"_id": oid})
+        event = events.append.await_args.args[0]
+        assert event.kind is EntitlementEventKind.OVERRIDE_REVOKED
+        assert event.before["key"] == "geo_targeting"
+        assert event.after is None
+        cache.invalidate.assert_awaited_once_with(UID)
+
+    @pytest.mark.asyncio
+    async def test_revoke_of_missing_override_is_false_and_silent(self):
+        col = _col("entitlement_overrides")
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(col, events, cache)
+        assert await repo.revoke(UID, "geo_targeting", actor="ops", reason="x") is False
+        events.append.assert_not_awaited()
+        cache.invalidate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_list_active_filters_expired(self):
+        col = _col("entitlement_overrides")
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(return_value=[])
+        col.find = MagicMock(return_value=cursor)
+        events, cache = _events_and_cache()
+        repo = EntitlementOverrideRepository(col, events, cache)
+        await repo.list_active(UID, NOW)
+        query = col.find.call_args.args[0]
+        assert query["user_id"] == UID
+        assert {"expires_at": None} in query["$or"]
+        assert {"expires_at": {"$gt": NOW}} in query["$or"]

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -35,6 +35,9 @@ class TestEnsureIndexes:
         safety_verdicts_col = AsyncMock()
         feed_domains_col = AsyncMock()
         scheduled_tasks_col = AsyncMock()
+        subscriptions_col = AsyncMock()
+        overrides_col = AsyncMock()
+        ent_events_col = AsyncMock()
 
         db.__getitem__ = lambda self, name: {
             "users": users_col,
@@ -57,6 +60,9 @@ class TestEnsureIndexes:
             "safety_verdicts": safety_verdicts_col,
             "safety_feed_domains": feed_domains_col,
             "scheduled_tasks": scheduled_tasks_col,
+            "subscriptions": subscriptions_col,
+            "entitlement_overrides": overrides_col,
+            "entitlement_events": ent_events_col,
         }[name]
 
         # create_collection raises CollectionInvalid when collection already exists
@@ -66,6 +72,11 @@ class TestEnsureIndexes:
 
         # Check a few critical indexes
         users_col.create_index.assert_any_await([("email", 1)], unique=True)
+        subscriptions_col.create_index.assert_any_await([("user_id", 1)], unique=True)
+        overrides_col.create_index.assert_any_await(
+            [("user_id", 1), ("key", 1)], unique=True
+        )
+        ent_events_col.create_index.assert_any_await([("user_id", 1), ("at", -1)])
         # Erasure sweep: partial — holds only PENDING_DELETION/ERASING docs.
         users_col.create_index.assert_any_await(
             [("status", 1), ("purge_after", 1)],

--- a/tests/unit/schemas/models/test_user.py
+++ b/tests/unit/schemas/models/test_user.py
@@ -16,7 +16,6 @@ class TestUserDoc:
         assert doc.email == "user@example.com"
         assert doc.email_verified is False
         assert doc.password_set is False
-        assert doc.plan == "free"
         assert doc.status == "ACTIVE"
         assert doc.auth_providers == []
 

--- a/tests/unit/services/entitlements/test_catalog.py
+++ b/tests/unit/services/entitlements/test_catalog.py
@@ -1,0 +1,85 @@
+"""Catalog drift test: every feature is declared completely, once.
+
+This is the test that fails when someone adds a feature and forgets half
+of it. Each assertion names the field it guards so the failure reads as an
+instruction.
+"""
+
+from __future__ import annotations
+
+import re
+
+from services.features.catalog import (
+    FEATURES,
+    UNLIMITED,
+    Kind,
+    Plan,
+    bool_features,
+    int_features,
+    plan_defaults,
+)
+
+_KEY = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def test_keys_are_snake_case_and_match_entries():
+    for key, feature in FEATURES.items():
+        assert _KEY.match(key), f"{key}: not snake_case"
+        assert feature.key == key, f"{key}: entry key mismatch"
+
+
+def test_every_feature_has_all_four_plan_defaults():
+    for key, feature in FEATURES.items():
+        assert set(feature.plans) == set(Plan), f"{key}: plans must cover every Plan"
+
+
+def test_plan_default_types_match_kind():
+    for key, feature in FEATURES.items():
+        for plan, value in feature.plans.items():
+            if feature.kind is Kind.BOOL:
+                assert isinstance(value, bool), f"{key}[{plan}]: BOOL needs a bool"
+            else:
+                assert isinstance(value, int) and not isinstance(value, bool), (
+                    f"{key}[{plan}]: INT needs an int"
+                )
+
+
+def test_bool_features_declare_lapse_and_no_over_limit():
+    for feature in bool_features():
+        assert feature.lapse is not None, f"{feature.key}: missing lapse policy"
+        assert feature.over_limit is None, f"{feature.key}: over_limit is for INT"
+
+
+def test_int_features_declare_no_lapse_or_rollout():
+    for feature in int_features():
+        assert feature.lapse is None, f"{feature.key}: lapse is for BOOL"
+        assert feature.rollout is None, f"{feature.key}: limits have no rollout"
+
+
+def test_selfhost_holds_everything():
+    for key, value in plan_defaults(Plan.SELFHOST).items():
+        expected = True if FEATURES[key].kind is Kind.BOOL else UNLIMITED
+        assert value == expected, f"{key}: selfhost must be {expected!r}"
+
+
+def test_pro_is_at_least_free():
+    for key, feature in FEATURES.items():
+        free, pro = feature.plans[Plan.FREE], feature.plans[Plan.PRO]
+        if feature.kind is Kind.BOOL:
+            assert pro or not free, f"{key}: free has it but pro does not"
+        else:
+            assert pro == UNLIMITED or pro >= free, f"{key}: pro below free"
+
+
+def test_anonymous_never_exceeds_free():
+    for key, feature in FEATURES.items():
+        anon, free = feature.plans[Plan.ANONYMOUS], feature.plans[Plan.FREE]
+        if feature.kind is Kind.BOOL:
+            assert free or not anon, f"{key}: anonymous has it but free does not"
+        else:
+            assert anon <= free, f"{key}: anonymous above free"
+
+
+def test_rollout_names_are_unique():
+    rollouts = [f.rollout for f in FEATURES.values() if f.rollout is not None]
+    assert len(rollouts) == len(set(rollouts)), "two features share a flag document"

--- a/tests/unit/services/entitlements/test_resolver.py
+++ b/tests/unit/services/entitlements/test_resolver.py
@@ -1,0 +1,104 @@
+"""Pure resolution: override > plan default, typed by the catalog."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from schemas.models.entitlement_override import EntitlementOverrideDoc, OverrideKind
+from services.entitlements.resolver import ANONYMOUS, Resolved, for_plan, resolve
+from services.features.catalog import FEATURES, UNLIMITED, Plan, plan_defaults
+
+UID = ObjectId()
+
+
+def _override(key: str, value, **extra) -> EntitlementOverrideDoc:
+    return EntitlementOverrideDoc(
+        user_id=UID,
+        key=key,
+        value=value,
+        kind=OverrideKind.COMP,
+        reason="test",
+        granted_by="tests",
+        **extra,
+    )
+
+
+def test_no_overrides_is_plan_defaults():
+    assert resolve(Plan.FREE) == plan_defaults(Plan.FREE)
+    assert resolve(Plan.PRO) == plan_defaults(Plan.PRO)
+
+
+def test_override_beats_plan_default_for_bool_and_int():
+    values = resolve(
+        Plan.FREE,
+        [_override("geo_targeting", True), _override("custom_domains_max", 3)],
+    )
+    assert values["geo_targeting"] is True
+    assert values["custom_domains_max"] == 3
+    # Everything else is untouched.
+    assert values["ab_variants"] is False
+    assert values["webhook_endpoints_max"] == 1
+
+
+def test_override_can_lower_a_pro_value():
+    values = resolve(Plan.PRO, [_override("api_rate_multiplier", 1)])
+    assert values["api_rate_multiplier"] == 1
+
+
+def test_override_values_are_coerced_to_the_catalog_kind():
+    values = resolve(
+        Plan.FREE,
+        [_override("geo_targeting", 1), _override("bulk_batch_max", True)],
+    )
+    assert values["geo_targeting"] is True
+    assert values["bulk_batch_max"] == 1
+
+
+def test_unknown_override_key_is_ignored():
+    values = resolve(Plan.FREE, [_override("not_a_feature", True)])
+    assert "not_a_feature" not in values
+    assert values == plan_defaults(Plan.FREE)
+
+
+def test_anonymous_constant_is_the_anonymous_plan():
+    assert ANONYMOUS.plan is Plan.ANONYMOUS
+    assert ANONYMOUS.version == 0
+    assert ANONYMOUS.values == plan_defaults(Plan.ANONYMOUS)
+
+
+def test_resolved_helpers():
+    r = for_plan(Plan.PRO)
+    assert r.has("geo_targeting") is True
+    assert r.limit("custom_domains_max") == 5
+    assert r.within_limit("custom_domains_max", 4) is True
+    assert r.within_limit("custom_domains_max", 5) is False
+    selfhost = for_plan(Plan.SELFHOST)
+    assert selfhost.is_unlimited("custom_domains_max")
+    assert selfhost.within_limit("custom_domains_max", 10_000) is True
+    assert selfhost.limit("custom_domains_max") == UNLIMITED
+
+
+def test_limit_of_a_bool_key_is_zero_not_one():
+    assert for_plan(Plan.PRO).limit("geo_targeting") == 0
+
+
+def test_degraded_is_never_serialised():
+    r = for_plan(Plan.FREE).model_copy(update={"degraded": True})
+    assert "degraded" not in r.model_dump()
+    assert Resolved.model_validate_json(r.model_dump_json()).degraded is False
+
+
+def test_round_trips_through_json_with_status_and_until():
+    r = Resolved(
+        plan=Plan.PRO,
+        status="grace",
+        until=datetime(2026, 10, 1, tzinfo=timezone.utc),
+        founding=True,
+        values=plan_defaults(Plan.PRO),
+        version=7,
+    )
+    back = Resolved.model_validate_json(r.model_dump_json())
+    assert back == r
+    assert set(back.values) == set(FEATURES)

--- a/tests/unit/services/entitlements/test_service.py
+++ b/tests/unit/services/entitlements/test_service.py
@@ -1,0 +1,249 @@
+"""EntitlementService: cache, degrade, selfhost, version, transitions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from bson import ObjectId
+
+from errors import InvalidTransitionError
+from schemas.models.entitlement_override import EntitlementOverrideDoc, OverrideKind
+from schemas.models.subscription import (
+    SubscriptionDoc,
+    SubscriptionKind,
+    SubscriptionProvider,
+    SubscriptionStatus,
+)
+from services.entitlements import EntitlementService, SubscriptionEvent, for_plan
+from services.features.catalog import Plan, plan_defaults
+
+UID = ObjectId()
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def _sub(status: SubscriptionStatus, **extra) -> SubscriptionDoc:
+    return SubscriptionDoc(
+        user_id=UID,
+        provider=SubscriptionProvider.PADDLE,
+        kind=SubscriptionKind.RECURRING,
+        status=status,
+        current_period_end=NOW + timedelta(days=10),
+        **extra,
+    )
+
+
+def _service(*, sub=None, overrides=(), events=3, cached=None, selfhost=False):
+    subs = AsyncMock()
+    subs.find_by_user = AsyncMock(return_value=sub)
+    subs.write_transition = AsyncMock(
+        side_effect=lambda uid, **kw: (
+            kw["before"] or _sub(kw["after_status"])
+        ).model_copy(update={"status": kw["after_status"], **kw["fields"]})
+    )
+    ovs = AsyncMock()
+    ovs.list_active = AsyncMock(return_value=list(overrides))
+    evs = AsyncMock()
+    evs.count_for = AsyncMock(return_value=events)
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=cached)
+    svc = EntitlementService(subs, ovs, evs, cache, selfhost=selfhost)
+    return svc, subs, ovs, evs, cache
+
+
+class TestResolveFor:
+    @pytest.mark.asyncio
+    async def test_anonymous_never_touches_stores(self):
+        svc, subs, _, _, cache = _service()
+        r = await svc.resolve_for(None)
+        assert r.plan is Plan.ANONYMOUS
+        cache.get.assert_not_awaited()
+        subs.find_by_user.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_selfhost_short_circuits(self):
+        svc, subs, _, _, cache = _service(
+            selfhost=True, sub=_sub(SubscriptionStatus.LAPSED)
+        )
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.SELFHOST
+        assert r.values == plan_defaults(Plan.SELFHOST)
+        cache.get.assert_not_awaited()
+        subs.find_by_user.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_mongo(self):
+        cached = for_plan(Plan.PRO, version=9)
+        svc, subs, _, _, cache = _service(cached=cached)
+        r = await svc.resolve_for(UID)
+        assert r is cached
+        subs.find_by_user.assert_not_awaited()
+        cache.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_subscription_is_free_and_cached(self):
+        svc, _, _, _, cache = _service(sub=None, events=0)
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.FREE
+        assert r.status is None
+        assert r.version == 0
+        assert r.values == plan_defaults(Plan.FREE)
+        cache.set.assert_awaited_once_with(UID, r)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [
+            SubscriptionStatus.ACTIVE,
+            SubscriptionStatus.PAST_DUE,
+            SubscriptionStatus.CANCEL_AT_PERIOD_END,
+            SubscriptionStatus.GRACE,
+        ],
+    )
+    async def test_paying_statuses_resolve_to_pro(self, status):
+        svc, *_ = _service(sub=_sub(status, grace_until=NOW + timedelta(days=14)))
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.PRO
+        assert r.status is status
+        assert r.values["geo_targeting"] is True
+
+    @pytest.mark.asyncio
+    async def test_lapsed_resolves_to_free(self):
+        svc, *_ = _service(sub=_sub(SubscriptionStatus.LAPSED))
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.FREE
+        assert r.status is SubscriptionStatus.LAPSED
+        assert r.values["geo_targeting"] is False
+
+    @pytest.mark.asyncio
+    async def test_grace_until_is_the_shown_date(self):
+        grace_end = NOW + timedelta(days=14)
+        svc, *_ = _service(sub=_sub(SubscriptionStatus.GRACE, grace_until=grace_end))
+        r = await svc.resolve_for(UID)
+        assert r.until == grace_end
+
+    @pytest.mark.asyncio
+    async def test_override_applies_on_top_of_plan(self):
+        ov = EntitlementOverrideDoc(
+            user_id=UID,
+            key="geo_targeting",
+            value=True,
+            kind=OverrideKind.BETA,
+            reason="beta",
+            granted_by="ops",
+        )
+        svc, *_ = _service(sub=None, overrides=[ov])
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.FREE
+        assert r.values["geo_targeting"] is True
+
+    @pytest.mark.asyncio
+    async def test_version_is_the_audit_event_count(self):
+        svc, *_ = _service(events=42)
+        assert (await svc.resolve_for(UID)).version == 42
+
+
+class TestDegradedMode:
+    @pytest.mark.asyncio
+    async def test_store_failure_falls_back_to_free_and_never_caches(self):
+        svc, subs, _, _, cache = _service()
+        subs.find_by_user.side_effect = RuntimeError("mongo down")
+        r = await svc.resolve_for(UID)
+        assert r.degraded is True
+        assert r.plan is Plan.FREE
+        cache.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pro_hint_keeps_pro_defaults_when_stores_are_down(self):
+        svc, subs, *_ = _service()
+        subs.find_by_user.side_effect = RuntimeError("mongo down")
+        r = await svc.resolve_for(UID, plan_hint="pro")
+        assert r.degraded is True
+        assert r.plan is Plan.PRO
+
+    @pytest.mark.asyncio
+    async def test_hint_can_never_produce_selfhost(self):
+        svc, subs, *_ = _service()
+        subs.find_by_user.side_effect = RuntimeError("mongo down")
+        r = await svc.resolve_for(UID, plan_hint="selfhost")
+        assert r.plan is Plan.FREE
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_falls_through_to_mongo(self):
+        svc, _, _, _, cache = _service(sub=_sub(SubscriptionStatus.ACTIVE))
+        cache.get = AsyncMock(return_value=None)
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.PRO
+        assert r.degraded is False
+
+    @pytest.mark.asyncio
+    async def test_write_during_compute_is_returned_but_not_cached(self):
+        svc, _, _, evs, cache = _service(sub=_sub(SubscriptionStatus.ACTIVE))
+        evs.count_for = AsyncMock(side_effect=[3, 4])
+        r = await svc.resolve_for(UID)
+        assert r.plan is Plan.PRO
+        assert r.version == 3
+        cache.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_version_for_is_none_when_degraded(self):
+        svc, subs, *_ = _service()
+        subs.find_by_user.side_effect = RuntimeError("down")
+        assert await svc.version_for(UID) is None
+
+    @pytest.mark.asyncio
+    async def test_plan_hint_for_never_raises(self):
+        svc, _, _, _, cache = _service()
+        cache.get.side_effect = RuntimeError("boom")
+        assert await svc.plan_hint_for(UID) == "free"
+
+
+class TestTransition:
+    @pytest.mark.asyncio
+    async def test_granted_from_nothing_writes_active(self):
+        svc, subs, *_ = _service(sub=None)
+        doc = await svc.transition(
+            UID,
+            SubscriptionEvent.GRANTED,
+            actor="ops",
+            reason="manual",
+            provider=SubscriptionProvider.MANUAL,
+            kind=SubscriptionKind.PREPAID,
+            prepaid_until=NOW + timedelta(days=30),
+        )
+        assert doc.status is SubscriptionStatus.ACTIVE
+        kwargs = subs.write_transition.await_args.kwargs
+        assert kwargs["before"] is None
+        assert kwargs["after_status"] is SubscriptionStatus.ACTIVE
+        assert kwargs["fields"]["provider"] is SubscriptionProvider.MANUAL
+
+    @pytest.mark.asyncio
+    async def test_rejected_event_never_reaches_the_repository(self):
+        svc, subs, *_ = _service(sub=_sub(SubscriptionStatus.LAPSED))
+        with pytest.raises(InvalidTransitionError):
+            await svc.transition(
+                UID, SubscriptionEvent.PAYMENT_SUCCEEDED, actor="paddle", reason="late"
+            )
+        subs.write_transition.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_grace_requires_grace_until(self):
+        svc, subs, *_ = _service(sub=_sub(SubscriptionStatus.ACTIVE))
+        with pytest.raises(ValueError):
+            await svc.transition(
+                UID, SubscriptionEvent.TERM_ENDED, actor="job", reason="term end"
+            )
+        subs.write_transition.assert_not_awaited()
+
+
+class TestUsage:
+    @pytest.mark.asyncio
+    async def test_usage_for_calls_each_counter(self):
+        subs, ovs, evs, cache = AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()
+        counter = AsyncMock(return_value=2)
+        svc = EntitlementService(
+            subs, ovs, evs, cache, selfhost=False, usage={"custom_domains_max": counter}
+        )
+        assert await svc.usage_for(UID) == {"custom_domains_max": 2}
+        counter.assert_awaited_once_with(UID)

--- a/tests/unit/services/entitlements/test_state_machine.py
+++ b/tests/unit/services/entitlements/test_state_machine.py
@@ -1,0 +1,119 @@
+"""Subscription state machine: every state times every event, explicitly."""
+
+from __future__ import annotations
+
+import pytest
+
+from errors import InvalidTransitionError
+from schemas.models.subscription import SubscriptionStatus as S
+from services.entitlements.state_machine import (
+    SubscriptionEvent as E,
+)
+from services.entitlements.state_machine import (
+    next_status,
+)
+
+REJECT = "reject"
+
+# Rows: current status (None = no subscription); columns: EVENTS in order.
+# A status means the transition lands there; REJECT means it cannot arrive.
+EVENTS = (
+    E.GRANTED,
+    E.PAYMENT_SUCCEEDED,
+    E.PAYMENT_FAILED,
+    E.CANCEL_SCHEDULED,
+    E.CANCEL_REVOKED,
+    E.TERM_ENDED,
+    E.GRACE_ENDED,
+    E.PAST_DUE_CEILING,
+    E.ENDED,
+)
+TABLE = {
+    None: (S.ACTIVE, REJECT, REJECT, REJECT, REJECT, REJECT, REJECT, REJECT, REJECT),
+    S.ACTIVE: (
+        S.ACTIVE,
+        S.ACTIVE,
+        S.PAST_DUE,
+        S.CANCEL_AT_PERIOD_END,
+        S.ACTIVE,
+        S.GRACE,
+        REJECT,
+        REJECT,
+        S.LAPSED,
+    ),
+    S.PAST_DUE: (
+        S.ACTIVE,
+        S.ACTIVE,
+        S.PAST_DUE,
+        S.CANCEL_AT_PERIOD_END,
+        REJECT,
+        REJECT,
+        REJECT,
+        S.LAPSED,
+        S.LAPSED,
+    ),
+    S.CANCEL_AT_PERIOD_END: (
+        S.ACTIVE,
+        S.CANCEL_AT_PERIOD_END,
+        S.PAST_DUE,
+        S.CANCEL_AT_PERIOD_END,
+        S.ACTIVE,
+        S.GRACE,
+        REJECT,
+        REJECT,
+        S.LAPSED,
+    ),
+    S.GRACE: (
+        S.ACTIVE,
+        REJECT,
+        REJECT,
+        REJECT,
+        REJECT,
+        S.GRACE,
+        S.LAPSED,
+        REJECT,
+        S.LAPSED,
+    ),
+    S.LAPSED: (
+        S.ACTIVE,
+        REJECT,
+        REJECT,
+        REJECT,
+        REJECT,
+        S.LAPSED,
+        S.LAPSED,
+        S.LAPSED,
+        S.LAPSED,
+    ),
+}
+
+
+def _cases():
+    for current, row in TABLE.items():
+        assert len(row) == len(EVENTS)
+        for event, expected in zip(EVENTS, row, strict=True):
+            yield current, event, expected
+
+
+@pytest.mark.parametrize(
+    ("current", "event", "expected"),
+    list(_cases()),
+    ids=lambda v: getattr(v, "value", str(v)),
+)
+def test_every_state_times_every_event(current, event, expected):
+    if expected == REJECT:
+        with pytest.raises(InvalidTransitionError):
+            next_status(current, event)
+    else:
+        assert next_status(current, event) is expected
+
+
+def test_table_covers_every_state_and_event():
+    assert set(TABLE) == {None, *S}
+    assert set(EVENTS) == set(E)
+
+
+def test_payment_never_reactivates_a_finished_subscription():
+    for current in (S.GRACE, S.LAPSED):
+        with pytest.raises(InvalidTransitionError):
+            next_status(current, E.PAYMENT_SUCCEEDED)

--- a/tests/unit/services/test_account_erasure_service.py
+++ b/tests/unit/services/test_account_erasure_service.py
@@ -102,6 +102,14 @@ class Stubs:
 
         self.feature_flag_repo = MagicMock()
         self.feature_flag_repo.pull_allowlisted = self._tracked("feature_flags_pull", 1)
+        self.subscription_repo = MagicMock()
+        self.subscription_repo.delete_by_user = self._tracked("subscriptions", 1)
+        self.override_repo = MagicMock()
+        self.override_repo.delete_by_user = self._tracked("entitlement_overrides", 2)
+        self.entitlement_event_repo = MagicMock()
+        self.entitlement_event_repo.delete_by_user = self._tracked(
+            "entitlement_events", 3
+        )
 
         prefix = owner_key_prefix(UID, SECRET)
         self.r2_storage = MagicMock()
@@ -163,6 +171,9 @@ def _service(
         report_repo=stubs.report_repo,
         report_submission_repo=stubs.report_submission_repo,
         feature_flag_repo=stubs.feature_flag_repo,
+        subscription_repo=stubs.subscription_repo,
+        override_repo=stubs.override_repo,
+        entitlement_event_repo=stubs.entitlement_event_repo,
         r2_storage=stubs.r2_storage if r2 is ... else r2,
         posthog=stubs.posthog if posthog is ... else posthog,
         mailer=stubs.mailer if mailer is ... else mailer,
@@ -190,6 +201,9 @@ EXPECTED_COUNTS = {
     "report_submissions": 1,
     "reports_pulled": 2,
     "feature_flags_pulled": 1,
+    "subscriptions": 1,
+    "entitlement_overrides": 2,
+    "entitlement_events": 3,
     "r2_objects": 2,
 }
 
@@ -234,6 +248,9 @@ async def test_erase_follows_cascade_order_user_doc_last():
         "report_submissions",
         "reports_pull",
         "feature_flags_pull",
+        "subscriptions",
+        "entitlement_overrides",
+        "entitlement_events",
         "posthog",
         "users.delete_hard",
         "mailer",

--- a/tests/unit/services/test_auth_service.py
+++ b/tests/unit/services/test_auth_service.py
@@ -204,11 +204,12 @@ class TestJWTHelpers:
         with pytest.raises(AuthenticationError):
             tf.verify_token("not.a.valid.token", token_type="access")
 
-    def test_issue_tokens_returns_valid_pair(self):
+    @pytest.mark.asyncio
+    async def test_issue_tokens_returns_valid_pair(self):
         tf = make_token_factory()
         settings = make_jwt_settings()
         user = make_user_doc()
-        access, refresh = tf.issue_tokens(user, "google")
+        access, refresh = await tf.issue_tokens(user, "google")
         # Access token has no type field
         access_payload = pyjwt.decode(
             access,
@@ -893,12 +894,12 @@ class TestGetUserProfile:
         from schemas.dto.responses.auth import UserProfileResponse
 
         user = make_user_doc()
-        profile = UserProfileResponse.from_user(user)
+        profile = UserProfileResponse.from_user(user, plan="pro")
         assert profile.id == str(USER_OID)
+        assert profile.plan == "pro"
         assert profile.email == "test@example.com"
         assert profile.email_verified is True
         assert profile.user_name == "Test User"
-        assert profile.plan == "free"
         assert profile.password_set is False
         assert profile.auth_providers == []
 
@@ -928,7 +929,7 @@ class TestGetUserProfile:
             "status": "ACTIVE",
         }
         user = UserDoc.from_mongo(user_doc)
-        profile = UserProfileResponse.from_user(user)
+        profile = UserProfileResponse.from_user(user, plan="free")
         assert len(profile.auth_providers) == 1
         assert profile.auth_providers[0].provider == "google"
         assert profile.auth_providers[0].linked_at == now
@@ -949,7 +950,7 @@ class TestGetUserProfile:
             "status": "ACTIVE",
         }
         user = UserDoc.from_mongo(user_doc)
-        profile = UserProfileResponse.from_user(user)
+        profile = UserProfileResponse.from_user(user, plan="free")
         assert profile.pfp.url == "https://img.url"
         assert profile.pfp.source == "google"
 

--- a/tests/unit/services/test_feature_flag_service.py
+++ b/tests/unit/services/test_feature_flag_service.py
@@ -13,14 +13,34 @@ from infrastructure.cache.feature_flag_cache import NEGATIVE_MISS
 from schemas.enums.rollout_type import RolloutType
 from schemas.models.feature_flag import FeatureFlagDoc
 from services.feature_flag_service import (
+    FEATURES,
     FeatureFlagService,
     _digit_bucket,
     _stable_hash,
 )
+from services.features.catalog import Feature, Kind, Lapse, Plan
 
 USER_A = ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")
 USER_B = ObjectId("bbbbbbbbbbbbbbbbbbbbbbbb")
 USER_C = ObjectId("cccccccccccccccccccccccc")
+
+
+@pytest.fixture(autouse=True)
+def _test_flag_in_catalog(monkeypatch):
+    """Register ``test_flag`` as a catalog feature whose rollout is the
+    ``test_flag`` document, so the rollout strategies can be exercised
+    without touching a real feature's entry."""
+    monkeypatch.setitem(
+        FEATURES,
+        "test_flag",
+        Feature(
+            key="test_flag",
+            kind=Kind.BOOL,
+            rollout="test_flag",
+            plans={p: True for p in Plan},
+            lapse=Lapse.KEEP,
+        ),
+    )
 
 
 def _flag(**overrides) -> FeatureFlagDoc:
@@ -32,7 +52,6 @@ def _flag(**overrides) -> FeatureFlagDoc:
         "allowlist_emails": [],
         "percentage": 0,
         "enabled_digits": [],
-        "tier": None,
         "description": "",
         "created_at": datetime.now(timezone.utc),
         "updated_at": datetime.now(timezone.utc),
@@ -41,13 +60,11 @@ def _flag(**overrides) -> FeatureFlagDoc:
     return FeatureFlagDoc.model_validate(base)
 
 
-def _user(
-    user_id: ObjectId = USER_A, email: str | None = None, tier: str | None = None
-):
+def _user(user_id: ObjectId = USER_A, email: str | None = None):
     """Build a stub CurrentUser-shaped object via SimpleNamespace.
 
-    The real ``CurrentUser`` carries ``user_id`` always; ``email`` and ``tier``
-    are accessed defensively via ``getattr``.
+    The real ``CurrentUser`` carries ``user_id`` always; ``email`` is
+    accessed defensively via ``getattr``.
     """
     from types import SimpleNamespace
 
@@ -59,8 +76,6 @@ def _user(
     }
     if email is not None:
         attrs["email"] = email
-    if tier is not None:
-        attrs["tier"] = tier
     return SimpleNamespace(**attrs)
 
 
@@ -86,8 +101,32 @@ class TestDefaultDeny:
     @pytest.mark.asyncio
     async def test_unregistered_flag_returns_false(self):
         service, _repo, cache = make_service(flag=None)
+        assert await service.is_enabled("test_flag", _user()) is False
+        cache.set_negative.assert_awaited_once_with("test_flag")
+
+    @pytest.mark.asyncio
+    async def test_key_outside_catalog_returns_false_without_lookup(self):
+        service, repo, cache = make_service(flag=_flag(rollout_type="everyone"))
         assert await service.is_enabled("missing", _user()) is False
-        cache.set_negative.assert_awaited_once_with("missing")
+        repo.find_by_name.assert_not_awaited()
+        cache.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_finished_rollout_is_always_on(self, monkeypatch):
+        monkeypatch.setitem(
+            FEATURES,
+            "done",
+            Feature(
+                key="done",
+                kind=Kind.BOOL,
+                rollout=None,
+                plans={p: True for p in Plan},
+                lapse=Lapse.KEEP,
+            ),
+        )
+        service, repo, _ = make_service(flag=None)
+        assert await service.is_enabled("done", None) is True
+        repo.find_by_name.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_disabled_flag_returns_false(self):
@@ -313,57 +352,6 @@ class TestRolloutHexDigit:
         assert await service.is_enabled("test_flag", _user(USER_A)) is False
 
 
-# ── TIER ─────────────────────────────────────────────────────────────────────
-
-
-class TestRolloutTier:
-    @pytest.mark.asyncio
-    async def test_user_without_tier_attr_blocked(self):
-        flag = _flag(rollout_type=RolloutType.TIER, tier="pro")
-        service, _, _ = make_service(flag=flag)
-        # _user() without tier kwarg omits the attribute.
-        assert await service.is_enabled("test_flag", _user()) is False
-
-    @pytest.mark.asyncio
-    async def test_user_with_matching_tier_allowed(self):
-        flag = _flag(rollout_type=RolloutType.TIER, tier="pro")
-        service, _, _ = make_service(flag=flag)
-        assert await service.is_enabled("test_flag", _user(tier="pro")) is True
-
-    @pytest.mark.asyncio
-    async def test_user_with_wrong_tier_blocked(self):
-        flag = _flag(rollout_type=RolloutType.TIER, tier="pro")
-        service, _, _ = make_service(flag=flag)
-        assert await service.is_enabled("test_flag", _user(tier="free")) is False
-
-    @pytest.mark.asyncio
-    async def test_unset_flag_tier_blocks_all(self):
-        # If the flag has rollout_type=TIER but tier=None, the gate must
-        # default-deny rather than match ``user.tier is None == flag.tier is None``.
-        flag = _flag(rollout_type=RolloutType.TIER, tier=None)
-        service, _, _ = make_service(flag=flag)
-        assert await service.is_enabled("test_flag", _user()) is False
-
-    @pytest.mark.asyncio
-    async def test_current_user_tier_field_flows_through(self):
-        """CurrentUser.tier (UserDoc.plan value) satisfies TIER rollouts —
-        flipping a flag ALLOWLIST→TIER at paid launch is a data change."""
-        from bson import ObjectId
-
-        from dependencies.auth import CurrentUser
-
-        flag = _flag(rollout_type=RolloutType.TIER, tier="PRO")
-        service, _, _ = make_service(flag=flag)
-        pro = CurrentUser(user_id=ObjectId(), email_verified=True, tier="PRO")
-        free = CurrentUser(user_id=ObjectId(), email_verified=True, tier="FREE")
-        anon_tier = CurrentUser(user_id=ObjectId(), email_verified=True)
-        assert await service.is_enabled("test_flag", pro) is True
-        assert await service.is_enabled("test_flag", free) is False
-        assert await service.is_enabled("test_flag", anon_tier) is False
-        assert await service.is_enabled("test_flag", _user(tier="pro")) is False
-        assert await service.is_enabled("test_flag", _user(tier="free")) is False
-
-
 # ── Caching behaviour ────────────────────────────────────────────────────────
 
 
@@ -395,8 +383,8 @@ class TestCaching:
     @pytest.mark.asyncio
     async def test_repo_miss_populates_negative_cache(self):
         service, _, cache = make_service(flag=None)
-        await service.is_enabled("missing", _user())
-        cache.set_negative.assert_awaited_once_with("missing")
+        await service.is_enabled("test_flag", _user())
+        cache.set_negative.assert_awaited_once_with("test_flag")
 
 
 # ── Stable hashing ───────────────────────────────────────────────────────────

--- a/tests/unit/services/test_profile_picture_service.py
+++ b/tests/unit/services/test_profile_picture_service.py
@@ -37,7 +37,6 @@ def _make_user_doc(pfp_url=None, providers=None, storage_prefix=None):
     doc.storage_prefix = storage_prefix
     doc.email_verified = True
     doc.user_name = "testuser"
-    doc.plan = "free"
     doc.password_set = True
     doc.auth_providers = providers or []
     if pfp_url:
@@ -94,7 +93,6 @@ async def test_get_dashboard_profile_returns_correct_shape():
     profile = await svc.get_dashboard_profile(user.id)
     assert profile["email"] == "user@example.com"
     assert profile["email_verified"] is True
-    assert profile["plan"] == "free"
     assert profile["password_set"] is True
     assert len(profile["auth_providers"]) == 1
     assert profile["auth_providers"][0]["provider"] == "google"

--- a/tests/unit/services/test_token_factory_plan.py
+++ b/tests/unit/services/test_token_factory_plan.py
@@ -1,0 +1,67 @@
+"""The JWT ``plan`` claim: issued from the resolver, never fatal."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import jwt as pyjwt
+import pytest
+
+from tests.unit.services.test_auth_service import make_jwt_settings, make_user_doc
+
+
+def _decode(token: str) -> dict:
+    s = make_jwt_settings()
+    return pyjwt.decode(
+        token,
+        s.jwt_secret,
+        algorithms=["HS256"],
+        audience=s.jwt_audience,
+        issuer=s.jwt_issuer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_claim_comes_from_the_lookup():
+    from services.token_factory import TokenFactory
+
+    lookup = AsyncMock(return_value="pro")
+    tf = TokenFactory(make_jwt_settings(), plan_of=lookup)
+    user = make_user_doc()
+    access, refresh = await tf.issue_tokens(user, "pwd")
+    assert _decode(access)["plan"] == "pro"
+    assert "plan" not in _decode(refresh)
+    lookup.assert_awaited_once_with(user.id)
+
+
+@pytest.mark.asyncio
+async def test_without_a_lookup_the_claim_is_free():
+    from services.token_factory import TokenFactory
+
+    tf = TokenFactory(make_jwt_settings())
+    access, _ = await tf.issue_tokens(make_user_doc(), "pwd")
+    assert _decode(access)["plan"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_lookup_failure_degrades_to_free():
+    from services.token_factory import TokenFactory
+
+    tf = TokenFactory(make_jwt_settings(), plan_of=AsyncMock(side_effect=RuntimeError))
+    access, _ = await tf.issue_tokens(make_user_doc(), "pwd")
+    assert _decode(access)["plan"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_current_user_reads_the_claim():
+    from dependencies.auth import get_current_user
+    from services.token_factory import TokenFactory
+    from tests.unit.test_auth_deps import make_request, make_settings
+
+    tf = TokenFactory(make_jwt_settings(), plan_of=AsyncMock(return_value="pro"))
+    access, _ = await tf.issue_tokens(make_user_doc(), "pwd")
+    request = make_request(auth_header=f"Bearer {access}")
+    with patch("dependencies.auth.get_settings", return_value=make_settings()):
+        user = await get_current_user(request, db=AsyncMock())
+    assert user is not None
+    assert user.plan_claim == "pro"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -117,6 +117,7 @@ def test_jwt_use_rs256(monkeypatch, private_key, public_key, expected):
 )
 def test_is_production(with_mongo, env, expected):
     with_mongo.setenv("ENV", env)
+    with_mongo.setenv("BILLING_PROVIDER", "none")
     assert AppSettings().is_production is expected
 
 
@@ -156,8 +157,31 @@ def test_zero_grace_days_refused_in_production(with_mongo, env, should_boot):
 
 def test_positive_grace_days_boots_in_production(with_mongo):
     with_mongo.setenv("ENV", "production")
+    with_mongo.setenv("BILLING_PROVIDER", "none")
     with_mongo.setenv("ACCOUNT_DELETION_GRACE_DAYS", "7")
     assert AppSettings().account_deletion_grace_days == 7
+
+
+@pytest.mark.parametrize(
+    "env, should_boot",
+    [("production", False), ("development", True)],
+    ids=["production_refuses", "development_allows"],
+)
+def test_unset_billing_provider_refused_in_production(with_mongo, env, should_boot):
+    # The default is self-host, which hands every account every feature.
+    with_mongo.setenv("ENV", env)
+    with_mongo.delenv("BILLING_PROVIDER", raising=False)
+    if should_boot:
+        assert AppSettings().billing.selfhost is True
+    else:
+        with pytest.raises(PydanticValidationError, match="BILLING_PROVIDER"):
+            AppSettings()
+
+
+def test_explicit_billing_provider_boots_in_production(with_mongo):
+    with_mongo.setenv("ENV", "production")
+    with_mongo.setenv("BILLING_PROVIDER", "none")
+    assert AppSettings().billing.selfhost is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_entitlement_boundaries.py
+++ b/tests/unit/test_entitlement_boundaries.py
@@ -1,0 +1,58 @@
+"""Import lint: nothing outside the entitlements package reads the plan
+stores for gating.
+
+Routes and services decide from the resolved map the ``Entitled``
+dependency hands them. The only modules allowed to touch ``subscriptions``,
+``entitlement_overrides`` or ``feature_flags`` are the resolver, the flag
+evaluator, the composition root, and the erasure cascade (which deletes).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN = (
+    re.compile(r"repositories\.subscription_repository"),
+    re.compile(r"repositories\.entitlement_override_repository"),
+    re.compile(r"repositories\.feature_flag_repository"),
+    re.compile(r'db\["(subscriptions|entitlement_overrides|feature_flags)"\]'),
+)
+
+ALLOWED = {
+    "dependencies/wiring.py",
+    "services/account_erasure_service.py",
+    "services/feature_flag_service.py",
+}
+ALLOWED_PREFIXES = ("services/entitlements/", "repositories/")
+
+
+def _python_files():
+    for folder in ("routes", "services", "dependencies", "middleware", "workers"):
+        yield from (ROOT / folder).rglob("*.py")
+
+
+def test_no_gating_code_reads_the_plan_stores_directly():
+    offenders = []
+    for path in _python_files():
+        rel = path.relative_to(ROOT).as_posix()
+        if rel in ALLOWED or rel.startswith(ALLOWED_PREFIXES):
+            continue
+        text = path.read_text()
+        for pattern in FORBIDDEN:
+            if pattern.search(text):
+                offenders.append(f"{rel}: {pattern.pattern}")
+    assert offenders == [], "\n".join(offenders)
+
+
+def test_nothing_reads_the_deleted_users_plan():
+    offenders = []
+    for path in _python_files():
+        text = path.read_text()
+        if re.search(r"\buser(_doc)?\.plan\b|UserPlan\b|\.tier\b", text):
+            offenders.append(path.relative_to(ROOT).as_posix())
+    # Safety verdicts have their own ``tier`` field; nothing else may.
+    offenders = [o for o in offenders if not o.startswith("services/safety/")]
+    assert offenders == [], "\n".join(offenders)


### PR DESCRIPTION
## What

The backend core of paid plans.

- One feature catalog (`services/features/catalog.py`) declares every gated capability and limit once: its rollout flag document, its per-plan defaults (anonymous, free, pro, selfhost), and its lapse or over-limit policy. Retiring a rollout is `rollout=None`, never deleting the entry.
- Two evaluators read it. The flag service answers "is this rolled out here" and now takes catalog keys. The new resolver (`services/entitlements/`) answers "what does this owner hold": plan defaults with overrides on top, cached per owner in Redis as `ent:{user_id}` with a version.
- Three collections: `subscriptions` (one per user, status state machine: active, past_due, cancel_at_period_end, grace, lapsed), `entitlement_overrides` (unique per user and key, with kind, reason, granted_by, expires_at), `entitlement_events` (append-only audit). The version bump, the audit event and the cache delete happen inside the repository write. A write that changes nothing writes no event and bumps nothing.
- `Entitled` request dependency resolves once per request and hands routes the map. `states_for` joins flag and entitlement: flag off is hidden, on and entitled is enabled, on and not entitled is locked.
- `GET /api/v1/me/entitlements` returns version, plan block, feature states, limits with live used counts, and over_limit. `/me/features` stays as the features-only alias. `GET /api/v1/plans` is the public projection of the catalog plus display prices from config.
- Every authenticated response carries `X-Entitlements-Version`.
- The JWT gets a `plan` claim (a hint for the client and the last fallback when both stores are down, never authority).
- Deleted: `RolloutType.TIER`, `FeatureFlagDoc.tier`, `CurrentUser.tier`, `UserPlan`, `users.plan` and the `plan` field on the profile response. `scripts/drop_users_plan.py` unsets the stored fields.
- Erasure deletes the three new collections for the user.

## Why

Every LOCKED upsell, every limit counter and the whole billing ticket need one answer to "what should this request do for whoever owns it". The redirect path asks that with no token in hand, so the resolver works from an owner id, and plan changes have to land within one request rather than one TTL, so the cache is versioned and invalidated by the write itself.

## Deploy notes

- Production now refuses to boot unless `BILLING_PROVIDER` is set, and accepts `paddle` only together with `BILLING_PADDLE_ENV=production`. Set `BILLING_PROVIDER=none` on the cloud deployment until billing goes live (self-host mode: every account resolves to the selfhost plan), then `paddle` with the `BILLING_PADDLE_*` keys when it does. Every billing setting carries the `BILLING_` prefix.
- Run `scripts/drop_users_plan.py` once after deploy.
- Accounts on a flag ALLOWLIST today read LOCKED for features their plan does not include. The enforcement sweep (next PR) turns that into 403 `plan_required`; beta access becomes an override with `kind: beta` through the ops tools.

## How proven

- Full suite green locally: 4149 passed, 8 skipped. `ruff check` and `ruff format --check` pass. `openapi.json` regenerated.
- New tests: catalog drift (fails on a missing lapse policy, checked by breaking an entry on purpose), state machine as every state times every event, resolver precedence, degraded mode with the stores down, repository writes (event and cache invalidation on every effective write, none on a no-op), version header middleware, `/me/entitlements` and `/plans` through the routes, import lint that nothing outside the entitlements package reads the plan stores.
- Live run against the app with real Mongo and Redis in Docker: register, `/me/entitlements` as free shows geo `locked` with version 0 and the header; an override grant flips geo to `enabled` on the very next request with version 1 and the `ent:` key gone; revoke flips it back at version 2; a manual pro subscription written through the repository flips it to `enabled` with plan pro at version 3, same token, no re-login; a repeated identical write leaves the version alone; a late `payment_succeeded` on a lapsed subscription is rejected; four audit events for four effective writes; a fresh login carries `plan: free` in the JWT.
