### PR TITLE
feat(entitlements): enforce plans on writes, limits, redirects and edge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,7 +143,6 @@ GITHUB_REPO="" # org/repo format
 # Access is feature-flag gated per user on top of this master switch.
 # WEBHOOKS_ENABLED="false"
 # WEBHOOKS_RUNTIME="auto"                        # auto | worker | embedded | off
-# WEBHOOKS_MAX_ENDPOINTS="5"                     # per user
 # WEBHOOKS_DELIVERY_TIMEOUT_SECONDS="15"
 # WEBHOOKS_MAX_CONSECUTIVE_FAILURES="10"         # exhausted deliveries → auto-disable
 # WEBHOOKS_DELIVERY_LOG_TTL_DAYS="30"            # events + delivery log retention

--- a/config.py
+++ b/config.py
@@ -161,7 +161,7 @@ class CustomDomainSettings(BaseSettings):
     even when False so the rollout has a clean code path to flip.
 
     All env vars must be prefixed ``CUSTOM_DOMAINS_`` so generic names
-    like ``ENABLED`` or ``MAX_PER_USER`` set elsewhere in the deploy
+    like ``ENABLED`` or ``MOCK_DCV`` set elsewhere in the deploy
     environment don't accidentally configure this feature.
     """
 
@@ -186,7 +186,6 @@ class CustomDomainSettings(BaseSettings):
     # All counts must be >= 1 — a zero quota silently bricks the feature
     # (every create raises QuotaExceeded with no log signal that the cause
     # is config, not abuse). Validators below fail container startup instead.
-    max_per_user: int = Field(default=1, ge=1)
     # Generous because CF's own DCV cadence can take 5-15 min per probe;
     # legitimate users may poll many times during initial activation.
     verify_attempts_per_hour: int = Field(default=60, ge=1)
@@ -457,7 +456,6 @@ class WebhookSettings(BaseSettings):
     enabled: bool = False
     runtime: Literal["auto", "worker", "embedded", "off"] = "auto"
 
-    max_endpoints: int = Field(default=5, ge=1)
     delivery_timeout_seconds: float = Field(default=15.0, gt=0)
     max_payload_bytes: int = Field(default=20_480, ge=1024)
     max_consecutive_failures: int = Field(default=10, ge=1)
@@ -755,8 +753,6 @@ class AppSettings(BaseSettings):
     hcaptcha_sitekey: str = ""
 
     # Service limits (overridable by self-hosters via env vars)
-    max_active_api_keys: int = 20
-    max_date_range_days: int = 90
     http_client_timeout: float = 5.0
     # Account deletion (GDPR Art. 17): days between the deletion request
     # and the erasure sweep purging the account (0 = purge on the next
@@ -798,8 +794,6 @@ class AppSettings(BaseSettings):
     # ── Field validators for safety-critical config ────────────────────
 
     @field_validator(
-        "max_active_api_keys",
-        "max_date_range_days",
         "max_emoji_alias_length",
         "emoji_generated_alias_length",
         "geo_rules_max_countries",

--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -121,6 +121,16 @@ async def get_current_user(
                 )
                 return None
 
+            if key.paused_by_limit:
+                log.warning(
+                    "api_key_auth_failed",
+                    reason="paused_by_limit",
+                    key_prefix=key.token_prefix,
+                    key_id=str(key.id),
+                    user_id=str(key.user_id),
+                )
+                return None
+
             now = datetime.now(timezone.utc)
             exp = as_aware_utc(key.expires_at)
             if exp is not None and exp <= now:

--- a/dependencies/entitlements.py
+++ b/dependencies/entitlements.py
@@ -29,6 +29,7 @@ async def get_entitlements(
         user.user_id if user else None,
         plan_hint=user.plan_claim if user else None,
     )
+    request.state.entitlements = resolved
     if user is not None and not resolved.degraded:
         request.state.entitlements_version = resolved.version
     return resolved

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -86,6 +86,7 @@ from services.custom_domain_service import CustomDomainService
 from services.domain_intel_service import DomainIntelService
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
 from services.entitlements import EntitlementService
+from services.entitlements.over_limit import OverLimitService
 from services.events.sinks import (
     InlineDomainEventSink,
     NullDomainEventSink,
@@ -291,6 +292,22 @@ def build_entitlement_service(
     cache, events, subscriptions, overrides = store or build_entitlement_store(
         db, redis_client
     )
+    domain_repo = CustomDomainRepository(db["custom_domains"])
+    endpoint_repo = WebhookEndpointRepository(db["webhook-endpoints"])
+    key_repo = ApiKeyRepository(db["api-keys"])
+    reconciler = OverLimitService(
+        endpoints=endpoint_repo,
+        domains=domain_repo,
+        keys=key_repo,
+        tenant_resolver=CachedMongoTenantResolver(
+            repo=domain_repo,
+            redis_client=redis_client,
+            system_default_domain=settings.system_default_domain,
+        ),
+        webhook_owner_cache=OwnerSubscriptionCache(
+            redis_client, ttl_seconds=settings.webhooks.matcher_cache_ttl_seconds
+        ),
+    )
     return EntitlementService(
         subscriptions,
         overrides,
@@ -298,14 +315,11 @@ def build_entitlement_service(
         cache,
         selfhost=settings.billing.selfhost,
         usage={
-            "custom_domains_max": CustomDomainRepository(
-                db["custom_domains"]
-            ).count_by_owner,
-            "webhook_endpoints_max": WebhookEndpointRepository(
-                db["webhook-endpoints"]
-            ).count_by_user,
-            "api_keys_max": ApiKeyRepository(db["api-keys"]).count_by_user,
+            "custom_domains_max": domain_repo.count_by_owner,
+            "webhook_endpoints_max": endpoint_repo.count_by_user,
+            "api_keys_max": key_repo.count_by_user,
         },
+        over_limit=reconciler,
     )
 
 
@@ -601,7 +615,6 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         webhook_executor,
         webhook_owner_cache,
         master_secret=settings.secret_key,
-        max_endpoints=wh_settings.max_endpoints,
     )
 
     # ── Safety pipeline ──────────────────────────────────────────────
@@ -764,6 +777,7 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         events=app.state.domain_event_sink,
         user_repo=user_repo,
         tag_service=app.state.tag_service,
+        entitlements=app.state.entitlement_service,
     )
     app.state.bulk_url_service = BulkUrlService(
         url_repo,
@@ -778,7 +792,6 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     app.state.stats_service = StatsService(
         click_repo,
         url_repo,
-        max_date_range_days=settings.max_date_range_days,
         tag_service=app.state.tag_service,
     )
     # One resolver serves BOTH public read-only surfaces (preview + stats)
@@ -790,7 +803,15 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         emoji_repo,
         system_default_domain=settings.system_default_domain,
     )
-    app.state.public_preview_service = PublicPreviewService(public_link_resolver)
+    app.state.feature_flag_service = FeatureFlagService(
+        feature_flag_repo, feature_flag_cache
+    )
+
+    app.state.public_preview_service = PublicPreviewService(
+        public_link_resolver,
+        app.state.entitlement_service,
+        app.state.feature_flag_service,
+    )
     app.state.url_expand_service = UrlExpandService(
         blocked_url_repo,
         MetaFetchCache(redis_client, prefix="url_expand"),
@@ -808,7 +829,8 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     app.state.public_stats_service = PublicStatsService(
         public_link_resolver,
         app.state.stats_service,
-        max_date_range_days=settings.max_date_range_days,
+        app.state.entitlement_service,
+        app.state.feature_flag_service,
     )
     # Report intake shares the resolver (existence checks answer from the
     # same generation the redirect serves) and the ops notifier + captcha
@@ -832,7 +854,6 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
     )
     app.state.api_key_service = ApiKeyService(
         api_key_repo,
-        max_active_keys=settings.max_active_api_keys,
     )
     app.state.page_layout_service = PageLayoutService(page_layout_repo)
     token_factory = TokenFactory(
@@ -939,10 +960,6 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
         app.state.click_sink = inline_sink
 
     app.state.app_grant_repo = app_grant_repo
-
-    app.state.feature_flag_service = FeatureFlagService(
-        feature_flag_repo, feature_flag_cache
-    )
 
     # Whenever clicks are tracked inline, link.clicked webhooks must fan
     # out at emit time — the worker's stream group only sees clicks that

--- a/errors.py
+++ b/errors.py
@@ -131,6 +131,41 @@ class InvalidTransitionError(ConflictError):
     error_code = "invalid_transition"
 
 
+class PlanRequiredError(ForbiddenError):
+    """The account's plan does not include the feature being written."""
+
+    error_code = "plan_required"
+
+    def __init__(self, feature: str) -> None:
+        super().__init__(f"{feature} is not included in your plan")
+        self.feature = feature
+
+    def to_dict(self) -> ErrorBody:
+        d = super().to_dict()
+        d["feature"] = self.feature
+        return d
+
+
+class LimitReachedError(ForbiddenError):
+    """A per-plan count limit is full; ``max`` and ``current`` let the UI
+    render the counter."""
+
+    error_code = "limit_reached"
+
+    def __init__(self, limit: str, *, max_: int, current: int) -> None:
+        super().__init__(f"{limit} limit reached ({current}/{max_})")
+        self.limit = limit
+        self.max = max_
+        self.current = current
+
+    def to_dict(self) -> ErrorBody:
+        d = super().to_dict()
+        d["limit"] = self.limit
+        d["max"] = self.max
+        d["current"] = self.current
+        return d
+
+
 class BlockedUrlError(AppError):
     status_code = 451
     error_code = "blocked"

--- a/infrastructure/cache/url_cache.py
+++ b/infrastructure/cache/url_cache.py
@@ -61,6 +61,9 @@ class UrlCacheData(BaseModel):
     # Entries cached before this field existed deserialize to None.
     start_time: int | None = None
     pre_start_url: str | None = None
+    # Owner entitlement version this entry was shaped under; None for
+    # unowned links and for entries written before the owner was consulted.
+    owner_ent_version: int | None = None
 
     @classmethod
     def from_v2_doc(cls, doc: UrlV2Doc) -> UrlCacheData:

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 import hashlib
 import math
 import os
+import re
+from collections.abc import Callable
 
 from fastapi import Request
 from slowapi import Limiter
 from starlette.datastructures import MutableHeaders
 
 from infrastructure.logging import get_logger
+from services.entitlements.resolver import Resolved
+from services.features.catalog import UNLIMITED
 from shared.ip_utils import get_client_ip
 
 log = get_logger(__name__)
@@ -91,8 +95,8 @@ class Limits:
     # so the request budget must never make bulk scarcer than looping the
     # per-item routes — that would push clients back to the fan-out these
     # endpoints exist to kill. Per-minute is kept high for bursts (a mass
-    # takedown chunks at 100 ids/request); the daily cap is a lid, not a
-    # ration. Blast radius per request is bounded by the 100-id cap and
+    # takedown chunks at the plan's bulk_batch_max); the daily cap is a lid, not a
+    # ration. Blast radius per request is bounded by that batch cap and
     # ownership scoping, and each batch is ~4 local calls plus at most
     # one CF call, so these are cheap requests. Delete stays the tighter
     # pair because it is irreversible.
@@ -190,12 +194,26 @@ class Limits:
 # ── Key resolution ───────────────────────────────────────────────────────────
 
 
+# Plan multiplier suffix on the key, so slowapi counts each tier in its own
+# bucket and the limit function can scale the string it applies.
+_MULTIPLIER_SEP = "|x"
+# What "unlimited" means for a rate: still bounded, just far above any client.
+_UNLIMITED_MULTIPLIER = 1000
+
+
 def rate_limit_key(request: Request) -> str:
-    """Three-tier rate limit key: API key hash → JWT hash → client IP.
+    """Three-tier rate limit key: API key hash → JWT hash → client IP, plus
+    the caller's plan rate multiplier when the route resolved entitlements.
 
     Lightweight header inspection only — no DB queries, no JWT verification.
     Provides consistent per-session bucketing for rate limiting purposes.
     """
+    key = _identity_key(request)
+    multiplier = plan_multiplier(request)
+    return f"{key}{_MULTIPLIER_SEP}{multiplier}" if multiplier > 1 else key
+
+
+def _identity_key(request: Request) -> str:
     auth_header = request.headers.get("Authorization", "")
 
     if auth_header.lower().startswith("bearer "):
@@ -212,6 +230,49 @@ def rate_limit_key(request: Request) -> str:
         return f"jwt:{token_hash}"
 
     return get_client_ip(request)
+
+
+def plan_multiplier(request: Request) -> int:
+    """The ``api_rate_multiplier`` of the entitlements the ``Entitled``
+    dependency stored on this request; 1 when the route did not resolve them."""
+    resolved = getattr(request.state, "entitlements", None)
+    if not isinstance(resolved, Resolved):
+        return 1
+    value = resolved.limit("api_rate_multiplier")
+    if value == UNLIMITED:
+        return _UNLIMITED_MULTIPLIER
+    return value if value > 1 else 1
+
+
+def multiplier_of(key: str) -> int:
+    _, sep, suffix = key.rpartition(_MULTIPLIER_SEP)
+    return int(suffix) if sep and suffix.isdigit() else 1
+
+
+def scale_limit(limit: str, factor: int) -> str:
+    """``"60 per minute; 5000 per day"`` times ``factor`` on every count."""
+    if factor <= 1:
+        return limit
+    return "; ".join(
+        re.sub(r"^\d+", lambda m: str(int(m.group(0)) * factor), part.strip())
+        for part in limit.split(";")
+    )
+
+
+def plan_scaled(limit: str) -> Callable[[str], str]:
+    """Limit callable for ``@limiter.limit``: the base string scaled by the
+    plan multiplier carried on the key. The route must declare ``Entitled``
+    so the multiplier is known before the limiter runs.
+
+    Scaled: the per-request API budgets an integration spends on links,
+    stats and exports. Flat: auth, keys, domains, webhooks and bulk, which
+    are admin actions (bulk already scales through ``bulk_batch_max``).
+    """
+
+    def _limit(key: str) -> str:
+        return scale_limit(limit, multiplier_of(key))
+
+    return _limit
 
 
 # ── Limiter singleton ────────────────────────────────────────────────────────
@@ -306,7 +367,7 @@ def dynamic_limit(authenticated: str, anonymous: str) -> tuple:
 
     def _limit(key: str) -> str:
         if key.startswith("apikey:") or key.startswith("jwt:"):
-            return authenticated
+            return scale_limit(authenticated, multiplier_of(key))
         return anonymous
 
     return _limit, rate_limit_key

--- a/openapi.json
+++ b/openapi.json
@@ -6724,7 +6724,7 @@
           "Custom Domains"
         ],
         "summary": "Register Custom Domain",
-        "description": "Register a new custom domain for branded short links.\n\nThe domain is born in `PENDING` state. The user must publish the DNS\nrecords returned in `dns_records` at their DNS provider, then call\n`POST /custom-domains/{id}/verify` to trigger verification. Cloudflare\nauto-verifies via HTTP DCV once the CNAME is live and propagated.\n\n**Authentication**: Required (JWT Bearer or API key with `domains:manage`).\n\n**Email verification**: Required (applies to API key callers too).\n\n**Feature gate**: Must be enabled for the calling user.\n\n**Rate Limits**: 10/hour (route, failed attempts count) + `max_per_user`\nowned domains (service quota, any status).",
+        "description": "Register a new custom domain for branded short links.\n\nThe domain is born in `PENDING` state. The user must publish the DNS\nrecords returned in `dns_records` at their DNS provider, then call\n`POST /custom-domains/{id}/verify` to trigger verification. Cloudflare\nauto-verifies via HTTP DCV once the CNAME is live and propagated.\n\n**Authentication**: Required (JWT Bearer or API key with `domains:manage`).\n\n**Email verification**: Required (applies to API key callers too).\n\n**Feature gate**: Must be enabled for the calling user.\n\n**Rate Limits**: 10/hour (route, failed attempts count). Owned domains\n(any status) count against the plan's `custom_domains_max`; a full\nlimit answers 403 `limit_reached`.",
         "operationId": "createCustomDomain",
         "requestBody": {
           "required": true,
@@ -7130,7 +7130,7 @@
           "Custom Domains"
         ],
         "summary": "Update Custom Domain Routing",
-        "description": "Update the per-domain routing config.\n\nPartial update \u2014 send only the fields you want to change. Omit a field to\nleave it untouched. Send explicit `null` to clear a stored value. The\nconfig takes effect only when the domain is `ACTIVE`; non-ACTIVE domains\nreturn 422.\n\n**Configurable fields**:\n- `root_redirect` \u2014 destination for `GET /` (302).\n- `not_found_redirect` \u2014 fallback for any path that doesn't match an alias.\n- `custom_robots_txt` \u2014 body served at `/robots.txt` (\u22644096 chars).\n\n**Authentication**: Required (JWT or API key with `domains:manage`).\n\n**Rate Limits**: 30/min.\n\n**Responses**:\n- 200 \u2014 updated; full domain response returned\n- 403 \u2014 caller does not own this domain\n- 404 \u2014 domain not found (or invalid id)\n- 422 \u2014 domain isn't ACTIVE, or body fails validation",
+        "description": "Update the per-domain routing config.\n\nPartial update \u2014 send only the fields you want to change. Omit a field to\nleave it untouched. Send explicit `null` to clear a stored value. The\nconfig takes effect only when the domain is `ACTIVE`; non-ACTIVE domains\nreturn 422.\n\n**Configurable fields**:\n- `root_redirect` \u2014 destination for `GET /` (302).\n- `not_found_redirect` \u2014 fallback for any path that doesn't match an alias.\n- `custom_robots_txt` \u2014 body served at `/robots.txt` (\u22644096 chars).\n\n**Authentication**: Required (JWT or API key with `domains:manage`).\n\n**Rate Limits**: 30/min.\n\n**Responses**:\n- 200 \u2014 updated; full domain response returned\n- 403 \u2014 caller does not own this domain, or the plan lacks domain polish\n- 404 \u2014 domain not found (or invalid id)\n- 422 \u2014 domain isn't ACTIVE, or body fails validation",
         "operationId": "updateCustomDomain",
         "parameters": [
           {
@@ -10665,10 +10665,10 @@
               "type": "string"
             },
             "type": "array",
-            "maxItems": 100,
+            "maxItems": 1000,
             "minItems": 1,
             "title": "Ids",
-            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
+            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 1000 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
             "examples": [
               [
                 "665f0c2f9e7a4b1d2c3d4e5f",
@@ -10727,10 +10727,10 @@
               "type": "string"
             },
             "type": "array",
-            "maxItems": 100,
+            "maxItems": 1000,
             "minItems": 1,
             "title": "Ids",
-            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
+            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 1000 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
             "examples": [
               [
                 "665f0c2f9e7a4b1d2c3d4e5f",
@@ -10797,10 +10797,10 @@
               "type": "string"
             },
             "type": "array",
-            "maxItems": 100,
+            "maxItems": 1000,
             "minItems": 1,
             "title": "Ids",
-            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
+            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 1000 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
             "examples": [
               [
                 "665f0c2f9e7a4b1d2c3d4e5f",
@@ -10850,10 +10850,10 @@
               "type": "string"
             },
             "type": "array",
-            "maxItems": 100,
+            "maxItems": 1000,
             "minItems": 1,
             "title": "Ids",
-            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
+            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 1000 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
             "examples": [
               [
                 "665f0c2f9e7a4b1d2c3d4e5f",
@@ -10896,10 +10896,10 @@
               "type": "string"
             },
             "type": "array",
-            "maxItems": 100,
+            "maxItems": 1000,
             "minItems": 1,
             "title": "Ids",
-            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 100 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
+            "description": "URL ids (MongoDB ObjectIds, as returned by the list endpoint). 1 to 1000 per request; duplicates are deduplicated server-side (first occurrence wins). One malformed id rejects the whole request \u2014 nothing is attempted.",
             "examples": [
               [
                 "665f0c2f9e7a4b1d2c3d4e5f",
@@ -14010,6 +14010,11 @@
             "type": "string",
             "title": "Short Url"
           },
+          "whitelabel": {
+            "type": "boolean",
+            "title": "Whitelabel",
+            "default": false
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -14142,6 +14147,11 @@
           },
           "link": {
             "$ref": "#/components/schemas/PublicLinkFacts"
+          },
+          "whitelabel": {
+            "type": "boolean",
+            "title": "Whitelabel",
+            "default": false
           },
           "stats": {
             "additionalProperties": true,
@@ -14787,6 +14797,22 @@
               }
             ],
             "title": "End Date"
+          },
+          "clamped": {
+            "type": "boolean",
+            "title": "Clamped",
+            "default": false
+          },
+          "window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Window Days"
           }
         },
         "type": "object",

--- a/repositories/api_key_repository.py
+++ b/repositories/api_key_repository.py
@@ -74,6 +74,12 @@ class ApiKeyRepository(BaseRepository[ApiKeyDoc]):
         """
         return await self._delete_many({"user_id": user_id})
 
+    async def set_paused_by_limit(self, ids: list[ObjectId], paused: bool) -> int:
+        result = await self._col.update_many(
+            {"_id": {"$in": ids}}, {"$set": {"paused_by_limit": paused}}
+        )
+        return result.modified_count
+
     async def count_by_user(self, user_id: ObjectId) -> int:
         """Count active (non-revoked) API keys for a user."""
         return await self._count({"user_id": user_id, "revoked": {"$ne": True}})

--- a/repositories/custom_domain_repository.py
+++ b/repositories/custom_domain_repository.py
@@ -49,7 +49,11 @@ class CustomDomainRepository(BaseRepository[CustomDomainDoc]):
         currently-active domains.
         """
         return await self._find_one(
-            {"fqdn": _canonical(fqdn), "status": DomainStatus.ACTIVE}
+            {
+                "fqdn": _canonical(fqdn),
+                "status": DomainStatus.ACTIVE,
+                "paused_by_limit": {"$ne": True},
+            }
         )
 
     async def find_blocking_by_fqdn(self, fqdn: str) -> CustomDomainDoc | None:
@@ -88,6 +92,26 @@ class CustomDomainRepository(BaseRepository[CustomDomainDoc]):
                 error_type=type(exc).__name__,
             )
             raise
+
+    async def list_live_by_owner(self, owner_id: ObjectId) -> list[CustomDomainDoc]:
+        """Every non-revoked domain of *owner_id*, oldest first."""
+        cursor = self._col.find(
+            {"owner_id": owner_id, "status": {"$ne": DomainStatus.REVOKED.value}}
+        ).sort("created_at", 1)
+        docs = await cursor.to_list(length=None)
+        return [CustomDomainDoc.from_mongo(d) for d in docs]  # type: ignore[misc]
+
+    async def set_paused_by_limit(self, ids: list[ObjectId], paused: bool) -> int:
+        result = await self._col.update_many(
+            {"_id": {"$in": ids}},
+            {
+                "$set": {
+                    "paused_by_limit": paused,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )
+        return result.modified_count
 
     async def count_by_owner(self, owner_id: ObjectId) -> int:
         """Count all domains owned by *owner_id* (any status)."""

--- a/repositories/webhook_endpoint_repository.py
+++ b/repositories/webhook_endpoint_repository.py
@@ -158,6 +158,22 @@ class WebhookEndpointRepository(BaseRepository[WebhookEndpointDoc]):
     async def increment_dropped(self, endpoint_id: ObjectId) -> None:
         await self._update({"_id": endpoint_id}, {"$inc": {"dropped_count": 1}})
 
+    async def reactivate_over_limit(self, endpoint_id: ObjectId) -> bool:
+        """Lift an over-limit pause; any other disabled reason stays."""
+        return await self._update(
+            {
+                "_id": endpoint_id,
+                "disabled_reason": EndpointDisabledReason.OVER_LIMIT.value,
+            },
+            {
+                "$set": {
+                    "status": WebhookStatus.ACTIVE.value,
+                    "disabled_reason": None,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )
+
     async def disable(
         self, endpoint_id: ObjectId, reason: EndpointDisabledReason
     ) -> bool:

--- a/routes/api_v1/bulk.py
+++ b/routes/api_v1/bulk.py
@@ -31,9 +31,11 @@ from dependencies import (
     BulkUrlSvc,
     CurrentUser,
     CustomDomainSvc,
+    Entitled,
     Settings,
     require_scopes,
 )
+from errors import LimitReachedError
 from middleware.openapi import ERROR_RESPONSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.dto.requests.bulk import (
@@ -44,8 +46,15 @@ from schemas.dto.requests.bulk import (
     BulkUpdateStatusRequest,
 )
 from schemas.dto.responses.bulk import BulkUrlOperationResponse
+from services.entitlements import Resolved
 
 router = APIRouter(tags=["Link Management"])
+
+
+def _check_batch_size(ids: list[str], entitlements: Resolved) -> None:
+    cap = entitlements.limit("bulk_batch_max")
+    if len(ids) > cap and not entitlements.is_unlimited("bulk_batch_max"):
+        raise LimitReachedError("bulk_batch_max", max_=cap, current=len(ids))
 
 
 @router.post(
@@ -58,6 +67,7 @@ router = APIRouter(tags=["Link Management"])
 async def bulk_delete_urls_v1(
     request: Request,
     body: BulkDeleteUrlsRequest,
+    entitlements: Entitled,
     bulk_service: BulkUrlSvc,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> BulkUrlOperationResponse:
@@ -80,6 +90,7 @@ async def bulk_delete_urls_v1(
 
     **Rate Limits**: 30/min, 100/day — counted per request, not per id.
     """
+    _check_batch_size(body.ids, entitlements)
     return await bulk_service.bulk_delete(body.object_ids(), user.user_id)
 
 
@@ -93,6 +104,7 @@ async def bulk_delete_urls_v1(
 async def bulk_update_url_status_v1(
     request: Request,
     body: BulkUpdateStatusRequest,
+    entitlements: Entitled,
     bulk_service: BulkUrlSvc,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> BulkUrlOperationResponse:
@@ -109,6 +121,7 @@ async def bulk_update_url_status_v1(
 
     **Rate Limits**: 60/min, 200/day — counted per request, not per id.
     """
+    _check_batch_size(body.ids, entitlements)
     return await bulk_service.bulk_set_status(
         body.object_ids(), body.status, user.user_id
     )
@@ -124,6 +137,7 @@ async def bulk_update_url_status_v1(
 async def bulk_update_url_expiry_v1(
     request: Request,
     body: BulkUpdateExpiryRequest,
+    entitlements: Entitled,
     bulk_service: BulkUrlSvc,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> BulkUrlOperationResponse:
@@ -141,6 +155,7 @@ async def bulk_update_url_expiry_v1(
 
     **Rate Limits**: 60/min, 200/day — counted per request, not per id.
     """
+    _check_batch_size(body.ids, entitlements)
     return await bulk_service.bulk_set_expiry(
         body.object_ids(), body.expire_after, user.user_id
     )
@@ -156,6 +171,7 @@ async def bulk_update_url_expiry_v1(
 async def bulk_move_url_domain_v1(
     request: Request,
     body: BulkMoveDomainRequest,
+    entitlements: Entitled,
     bulk_service: BulkUrlSvc,
     custom_domain_service: CustomDomainSvc,
     settings: Settings,
@@ -185,6 +201,7 @@ async def bulk_move_url_domain_v1(
 
     **Rate Limits**: 60/min, 200/day — counted per request, not per id.
     """
+    _check_batch_size(body.ids, entitlements)
     if body.domain and body.domain != settings.system_default_domain:
         await custom_domain_service.assert_owned_and_active(user, body.domain)
     return await bulk_service.bulk_move_domain(
@@ -202,6 +219,7 @@ async def bulk_move_url_domain_v1(
 async def bulk_tag_urls_v1(
     request: Request,
     body: BulkTagUrlsRequest,
+    entitlements: Entitled,
     bulk_service: BulkUrlSvc,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> BulkUrlOperationResponse:
@@ -222,6 +240,7 @@ async def bulk_tag_urls_v1(
 
     **Rate Limits**: 60/min, 200/day — counted per request, not per id.
     """
+    _check_batch_size(body.ids, entitlements)
     return await bulk_service.bulk_tag(
         body.object_ids(), body.add_ids(), body.remove_ids(), user.user_id
     )

--- a/routes/api_v1/custom_domains.py
+++ b/routes/api_v1/custom_domains.py
@@ -26,11 +26,12 @@ from dependencies import (
     DOMAIN_READ_SCOPES,
     CurrentUser,
     CustomDomainSvc,
+    Entitled,
     FeatureFlagSvc,
     require_scopes,
     require_scopes_verified,
 )
-from errors import NotFoundError
+from errors import NotFoundError, PlanRequiredError
 from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
 from middleware.rate_limiter import Limits, limiter
 from schemas.dto.requests.custom_domain import (
@@ -43,6 +44,7 @@ from schemas.dto.responses.custom_domain import (
     CustomDomainListResponse,
     CustomDomainResponse,
 )
+from services.entitlements import Resolved
 from services.feature_flag_service import CUSTOM_DOMAINS_FLAG
 
 router = APIRouter(tags=["Custom Domains"])
@@ -61,10 +63,12 @@ def _parse_domain_id(domain_id: str) -> ObjectId:
         raise NotFoundError("domain not found") from None
 
 
-async def _require_create_enabled(flag_svc: FeatureFlagSvc, user: CurrentUser) -> None:
-    """Flag gate for CREATE. 404 (not 403) — don't leak feature existence."""
-    if not await flag_svc.is_enabled(_FEATURE_FLAG, user):
-        raise NotFoundError("not found")
+async def _require_create_enabled(
+    flag_svc: FeatureFlagSvc, user: CurrentUser, entitlements: Resolved
+) -> None:
+    """Flag off: 404, so the feature's existence never leaks. Flag on but
+    not in the plan: 403 ``plan_required``, the client already sees LOCKED."""
+    await flag_svc.require(_FEATURE_FLAG, user, entitlements=entitlements, hide=True)
 
 
 @router.post(
@@ -80,6 +84,7 @@ async def create_custom_domain(
     body: CreateCustomDomainRequest,
     service: CustomDomainSvc,
     flag_svc: FeatureFlagSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes_verified(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
 ) -> CustomDomainResponse:
     """Register a new custom domain for branded short links.
@@ -95,11 +100,14 @@ async def create_custom_domain(
 
     **Feature gate**: Must be enabled for the calling user.
 
-    **Rate Limits**: 10/hour (route, failed attempts count) + `max_per_user`
-    owned domains (service quota, any status).
+    **Rate Limits**: 10/hour (route, failed attempts count). Owned domains
+    (any status) count against the plan's `custom_domains_max`; a full
+    limit answers 403 `limit_reached`.
     """
-    await _require_create_enabled(flag_svc, user)
-    doc = await service.create(body, user)
+    await _require_create_enabled(flag_svc, user, entitlements)
+    doc = await service.create(
+        body, user, max_domains=entitlements.limit("custom_domains_max")
+    )
     return CustomDomainResponse.from_doc(doc)
 
 
@@ -205,6 +213,7 @@ async def update_custom_domain(
     domain_id: Annotated[str, Path(description="MongoDB ObjectId of the domain.")],
     body: UpdateCustomDomainRequest,
     service: CustomDomainSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes(DOMAIN_MANAGE_SCOPES)),  # noqa: B008
 ) -> CustomDomainResponse:
     """Update the per-domain routing config.
@@ -225,11 +234,18 @@ async def update_custom_domain(
 
     **Responses**:
     - 200 — updated; full domain response returned
-    - 403 — caller does not own this domain
+    - 403 — caller does not own this domain, or the plan lacks domain polish
     - 404 — domain not found (or invalid id)
     - 422 — domain isn't ACTIVE, or body fails validation
     """
     oid = _parse_domain_id(domain_id)
+    # Setting any routing value needs the entitlement (the endpoint itself is
+    # already behind custom_domains); clearing (null) never does.
+    if not entitlements.has("domain_polish") and any(
+        getattr(body, f) is not None
+        for f in ("root_redirect", "not_found_redirect", "custom_robots_txt")
+    ):
+        raise PlanRequiredError("domain_polish")
     doc = await service.update_routing(oid, user, body)
     return CustomDomainResponse.from_doc(doc)
 

--- a/routes/api_v1/exports.py
+++ b/routes/api_v1/exports.py
@@ -16,12 +16,13 @@ from fastapi.responses import Response
 from dependencies import (
     STATS_SCOPES,
     CurrentUser,
+    Entitled,
     ExportSvc,
     UrlSvc,
     require_scopes,
 )
 from middleware.openapi import EXPORT_RESPONSES
-from middleware.rate_limiter import Limits, limiter
+from middleware.rate_limiter import Limits, limiter, plan_scaled
 from routes.api_v1._helpers import parse_url_id
 from schemas.dto.requests.stats import ExportQuery, LinkExportQuery
 
@@ -59,11 +60,12 @@ _EXPORT_200_RESPONSES = {
     operation_id="exportStats",
     summary="Export Statistics",
 )
-@limiter.limit(Limits.API_EXPORT_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_EXPORT_AUTHED))
 async def export_v1(
     request: Request,
     query: Annotated[ExportQuery, Query()],
     export_service: ExportSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes(STATS_SCOPES)),  # noqa: B008
 ) -> Response:
     """Export click statistics across all URLs you own as a downloadable file.
@@ -105,7 +107,7 @@ async def export_v1(
     operation_id="exportLinkStats",
     summary="Export Link Statistics",
 )
-@limiter.limit(Limits.API_EXPORT_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_EXPORT_AUTHED))
 async def export_link_v1(
     request: Request,
     url_id: Annotated[
@@ -115,6 +117,7 @@ async def export_link_v1(
     query: Annotated[LinkExportQuery, Query()],
     export_service: ExportSvc,
     url_service: UrlSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes(STATS_SCOPES)),  # noqa: B008
 ) -> Response:
     """Export click statistics for a single URL you own.

--- a/routes/api_v1/keys.py
+++ b/routes/api_v1/keys.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Path, Query, Request
 
 from dependencies import (
     ApiKeySvc,
+    Entitled,
     JwtVerifiedUser,
     KeysAccessUser,
 )
@@ -50,6 +51,7 @@ async def create_api_key(
     body: CreateApiKeyRequest,
     user: JwtVerifiedUser,
     api_key_service: ApiKeySvc,
+    entitlements: Entitled,
 ) -> ApiKeyCreatedResponse:
     """Create a new API key for programmatic access.
 
@@ -94,6 +96,7 @@ async def create_api_key(
         email_verified=user.email_verified,
         description=body.description,
         expires_at=expires_at,
+        max_keys=entitlements.limit("api_keys_max"),
     )
 
     return ApiKeyCreatedResponse(

--- a/routes/api_v1/management.py
+++ b/routes/api_v1/management.py
@@ -17,6 +17,7 @@ from dependencies import (
     URL_MANAGEMENT_SCOPES,
     CurrentUser,
     CustomDomainSvc,
+    Entitled,
     FeatureFlagSvc,
     Settings,
     TagSvc,
@@ -24,7 +25,7 @@ from dependencies import (
     require_scopes,
 )
 from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
-from middleware.rate_limiter import Limits, limiter
+from middleware.rate_limiter import Limits, limiter, plan_scaled
 from routes.api_v1._helpers import parse_url_id
 from schemas.dto.requests.url import (
     ClaimUrlsRequest,
@@ -94,7 +95,7 @@ async def claim_urls_v1(
     operation_id="updateUrl",
     summary="Update URL",
 )
-@limiter.limit(Limits.URL_MANAGE)
+@limiter.limit(plan_scaled(Limits.URL_MANAGE))
 async def update_url_v1(
     request: Request,
     url_id: Annotated[
@@ -112,6 +113,7 @@ async def update_url_v1(
     custom_domain_service: CustomDomainSvc,
     settings: Settings,
     flag_svc: FeatureFlagSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> UpdateUrlResponse:
     """Update an existing URL's properties.
@@ -149,17 +151,17 @@ async def update_url_v1(
     # Setting geo rules is flag-gated; clearing (null/{}) is always allowed so
     # de-allowlisted owners can remove their rules during rollback.
     if "geo_rules" in body.model_fields_set and body.geo_rules:
-        await flag_svc.require(GEO_TARGETING_FLAG, user)
+        await flag_svc.require(GEO_TARGETING_FLAG, user, entitlements=entitlements)
     if "ab_variants" in body.model_fields_set and body.ab_variants:
-        await flag_svc.require(AB_TESTING_FLAG, user)
+        await flag_svc.require(AB_TESTING_FLAG, user, entitlements=entitlements)
     if "expired_redirect_url" in body.model_fields_set and body.expired_redirect_url:
-        await flag_svc.require(EXPIRED_FALLBACK_FLAG, user)
+        await flag_svc.require(EXPIRED_FALLBACK_FLAG, user, entitlements=entitlements)
     # Same deal for meta_tags: setting/replacing is flag-gated, clearing
     # (null) never is.
     if "meta_tags" in body.model_fields_set and body.meta_tags is not None:
-        await flag_svc.require(META_TAGS_FLAG, user)
+        await flag_svc.require(META_TAGS_FLAG, user, entitlements=entitlements)
     if body.starts_at is not None or body.pre_start_url:
-        await flag_svc.require(LINK_SCHEDULING_FLAG, user)
+        await flag_svc.require(LINK_SCHEDULING_FLAG, user, entitlements=entitlements)
     # Verify domain ownership at the edge so the service can stay opaque about
     # tenancy. `domain` field-set with null means "move to system default" —
     # no ownership check needed for the default namespace.
@@ -178,7 +180,7 @@ async def update_url_v1(
     operation_id="updateUrlStatus",
     summary="Update URL Status",
 )
-@limiter.limit(Limits.URL_MANAGE)
+@limiter.limit(plan_scaled(Limits.URL_MANAGE))
 async def update_url_status_v1(
     request: Request,
     url_id: Annotated[
@@ -193,6 +195,7 @@ async def update_url_status_v1(
     body: UpdateUrlStatusRequest,
     url_service: UrlSvc,
     tag_service: TagSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> UpdateUrlResponse:
     """Update only the status of a URL (ACTIVE / INACTIVE).
@@ -237,7 +240,7 @@ async def update_url_status_v1(
     operation_id="deleteUrl",
     summary="Delete URL",
 )
-@limiter.limit(Limits.URL_DELETE)
+@limiter.limit(plan_scaled(Limits.URL_DELETE))
 async def delete_url_v1(
     request: Request,
     url_id: Annotated[
@@ -250,6 +253,7 @@ async def delete_url_v1(
         ),
     ],
     url_service: UrlSvc,
+    entitlements: Entitled,
     user: CurrentUser = Depends(require_scopes(URL_MANAGEMENT_SCOPES)),  # noqa: B008
 ) -> DeleteUrlResponse:
     """Delete a URL permanently.

--- a/routes/api_v1/me.py
+++ b/routes/api_v1/me.py
@@ -43,6 +43,7 @@ from schemas.dto.responses.account import AccountDeletionResponse
 from schemas.dto.responses.entitlements import (
     EntitlementsResponse,
     LimitBlock,
+    OverLimitBlock,
     PlanBlock,
 )
 from schemas.dto.responses.features import FeaturesResponse
@@ -152,6 +153,7 @@ async def get_my_entitlements(
     """
     features = await flag_service.states_for(user, entitlements)
     used = await entitlement_service.usage_for(user.user_id)
+    paused = await entitlement_service.over_limit_for(user.user_id)
     return EntitlementsResponse(
         version=entitlements.version,
         plan=PlanBlock(
@@ -165,6 +167,7 @@ async def get_my_entitlements(
             f.key: LimitBlock(max=entitlements.limit(f.key), used=used.get(f.key))
             for f in int_features()
         },
+        over_limit={k: OverLimitBlock(paused=v) for k, v in paused.items()},
     )
 
 

--- a/routes/api_v1/shorten.py
+++ b/routes/api_v1/shorten.py
@@ -19,6 +19,7 @@ from dependencies import (
     SHORTEN_SCOPES,
     CurrentUser,
     CustomDomainSvc,
+    Entitled,
     FeatureFlagSvc,
     Settings,
     TagSvc,
@@ -63,6 +64,7 @@ async def shorten_v1(
     custom_domain_service: CustomDomainSvc,
     settings: Settings,
     flag_svc: FeatureFlagSvc,
+    entitlements: Entitled,
     user: CurrentUser | None = Depends(optional_scopes_verified(SHORTEN_SCOPES)),  # noqa: B008
 ) -> UrlResponse:
     """Create a new shortened URL.
@@ -106,31 +108,31 @@ async def shorten_v1(
     if body.geo_rules:
         if user is None:
             raise AuthenticationError("Authentication required to set geo_rules")
-        await flag_svc.require(GEO_TARGETING_FLAG, user)
+        await flag_svc.require(GEO_TARGETING_FLAG, user, entitlements=entitlements)
 
     if body.ab_variants:
         if user is None:
             raise AuthenticationError("Authentication required to set ab_variants")
-        await flag_svc.require(AB_TESTING_FLAG, user)
+        await flag_svc.require(AB_TESTING_FLAG, user, entitlements=entitlements)
 
     if body.expired_redirect_url:
         if user is None:
             raise AuthenticationError(
                 "Authentication required to set expired_redirect_url"
             )
-        await flag_svc.require(EXPIRED_FALLBACK_FLAG, user)
+        await flag_svc.require(EXPIRED_FALLBACK_FLAG, user, entitlements=entitlements)
 
     # optional_scopes_verified already rejects unverified authenticated users,
     # so the flag is the only remaining gate here.
     if body.meta_tags is not None:
         if user is None:
             raise AuthenticationError("Authentication required to set meta_tags")
-        await flag_svc.require(META_TAGS_FLAG, user)
+        await flag_svc.require(META_TAGS_FLAG, user, entitlements=entitlements)
 
     if body.starts_at is not None or body.pre_start_url:
         if user is None:
             raise AuthenticationError("Authentication required to schedule a link")
-        await flag_svc.require(LINK_SCHEDULING_FLAG, user)
+        await flag_svc.require(LINK_SCHEDULING_FLAG, user, entitlements=entitlements)
 
     if body.domain and body.domain != settings.system_default_domain:
         if user is None:

--- a/routes/api_v1/stats.py
+++ b/routes/api_v1/stats.py
@@ -21,12 +21,13 @@ from fastapi import APIRouter, Depends, Path, Query, Request
 from dependencies import (
     STATS_SCOPES,
     CurrentUser,
+    Entitled,
     StatsSvc,
     UrlSvc,
     require_scopes,
 )
 from middleware.openapi import ERROR_RESPONSES
-from middleware.rate_limiter import Limits, limiter
+from middleware.rate_limiter import Limits, limiter, plan_scaled
 from routes.api_v1._helpers import parse_url_id
 from schemas.dto.requests.stats import LinkStatsQuery, StatsQuery
 from schemas.dto.responses.stats import LinkStatsResponse, StatsResponse
@@ -40,9 +41,10 @@ router = APIRouter(tags=["Statistics"])
     operation_id="getStats",
     summary="URL Statistics",
 )
-@limiter.limit(Limits.API_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_AUTHED))
 async def stats_v1(
     request: Request,
+    entitlements: Entitled,
     query: Annotated[StatsQuery, Query()],
     stats_service: StatsSvc,
     user: CurrentUser = Depends(require_scopes(STATS_SCOPES)),  # noqa: B008
@@ -70,7 +72,11 @@ async def stats_v1(
     `url_id` values you do not own simply match nothing. For statistics on
     a single link, prefer `GET /stats/links/{url_id}`.
     """
-    result = await stats_service.query(query, str(user.user_id))
+    result = await stats_service.query(
+        query,
+        str(user.user_id),
+        window_days=entitlements.limit("analytics_window_days"),
+    )
     return StatsResponse.model_validate(result)
 
 
@@ -80,9 +86,10 @@ async def stats_v1(
     operation_id="getLinkStats",
     summary="Link Statistics",
 )
-@limiter.limit(Limits.API_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_AUTHED))
 async def link_stats_v1(
     request: Request,
+    entitlements: Entitled,
     url_id: Annotated[
         str,
         Path(description="Unique identifier of the URL (MongoDB ObjectId)."),
@@ -123,5 +130,7 @@ async def link_stats_v1(
     """
     oid = parse_url_id(url_id)
     url = await url_service.get_owned(oid, user.user_id)
-    result = await stats_service.query_link(query, url)
+    result = await stats_service.query_link(
+        query, url, window_days=entitlements.limit("analytics_window_days")
+    )
     return LinkStatsResponse.model_validate(result)

--- a/routes/api_v1/tags.py
+++ b/routes/api_v1/tags.py
@@ -19,11 +19,12 @@ from dependencies import (
     URL_MANAGEMENT_SCOPES,
     URL_READ_SCOPES,
     CurrentUser,
+    Entitled,
     TagSvc,
     require_scopes,
 )
 from middleware.openapi import ERROR_RESPONSES
-from middleware.rate_limiter import Limits, limiter
+from middleware.rate_limiter import Limits, limiter, plan_scaled
 from routes.api_v1._helpers import parse_object_id
 from schemas.dto.requests.tag import CreateTagRequest, UpdateTagRequest
 from schemas.dto.responses.tag import (
@@ -47,9 +48,10 @@ _TAG_ID_PATH = Path(
     operation_id="listTags",
     summary="List Your Tags",
 )
-@limiter.limit(Limits.API_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_AUTHED))
 async def list_tags_v1(
     request: Request,
+    entitlements: Entitled,
     tag_service: TagSvc,
     user: CurrentUser = Depends(require_scopes(URL_READ_SCOPES)),  # noqa: B008
 ) -> TagListResponse:

--- a/routes/api_v1/urls.py
+++ b/routes/api_v1/urls.py
@@ -36,6 +36,7 @@ from dependencies import (
     URL_READ_SCOPES,
     CurrentUser,
     CustomDomainSvc,
+    Entitled,
     Settings,
     TagSvc,
     UrlSvc,
@@ -43,7 +44,7 @@ from dependencies import (
 )
 from errors import NotFoundError, ValidationError
 from middleware.openapi import AUTH_RESPONSES, ERROR_RESPONSES
-from middleware.rate_limiter import Limits, limiter
+from middleware.rate_limiter import Limits, limiter, plan_scaled
 from routes.api_v1._helpers import parse_url_id
 from schemas.dto.requests.url import ListUrlsQuery
 from schemas.dto.responses.url import (
@@ -63,9 +64,10 @@ router = APIRouter(tags=["Link Management"])
     operation_id="listUrls",
     summary="List Your URLs",
 )
-@limiter.limit(Limits.API_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_AUTHED))
 async def list_urls_v1(
     request: Request,
+    entitlements: Entitled,
     query: Annotated[ListUrlsQuery, Query()],
     url_service: UrlSvc,
     tag_service: TagSvc,
@@ -106,9 +108,10 @@ async def list_urls_v1(
     operation_id="getUrl",
     summary="Get URL by ID",
 )
-@limiter.limit(Limits.API_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_AUTHED))
 async def get_url_v1(
     request: Request,
+    entitlements: Entitled,
     url_id: Annotated[
         str,
         Path(description="Unique identifier of the URL (MongoDB ObjectId)."),
@@ -167,9 +170,10 @@ def _resolve_lookup_domain(raw: str, system_default_domain: str) -> str:
     operation_id="getUrlByAddress",
     summary="Get URL by Domain and Alias",
 )
-@limiter.limit(Limits.API_AUTHED)
+@limiter.limit(plan_scaled(Limits.API_AUTHED))
 async def get_url_by_address_v1(
     request: Request,
+    entitlements: Entitled,
     domain: Annotated[
         str,
         Path(

--- a/routes/api_v1/webhooks.py
+++ b/routes/api_v1/webhooks.py
@@ -25,7 +25,7 @@ from typing import Annotated
 from bson import ObjectId
 from fastapi import APIRouter, Depends, Path, Query, Request
 
-from dependencies import FeatureFlagSvc, WebhookSvc
+from dependencies import Entitled, FeatureFlagSvc, WebhookSvc
 from dependencies.auth import (
     WEBHOOKS_MANAGE_SCOPES,
     WEBHOOKS_READ_SCOPES,
@@ -113,6 +113,7 @@ async def create_endpoint(
     user: ManageUser,
     webhook_service: WebhookSvc,
     flag_svc: FeatureFlagSvc,
+    entitlements: Entitled,
 ) -> WebhookEndpointCreatedResponse:
     """Register an HTTPS endpoint to receive event deliveries.
 
@@ -124,7 +125,7 @@ async def create_endpoint(
 
     **Rate Limits**: 10/hour
     """
-    await flag_svc.require(WEBHOOKS_FLAG, user)
+    await flag_svc.require(WEBHOOKS_FLAG, user, entitlements=entitlements)
     doc, secret = await webhook_service.create_endpoint(
         user.user_id,
         url=body.url,
@@ -132,6 +133,7 @@ async def create_endpoint(
         description=body.description,
         scope_links=body.scope_links,
         flavor=body.flavor,
+        max_endpoints=entitlements.limit("webhook_endpoints_max"),
     )
     base = WebhookEndpointResponse.from_doc(doc)
     return WebhookEndpointCreatedResponse(**base.model_dump(), signing_secret=secret)

--- a/schemas/dto/requests/bulk.py
+++ b/schemas/dto/requests/bulk.py
@@ -26,11 +26,9 @@ from shared.tags import TAGS_MAX_PER_LINK
 from shared.url_utils import normalise_fqdn
 from shared.validators import normalise_object_ids
 
-# Server cap per request. The frontend chunks larger selections and
-# merges the per-chunk reports. Bounded by report ergonomics and the
-# per-day item math in middleware/rate_limiter.py, not by execution
-# cost (the set-based pipeline is ~4 calls regardless of batch size).
-BULK_MAX_IDS = 100
+# Envelope cap = the pro plan's bulk_batch_max; the route enforces the
+# caller's plan cap and the frontend chunks larger selections.
+BULK_MAX_IDS = 1000
 
 _OBJECT_ID_RE = re.compile(r"^[0-9a-f]{24}$")
 

--- a/schemas/dto/responses/public_preview.py
+++ b/schemas/dto/responses/public_preview.py
@@ -53,6 +53,7 @@ class PublicPreviewResponse(ResponseBase):
     generation: Literal["v1", "v2"]
     alias: str
     short_url: str
+    whitelabel: bool = False
     status: Literal["active", "inactive", "expired", "blocked", "scheduled"]
     created_at: str | None
     # Unix seconds; present only while ``status`` is ``"scheduled"``.

--- a/schemas/dto/responses/public_stats.py
+++ b/schemas/dto/responses/public_stats.py
@@ -47,6 +47,8 @@ class PublicStatsResponse(ResponseBase):
     # "v1" — they carry v1-shaped (lifetime-dimension) analytics.
     generation: Literal["v1", "v2"]
     link: PublicLinkFacts
+    # The owner's plan strips the spoo.me chrome from the public page.
+    whitelabel: bool = False
     stats: dict[str, Any] = Field(
         description=(
             "The modern stats wire shape (same as GET /api/v1/stats): "

--- a/schemas/dto/responses/stats.py
+++ b/schemas/dto/responses/stats.py
@@ -38,6 +38,9 @@ class StatsTimeRange(ResponseBase):
 
     start_date: datetime | None = None
     end_date: datetime | None = None
+    # True when start_date was pulled forward to fit the plan's window.
+    clamped: bool = False
+    window_days: int | None = None
 
 
 class ComputedMetrics(ResponseBase):

--- a/schemas/enums/webhook.py
+++ b/schemas/enums/webhook.py
@@ -33,3 +33,5 @@ class EndpointDisabledReason(str, Enum):
     # delivery would fail identically, so the endpoint is disabled loudly.
     SECRET_UNREADABLE = "secret_unreadable"
     ADMIN = "admin"
+    # Newest endpoints beyond the plan's limit; lifted when the limit grows.
+    OVER_LIMIT = "over_limit"

--- a/schemas/models/api_key.py
+++ b/schemas/models/api_key.py
@@ -27,6 +27,8 @@ class ApiKeyDoc(MongoBaseModel):
     expires_at: datetime | None = None
     created_at: datetime | None = None
     revoked: bool = False
+    # Newest keys beyond the plan's limit stop authenticating until it grows.
+    paused_by_limit: bool = False
     # Stamped on successful auth, debounced to at most one write per hour —
     # accurate enough for "is this key still in use", cheap on the hot path.
     last_used_at: datetime | None = None

--- a/schemas/models/custom_domain.py
+++ b/schemas/models/custom_domain.py
@@ -25,6 +25,8 @@ class CustomDomainDoc(MongoBaseModel):
     # actually consumes it.
     verification_token: str | None = None
     is_system_default: bool = False
+    # Newest domains beyond the plan's limit stop serving until it grows.
+    paused_by_limit: bool = False
 
     created_at: datetime
     updated_at: datetime | None = None

--- a/services/api_key_service.py
+++ b/services/api_key_service.py
@@ -11,11 +11,12 @@ from datetime import datetime, timezone
 
 from bson import ObjectId
 
-from errors import EmailNotVerifiedError, ValidationError
+from errors import EmailNotVerifiedError, LimitReachedError
 from infrastructure.crypto import hash_token
 from infrastructure.logging import get_logger
 from repositories.api_key_repository import ApiKeyRepository
 from schemas.models.api_key import ApiKeyDoc
+from services.features.catalog import UNLIMITED
 from shared.generators import generate_secure_token
 
 log = get_logger(__name__)
@@ -25,10 +26,8 @@ class ApiKeyService:
     def __init__(
         self,
         api_key_repo: ApiKeyRepository,
-        max_active_keys: int = 20,
     ) -> None:
         self._repo = api_key_repo
-        self._max_active_keys = max_active_keys
 
     async def create(
         self,
@@ -38,6 +37,8 @@ class ApiKeyService:
         email_verified: bool,
         description: str | None = None,
         expires_at: datetime | None = None,
+        *,
+        max_keys: int,
     ) -> tuple[ApiKeyDoc, str]:
         """Create a new API key.
 
@@ -57,17 +58,18 @@ class ApiKeyService:
             )
             raise EmailNotVerifiedError("Email verification required")
 
-        active_count = await self._repo.count_by_user(user_id)
-        if active_count >= self._max_active_keys:
-            log.info(
-                "api_key_create_rejected",
-                reason="max_limit_reached",
-                user_id=str(user_id),
-                count=active_count,
-            )
-            raise ValidationError(
-                f"maximum {self._max_active_keys} active keys allowed"
-            )
+        if max_keys != UNLIMITED:
+            active_count = await self._repo.count_by_user(user_id)
+            if active_count >= max_keys:
+                log.info(
+                    "api_key_create_rejected",
+                    reason="max_limit_reached",
+                    user_id=str(user_id),
+                    count=active_count,
+                )
+                raise LimitReachedError(
+                    "api_keys_max", max_=max_keys, current=active_count
+                )
 
         raw = generate_secure_token()
         token_prefix = raw[:8]

--- a/services/custom_domain_service.py
+++ b/services/custom_domain_service.py
@@ -20,6 +20,7 @@ from errors import (
     FeatureDisabledError,
     ForbiddenError,
     InvalidDomainTransitionError,
+    LimitReachedError,
     NotFoundError,
 )
 from infrastructure.logging import get_logger
@@ -34,6 +35,7 @@ from schemas.enums.domain_status import DomainStatus, VerificationMethod
 from schemas.models.custom_domain import LEGAL_TRANSITIONS, CustomDomainDoc
 from services.dns_preflight import check_cname, uses_cloudflare_dns
 from services.edge_provisioner.protocol import EdgeProvisioner
+from services.features.catalog import UNLIMITED
 from services.registrar.protocol import HostnameRegistrar
 from services.tenant_resolver.protocol import TenantResolver
 from services.verifiers.protocol import DomainVerifier, VerificationResult
@@ -86,13 +88,18 @@ class CustomDomainService:
         self,
         request: CreateCustomDomainRequest,
         user: CurrentUser,
+        *,
+        max_domains: int,
     ) -> CustomDomainDoc:
-        """Register a new custom domain. Doc is born in PENDING state."""
+        """Register a new custom domain. Doc is born in PENDING state.
+
+        ``max_domains`` is the caller's plan limit; ``-1`` means unlimited.
+        """
         self._require_enabled()
 
         await self._enforce_blocklist(request.fqdn)
         await self._enforce_uniqueness(request.fqdn)
-        await self._enforce_per_user_quota(user.user_id)
+        await self._enforce_per_user_quota(user.user_id, max_domains)
 
         method = self._pick_verification_method(request.fqdn)
         if method not in self._verifiers:
@@ -692,15 +699,15 @@ class CustomDomainService:
                 f"{fqdn} is registered to another account."
             )
 
-    async def _enforce_per_user_quota(self, owner_id: ObjectId) -> None:
+    async def _enforce_per_user_quota(
+        self, owner_id: ObjectId, max_domains: int
+    ) -> None:
+        if max_domains == UNLIMITED:
+            return
         current = await self._repo.count_by_owner(owner_id)
-        if current >= self._settings.max_per_user:
-            cap = self._settings.max_per_user
-            suffix = "domain" if cap == 1 else "domains"
-            raise DomainQuotaExceededError(
-                f"You already have {cap} custom {suffix} on this account. "
-                f"Remove a revoked one, or revoke an active one and then "
-                f"remove it, before adding another."
+        if current >= max_domains:
+            raise LimitReachedError(
+                "custom_domains_max", max_=max_domains, current=current
             )
 
     async def _enforce_verify_attempts_quota(self, domain_id: ObjectId) -> None:

--- a/services/entitlements/lapse.py
+++ b/services/entitlements/lapse.py
@@ -1,0 +1,34 @@
+"""
+Lapse policies on the redirect path: what a cached link does once its owner
+no longer holds a feature.
+
+Pure: takes the link as the cache would serve it and the owner's resolved
+entitlements, returns the link as the redirect must behave. Stored data is
+never touched; a re-subscribe re-resolves from the document and the rules
+come back.
+"""
+
+from __future__ import annotations
+
+from infrastructure.cache.url_cache import UrlCacheData
+from services.entitlements.resolver import Resolved
+
+
+def apply_lapse_policies(data: UrlCacheData, resolved: Resolved) -> UrlCacheData:
+    changes: dict = {"owner_ent_version": resolved.version}
+    if data.geo_rules and not resolved.has("geo_targeting"):
+        changes["geo_rules"] = None
+    if data.ab_variants and not resolved.has("ab_variants"):
+        changes["ab_variants"] = None
+    if data.expired_redirect_url and not resolved.has("expired_fallback"):
+        changes["expired_redirect_url"] = None
+    if data.meta_title is not None and not resolved.has("custom_meta_tags"):
+        changes.update(
+            meta_title=None,
+            meta_description=None,
+            meta_image=None,
+            meta_color=None,
+            meta_image_width=None,
+            meta_image_height=None,
+        )
+    return data.model_copy(update=changes)

--- a/services/entitlements/over_limit.py
+++ b/services/entitlements/over_limit.py
@@ -1,0 +1,158 @@
+"""
+Over-limit pausing: when a plan's count limit shrinks below what an owner
+already has, the newest items pause and the oldest keep working.
+
+Every countable limit with a ``pause_newest`` policy is reconciled the same
+way: sort the owner's items oldest first, keep the first ``max``, pause the
+rest, and unpause anything this policy paused earlier that now fits. The
+pause is stored on the item itself (so the redirect path, the webhook matcher
+and API key auth each read one flag) and surfaced as ``over_limit`` in
+``/me/entitlements``. Nothing is deleted.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+from bson import ObjectId
+
+from infrastructure.logging import get_logger
+from repositories.api_key_repository import ApiKeyRepository
+from repositories.custom_domain_repository import CustomDomainRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from schemas.enums.webhook import EndpointDisabledReason, WebhookStatus
+from services.entitlements.resolver import Resolved
+from services.features.catalog import UNLIMITED
+from services.tenant_resolver.protocol import TenantResolver
+
+log = get_logger(__name__)
+
+
+class _OwnerCache(Protocol):
+    async def invalidate(self, owner_id: str) -> None: ...
+
+
+def split_newest(
+    items: list[tuple[ObjectId, datetime | None]], limit: int
+) -> tuple[list[ObjectId], list[ObjectId]]:
+    """(keep, pause): oldest ``limit`` items keep working, the rest pause."""
+    ordered = sorted(items, key=lambda it: (it[1] is None, it[1] or 0, str(it[0])))
+    ids = [oid for oid, _ in ordered]
+    if limit == UNLIMITED or limit >= len(ids):
+        return ids, []
+    return ids[:limit], ids[limit:]
+
+
+class OverLimitService:
+    def __init__(
+        self,
+        *,
+        endpoints: WebhookEndpointRepository,
+        domains: CustomDomainRepository,
+        keys: ApiKeyRepository,
+        tenant_resolver: TenantResolver,
+        webhook_owner_cache: _OwnerCache,
+    ) -> None:
+        self._endpoints = endpoints
+        self._domains = domains
+        self._keys = keys
+        self._tenants = tenant_resolver
+        self._webhook_owner_cache = webhook_owner_cache
+
+    async def apply(
+        self, user_id: ObjectId, resolved: Resolved
+    ) -> dict[str, list[str]]:
+        """Pause and unpause the owner's items to fit ``resolved``. Returns
+        the ids paused per limit key (empty when everything fits)."""
+        paused = {
+            "webhook_endpoints_max": await self._apply_endpoints(
+                user_id, resolved.limit("webhook_endpoints_max")
+            ),
+            "custom_domains_max": await self._apply_domains(
+                user_id,
+                resolved.limit("custom_domains_max")
+                if resolved.has("custom_domains")
+                else 0,
+            ),
+            "api_keys_max": await self._apply_keys(
+                user_id, resolved.limit("api_keys_max")
+            ),
+        }
+        result = {k: [str(i) for i in v] for k, v in paused.items() if v}
+        if result:
+            log.info("over_limit_applied", user_id=str(user_id), paused=result)
+        return result
+
+    async def paused(self, user_id: ObjectId) -> dict[str, list[str]]:
+        """Ids currently paused by this policy, per limit key."""
+        endpoints = [
+            str(e.id)
+            for e in await self._endpoints.find_by_user(user_id)
+            if e.disabled_reason is EndpointDisabledReason.OVER_LIMIT
+        ]
+        domains = [
+            str(d.id)
+            for d in await self._domains.list_live_by_owner(user_id)
+            if d.paused_by_limit
+        ]
+        keys = [
+            str(k.id)
+            for k in await self._keys.list_by_user(user_id)
+            if k.paused_by_limit
+        ]
+        out = {
+            "webhook_endpoints_max": endpoints,
+            "custom_domains_max": domains,
+            "api_keys_max": keys,
+        }
+        return {k: v for k, v in out.items() if v}
+
+    async def _apply_endpoints(self, user_id: ObjectId, limit: int) -> list[ObjectId]:
+        docs = await self._endpoints.find_by_user(user_id)
+        keep, pause = split_newest([(d.id, d.created_at) for d in docs], limit)
+        by_id = {d.id: d for d in docs}
+        changed = False
+        for oid in pause:
+            doc = by_id[oid]
+            if doc.status is not WebhookStatus.DISABLED:
+                await self._endpoints.disable(oid, EndpointDisabledReason.OVER_LIMIT)
+                changed = True
+        for oid in keep:
+            if by_id[oid].disabled_reason is EndpointDisabledReason.OVER_LIMIT:
+                await self._endpoints.reactivate_over_limit(oid)
+                changed = True
+        if changed:
+            await self._webhook_owner_cache.invalidate(str(user_id))
+        return [
+            oid
+            for oid in pause
+            if by_id[oid].status is not WebhookStatus.DISABLED
+            or by_id[oid].disabled_reason is EndpointDisabledReason.OVER_LIMIT
+        ]
+
+    async def _apply_domains(self, user_id: ObjectId, limit: int) -> list[ObjectId]:
+        docs = await self._domains.list_live_by_owner(user_id)
+        keep, pause = split_newest([(d.id, d.created_at) for d in docs], limit)
+        by_id = {d.id: d for d in docs}
+        to_pause = [oid for oid in pause if not by_id[oid].paused_by_limit]
+        to_unpause = [oid for oid in keep if by_id[oid].paused_by_limit]
+        if to_pause:
+            await self._domains.set_paused_by_limit(to_pause, True)
+        if to_unpause:
+            await self._domains.set_paused_by_limit(to_unpause, False)
+        for oid in to_pause + to_unpause:
+            await self._tenants.invalidate(by_id[oid].fqdn)
+        return pause
+
+    async def _apply_keys(self, user_id: ObjectId, limit: int) -> list[ObjectId]:
+        docs = [k for k in await self._keys.list_by_user(user_id) if not k.revoked]
+        keep, pause = split_newest([(d.id, d.created_at) for d in docs], limit)
+        by_id = {d.id: d for d in docs}
+        to_pause = [oid for oid in pause if not by_id[oid].paused_by_limit]
+        to_unpause = [oid for oid in keep if by_id[oid].paused_by_limit]
+        if to_pause:
+            await self._keys.set_paused_by_limit(to_pause, True)
+        if to_unpause:
+            await self._keys.set_paused_by_limit(to_unpause, False)
+        return pause

--- a/services/entitlements/service.py
+++ b/services/entitlements/service.py
@@ -24,6 +24,7 @@ from repositories.entitlement_override_repository import (
 )
 from repositories.subscription_repository import SubscriptionRepository
 from schemas.models.subscription import SubscriptionDoc, SubscriptionStatus
+from services.entitlements.over_limit import OverLimitService
 from services.entitlements.resolver import ANONYMOUS, Resolved, for_plan, resolve
 from services.entitlements.state_machine import SubscriptionEvent, next_status
 from services.features.catalog import Plan
@@ -43,6 +44,7 @@ class EntitlementService:
         *,
         selfhost: bool,
         usage: dict[str, UsageCounter] | None = None,
+        over_limit: OverLimitService | None = None,
     ) -> None:
         self._subs = subscriptions
         self._overrides = overrides
@@ -50,6 +52,7 @@ class EntitlementService:
         self._cache = cache
         self._selfhost = selfhost
         self._usage = usage or {}
+        self._over_limit = over_limit
 
     @property
     def selfhost(self) -> bool:
@@ -128,6 +131,17 @@ class EntitlementService:
             out[key] = await counter(user_id)
         return out
 
+    async def over_limit_for(self, user_id: ObjectId) -> dict[str, list[str]]:
+        if self._over_limit is None:
+            return {}
+        return await self._over_limit.paused(user_id)
+
+    async def reconcile_over_limit(self, user_id: ObjectId) -> dict[str, list[str]]:
+        """Pause or unpause the owner's items to fit what they hold now."""
+        if self._over_limit is None:
+            return {}
+        return await self._over_limit.apply(user_id, await self.resolve_for(user_id))
+
     # ── Write ────────────────────────────────────────────────────────────
 
     async def transition(
@@ -150,7 +164,7 @@ class EntitlementService:
         after_status = next_status(before.status if before else None, event)
         if after_status is SubscriptionStatus.GRACE and "grace_until" not in fields:
             raise ValueError("a transition to grace needs grace_until")
-        return await self._subs.write_transition(
+        after = await self._subs.write_transition(
             user_id,
             before=before,
             after_status=after_status,
@@ -159,3 +173,14 @@ class EntitlementService:
             reason=reason,
             now=now,
         )
+        before_plan = before.effective_plan if before else Plan.FREE
+        if after.effective_plan != before_plan:
+            # The transition is already durable; a failed pause is retried by
+            # the lifecycle tick, not by failing the caller.
+            try:
+                await self.reconcile_over_limit(user_id)
+            except Exception as e:
+                log.error(
+                    "over_limit_reconcile_failed", user_id=str(user_id), error=str(e)
+                )
+        return after

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 
 from bson import ObjectId
 
-from errors import ForbiddenError, NotFoundError
+from errors import ForbiddenError, NotFoundError, PlanRequiredError
 from infrastructure.cache.feature_flag_cache import (
     NEGATIVE_MISS,
     FeatureFlagCache,
@@ -59,6 +59,7 @@ log = get_logger(__name__)
 # Catalog keys referenced by routes. Code names features through these,
 # never through bare string literals at call sites.
 CUSTOM_DOMAINS_FLAG = "custom_domains"
+DOMAIN_POLISH_FLAG = "domain_polish"
 GEO_TARGETING_FLAG = "geo_targeting"
 META_TAGS_FLAG = "custom_meta_tags"
 AB_TESTING_FLAG = "ab_variants"
@@ -104,6 +105,19 @@ class FeatureFlagService:
 
         Default-deny on any error or unknown key.
         """
+        if user is None:
+            return await self._rolled_out(key, None, None)
+        return await self._rolled_out(key, user.user_id, _email_of(user))
+
+    async def is_enabled_for_owner(self, key: str, owner_id: ObjectId) -> bool:
+        """``is_enabled`` for a link owner known only by id (public pages).
+        Allowlist this feature by user id, not email, or the pages disagree
+        with the owner's dashboard."""
+        return await self._rolled_out(key, owner_id, None)
+
+    async def _rolled_out(
+        self, key: str, user_id: ObjectId | None, email: str | None
+    ) -> bool:
         feature = FEATURES.get(key)
         if feature is None:
             log.warning("feature_flag_unknown_key", key=key)
@@ -124,17 +138,17 @@ class FeatureFlagService:
 
         # All non-EVERYONE rollouts require an authenticated user — anonymous
         # callers get default-deny.
-        if user is None:
+        if user_id is None:
             return False
 
         if rollout == RolloutType.ALLOWLIST:
-            return flag.is_user_in_allowlist(user.user_id, _email_of(user))
+            return flag.is_user_in_allowlist(user_id, email)
 
         if rollout == RolloutType.PERCENTAGE:
-            return _stable_hash(user.user_id, salt=flag.name) < flag.percentage
+            return _stable_hash(user_id, salt=flag.name) < flag.percentage
 
         if rollout == RolloutType.HEX_DIGIT:
-            return _digit_bucket(user.user_id, salt=flag.name) in flag.enabled_digits
+            return _digit_bucket(user_id, salt=flag.name) in flag.enabled_digits
 
         # Unreachable today — Pydantic validates rollout_type against the
         # RolloutType enum. Kept as default-deny if the field is ever widened.
@@ -169,22 +183,31 @@ class FeatureFlagService:
         return states
 
     async def require(
-        self, key: str, user: CurrentUser | None, *, hide: bool = False
+        self,
+        key: str,
+        user: CurrentUser | None,
+        *,
+        entitlements: Resolved | None = None,
+        hide: bool = False,
     ) -> None:
-        """Raise unless ``key`` is rolled out to ``user``.
+        """Raise unless ``key`` is rolled out to ``user`` and, when
+        ``entitlements`` is given, included in their plan.
 
-        403 by default — the right signal for flag-gated FIELDS on shared
-        endpoints, which appear in public OpenAPI docs and can't be
-        concealed. Pass ``hide=True`` for whole-endpoint features whose
-        existence is itself gated (the custom-domains pattern): 404, so
-        non-allowlisted callers can't tell the feature exists.
+        Flag off answers 403 by default — the right signal for flag-gated
+        FIELDS on shared endpoints, which appear in public OpenAPI docs and
+        can't be concealed. Pass ``hide=True`` for whole-endpoint features
+        whose existence is itself gated (the custom-domains pattern): 404,
+        so non-allowlisted callers can't tell the feature exists. Flag on
+        but plan without the feature answers 403 ``plan_required``, never
+        404: the LOCKED state already told the client the feature exists.
         """
-        if await self.is_enabled(key, user):
-            return
-        if hide:
-            raise NotFoundError("not found")
-        feature = key.replace("_", " ").capitalize()
-        raise ForbiddenError(f"{feature} is not enabled for this account")
+        if not await self.is_enabled(key, user):
+            if hide:
+                raise NotFoundError("not found")
+            feature = key.replace("_", " ").capitalize()
+            raise ForbiddenError(f"{feature} is not enabled for this account")
+        if entitlements is not None and not entitlements.has(key):
+            raise PlanRequiredError(key)
 
     async def _lookup(self, name: str) -> FeatureFlagDoc | None:
         """Fetch a flag through cache → repo, returning None for unregistered."""

--- a/services/features/catalog.py
+++ b/services/features/catalog.py
@@ -94,6 +94,7 @@ def _int(
 
 _ENTRIES: tuple[Feature, ...] = (
     _bool("geo_targeting", rollout="geo_targeting", free=False, lapse=Lapse.DISABLE),
+    # Edge KV keeps an already-written card for up to its TTL after a lapse.
     _bool(
         "custom_meta_tags", rollout="custom_meta_tags", free=False, lapse=Lapse.DISABLE
     ),

--- a/services/public_preview_service.py
+++ b/services/public_preview_service.py
@@ -29,6 +29,9 @@ from schemas.dto.responses.public_preview import (
     PreviewVariantDestination,
     PublicPreviewResponse,
 )
+from schemas.models.base import ANONYMOUS_OWNER_ID
+from services.entitlements import EntitlementService
+from services.feature_flag_service import DOMAIN_POLISH_FLAG, FeatureFlagService
 from services.public_link_resolver import PublicLinkResolver, ResolvedPublicLink
 from shared.datetime_utils import to_unix_timestamp
 from shared.url_utils import split_destination
@@ -39,8 +42,15 @@ log = get_logger(__name__)
 class PublicPreviewService:
     """Derivation of the public link preview wire over the shared resolver."""
 
-    def __init__(self, resolver: PublicLinkResolver) -> None:
+    def __init__(
+        self,
+        resolver: PublicLinkResolver,
+        entitlements: EntitlementService,
+        flags: FeatureFlagService,
+    ) -> None:
         self._resolver = resolver
+        self._entitlements = entitlements
+        self._flags = flags
 
     # ── Public API ────────────────────────────────────────────────────────
 
@@ -54,9 +64,15 @@ class PublicPreviewService:
         if link is None:
             log.info("public_preview_not_found", short_code=short_code)
             raise NotFoundError("short_code not found")
-        if link.is_v2:
-            return self._v2_preview(link)
-        return self._v1_preview(link)
+        preview = self._v2_preview(link) if link.is_v2 else self._v1_preview(link)
+        owner = link.v2_doc.owner_id if link.is_v2 else None
+        if not owner or owner == ANONYMOUS_OWNER_ID:
+            return preview
+        plan = await self._entitlements.resolve_for(owner)
+        whitelabel = plan.has(
+            "domain_polish"
+        ) and await self._flags.is_enabled_for_owner(DOMAIN_POLISH_FLAG, owner)
+        return preview.model_copy(update={"whitelabel": whitelabel})
 
     # ── v2 derivation ─────────────────────────────────────────────────────
 

--- a/services/public_stats_service.py
+++ b/services/public_stats_service.py
@@ -31,7 +31,7 @@ this service never writes.
 from __future__ import annotations
 
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 from bson import ObjectId
@@ -40,16 +40,18 @@ from errors import (
     InvalidPasswordError,
     NotFoundError,
     PasswordRequiredError,
-    ValidationError,
 )
 from infrastructure.crypto import verify_password
 from infrastructure.logging import get_logger
 from schemas.enums.stats import StatsScope
+from schemas.models.base import ANONYMOUS_OWNER_ID
 from schemas.models.url import LegacyUrlDoc, UrlV2Doc
+from services.entitlements import EntitlementService
+from services.feature_flag_service import DOMAIN_POLISH_FLAG, FeatureFlagService
+from services.features.catalog import Plan, plan_defaults
 from services.public_link_resolver import PublicLinkResolver, ResolvedPublicLink
 from services.stats_service import StatsService
 from shared.aggregation_strategies import convert_country_name
-from shared.datetime_utils import parse_datetime
 
 log = get_logger(__name__)
 
@@ -74,19 +76,21 @@ class PublicStatsService:
         resolver:            The shared public-link resolver (resolution,
                              raw v1 reads, derived status, created_at).
         stats_service:       The shared StatsService (v2 aggregation reuse).
-        max_date_range_days: Maximum allowed date range in days.
+        entitlements:        Resolves the owner's plan: the analytics window
+                             the page may show and whether it is whitelabel.
     """
 
     def __init__(
         self,
         resolver: PublicLinkResolver,
         stats_service: StatsService,
-        *,
-        max_date_range_days: int = 90,
+        entitlements: EntitlementService,
+        flags: FeatureFlagService,
     ) -> None:
         self._resolver = resolver
         self._stats = stats_service
-        self._max_date_range_days = max_date_range_days
+        self._entitlements = entitlements
+        self._flags = flags
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -168,15 +172,33 @@ class PublicStatsService:
                 )
                 raise InvalidPasswordError("incorrect password")
 
-        window_start, window_end, tz_name = self._resolve_window(
-            start_date, end_date, tz_name
+        owner = doc.owner_id if is_v2 else None
+        if not owner or owner == ANONYMOUS_OWNER_ID:
+            owner = None
+        plan = await self._entitlements.resolve_for(owner)
+        whitelabel = bool(owner) and plan.has("domain_polish")
+        if whitelabel:
+            whitelabel = await self._flags.is_enabled_for_owner(
+                DOMAIN_POLISH_FLAG, owner
+            )
+        # Only the owner gets the plan's window; a public visitor's facet
+        # stays sized for the anonymous rate budget.
+        window_days = (
+            plan.limit("analytics_window_days")
+            if is_owner
+            else plan_defaults(Plan.FREE)["analytics_window_days"]
+        )
+        window_start, window_end, tz_name, clamped = self._resolve_window(
+            start_date, end_date, tz_name, window_days
         )
 
         status = link.effective_status()
         facts = self._link_facts(link, doc, status, is_owner=is_owner)
 
         if is_v2:
-            stats = await self._query_v2_stats(doc, window_start, window_end, tz_name)
+            stats = await self._query_v2_stats(
+                doc, window_start, window_end, tz_name, clamped=clamped
+            )
         else:
             stats = self._synthesize_v1_stats(
                 doc, link.alias, window_start, window_end, tz_name
@@ -195,7 +217,12 @@ class PublicStatsService:
             duration_ms=duration_ms,
         )
 
-        return {"generation": link.generation, "link": facts, "stats": stats}
+        return {
+            "generation": link.generation,
+            "link": facts,
+            "stats": stats,
+            "whitelabel": whitelabel,
+        }
 
     # ── Private: gates and derived facts ──────────────────────────────────────
 
@@ -242,37 +269,13 @@ class PublicStatsService:
         start_raw: str | None,
         end_raw: str | None,
         tz_name: str,
-    ) -> tuple[datetime, datetime, str]:
-        """Defaults and validation mirroring StatsService.query."""
-        start = parse_datetime(start_raw) if start_raw else None
-        if start_raw and start is None:
-            raise ValidationError("invalid start_date format")
-        end = parse_datetime(end_raw) if end_raw else None
-        if end_raw and end is None:
-            raise ValidationError("invalid end_date format")
-
-        now = datetime.now(timezone.utc)
-        if start is None and end is None:
-            end = now
-            start = now - timedelta(days=7)
-        elif start is None:
-            start = end - timedelta(days=7)
-        elif end is None:
-            end = now
-
-        if start > now:
-            start = now
-        if end > now:
-            end = now
-
-        if start > end:
-            raise ValidationError("start_date must be before end_date")
-        if (end - start).days > self._max_date_range_days:
-            raise ValidationError(
-                f"date range cannot exceed {self._max_date_range_days} days"
-            )
-
-        return start, end, self._stats.normalize_timezone(tz_name)
+        window_days: int,
+    ) -> tuple[datetime, datetime, str, bool]:
+        """The dashboard's window rules, then the normalized timezone."""
+        start, end, clamped = self._stats.resolve_window(
+            start_raw, end_raw, window_days
+        )
+        return start, end, self._stats.normalize_timezone(tz_name), clamped
 
     # ── Private: v2 stats (StatsService reuse, scoped by url_id) ─────────────
 
@@ -282,6 +285,8 @@ class PublicStatsService:
         start_date: datetime,
         end_date: datetime,
         tz_name: str,
+        *,
+        clamped: bool = False,
     ) -> dict[str, Any]:
         """Run the standard $facet aggregation scoped by ``meta.url_id``.
 
@@ -301,6 +306,7 @@ class PublicStatsService:
             group_by=_V2_GROUP_BY,
             metrics=_METRICS,
             tz_name=tz_name,
+            clamped=clamped,
         )
 
     # ── Private: v1/emoji stats (synthesized from the embedded doc) ──────────

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -41,6 +41,7 @@ from schemas.enums.stats import (
     StatsScope,
 )
 from schemas.models.url import UrlV2Doc
+from services.features.catalog import UNLIMITED
 from shared.aggregation_strategies import AggregationStrategyFactory
 from shared.datetime_utils import parse_datetime
 
@@ -102,17 +103,14 @@ class StatsService:
     Args:
         click_repo:         Repository for the ``clicks`` time-series collection.
         url_repo:           Repository for the ``urlsV2`` collection (claimed ids).
-        max_date_range_days: Maximum allowed date range in days (default 90).
     """
 
     def __init__(
         self,
         click_repo: ClickRepository,
         url_repo: UrlRepository,
-        max_date_range_days: int = 90,
         tag_service: TagService | None = None,
     ) -> None:
-        self._max_date_range_days = max_date_range_days
         self._click_repo = click_repo
         self._url_repo = url_repo
         self._tag_service = tag_service
@@ -157,15 +155,18 @@ class StatsService:
 
     # ── Private: date window ──────────────────────────────────────────────────
 
-    def _resolve_window(
+    def resolve_window(
         self,
         start_raw: str | None,
         end_raw: str | None,
-    ) -> tuple[datetime, datetime]:
-        """Parse, default, cap, and validate the date window.
+        window_days: int,
+    ) -> tuple[datetime, datetime, bool]:
+        """Parse, default, cap, and clamp the date window.
 
-        Shared by ``query()`` and ``query_link()``; mirrored by
-        PublicStatsService._resolve_window — the three must not drift.
+        ``window_days`` is the caller's plan retention window (``-1`` means
+        unlimited). A range reaching further back is clamped to the window
+        and the third value says so, so the response can name it. Shared by
+        ``query()``, ``query_link()`` and the public stats page.
         """
         start_date = parse_datetime(start_raw) if start_raw else None
         if start_raw and start_date is None:
@@ -191,12 +192,14 @@ class StatsService:
 
         if start_date > end_date:
             raise ValidationError("start_date must be before end_date")
-        if (end_date - start_date).days > self._max_date_range_days:
-            raise ValidationError(
-                f"date range cannot exceed {self._max_date_range_days} days"
-            )
+        clamped = False
+        if window_days != UNLIMITED and end_date - start_date > timedelta(
+            days=window_days
+        ):
+            start_date = end_date - timedelta(days=window_days)
+            clamped = True
 
-        return start_date, end_date
+        return start_date, end_date, clamped
 
     # ── Private: query building ───────────────────────────────────────────────
 
@@ -471,6 +474,8 @@ class StatsService:
         metrics: list[str],
         tz_name: str,
         aggregation_results: dict[str, list[dict[str, Any]]],
+        clamped: bool = False,
+        window_days: int | None = None,
     ) -> dict[str, Any]:
         """Format aggregation results into the API response structure.
 
@@ -490,6 +495,8 @@ class StatsService:
         response["time_range"] = {
             "start_date": self._fmt_tz(start_date, tz_name),
             "end_date": self._fmt_tz(end_date, tz_name),
+            "clamped": clamped,
+            "window_days": window_days,
         }
 
         # Add time bucket info when time aggregation is requested
@@ -596,6 +603,8 @@ class StatsService:
         metrics: list[str],
         tz_name: str,
         filters: dict[str, list[str]] | None = None,
+        clamped: bool = False,
+        window_days: int | None = None,
     ) -> dict[str, Any]:
         """Run a pre-built clicks ``$match`` and format the standard wire.
 
@@ -622,6 +631,8 @@ class StatsService:
             metrics,
             tz_name,
             aggregation_results,
+            clamped=clamped,
+            window_days=window_days,
         )
         response["summary"] = summary
         return self.add_metadata(response)
@@ -630,6 +641,8 @@ class StatsService:
         self,
         query: StatsQuery,
         owner_id: str | None,
+        *,
+        window_days: int,
     ) -> dict[str, Any]:
         """Execute an account-scoped stats query and return the enhanced response.
 
@@ -652,7 +665,9 @@ class StatsService:
 
         start_time = time.perf_counter()
 
-        start_date, end_date = self._resolve_window(query.start_date, query.end_date)
+        start_date, end_date, clamped = self.resolve_window(
+            query.start_date, query.end_date, window_days
+        )
         tz_name = self.normalize_timezone(query.timezone)
 
         if owner_id is None:
@@ -682,6 +697,8 @@ class StatsService:
             metrics=metrics,
             tz_name=tz_name,
             filters=filters,
+            clamped=clamped,
+            window_days=window_days,
         )
         summary = response.get("summary", {})
 
@@ -704,6 +721,8 @@ class StatsService:
         self,
         query: LinkStatsQuery,
         url: UrlV2Doc,
+        *,
+        window_days: int,
     ) -> dict[str, Any]:
         """Execute a per-link stats query for an already-resolved owned URL.
 
@@ -731,7 +750,9 @@ class StatsService:
 
         start_time = time.perf_counter()
 
-        start_date, end_date = self._resolve_window(query.start_date, query.end_date)
+        start_date, end_date, clamped = self.resolve_window(
+            query.start_date, query.end_date, window_days
+        )
         tz_name = self.normalize_timezone(query.timezone)
 
         click_query: dict[str, Any] = {
@@ -752,6 +773,8 @@ class StatsService:
             metrics=metrics,
             tz_name=tz_name,
             filters=filters,
+            clamped=clamped,
+            window_days=window_days,
         )
         response["url_id"] = str(url.id)
         response["alias"] = url.alias

--- a/services/url_service.py
+++ b/services/url_service.py
@@ -56,6 +56,8 @@ from schemas.dto.requests.url import (
 )
 from services.edge_cache.contract import cache_key
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
+from services.entitlements.lapse import apply_lapse_policies
+from services.entitlements.service import EntitlementService
 from services.events.contract import DomainEvent
 from services.events.protocol import DomainEventSink
 from services.events.sinks import NullDomainEventSink
@@ -111,6 +113,8 @@ from shared.validators import (
     validate_alias,
     validate_blocked_url,
 )
+
+_ANONYMOUS_OWNER = str(ANONYMOUS_OWNER_ID)
 
 log = get_logger(__name__)
 
@@ -579,7 +583,9 @@ class UrlService:
         events: DomainEventSink | None = None,
         user_repo: UserRepository | None = None,
         tag_service: TagService | None = None,
+        entitlements: EntitlementService | None = None,
     ) -> None:
+        self._entitlements = entitlements
         self._url_repo = url_repo
         self._legacy_repo = legacy_repo
         self._emoji_repo = emoji_repo
@@ -662,6 +668,9 @@ class UrlService:
         # 1. Cache hit
         cached = await self._url_cache.get(short_code, scope)
         if cached is not None:
+            cached = await self._with_owner_policies(
+                cached, short_code, scope, from_cache=True
+            )
             schema = cached.schema_version
             # BLOCKED raises on every schema (v1/emoji carry the safety
             # flag); EXPIRED/INACTIVE only exist on v2.
@@ -700,6 +709,9 @@ class UrlService:
         if url_cache_data is None:
             log.info("url_resolve_not_found", short_code=short_code, domain=scope)
             raise NotFoundError("URL not found")
+        url_cache_data = await self._with_owner_policies(
+            url_cache_data, short_code, scope, from_cache=False
+        )
 
         # 3. Populate cache according to caching rules
         await self._populate_cache(short_code, url_cache_data, schema)
@@ -740,6 +752,45 @@ class UrlService:
         _raise_if_not_yet_live(url_cache_data, short_code, "db")
 
         return url_cache_data, schema
+
+    async def _with_owner_policies(
+        self,
+        data: UrlCacheData,
+        short_code: str,
+        scope: str,
+        *,
+        from_cache: bool,
+    ) -> UrlCacheData:
+        """Shape an owned v2 link by its owner's current entitlements.
+
+        A cache entry carries the owner version it was shaped under; on a
+        match it is served as-is (one Redis GET for the owner map). On a
+        mismatch the document is re-read, the lapse policies applied, and
+        the entry rewritten. When the resolver is degraded the entry is
+        served as-is: the last known behaviour beats a guess.
+        """
+        if (
+            self._entitlements is None
+            or data.schema_version != SchemaVersion.V2
+            or not data.owner_id
+            or data.owner_id == _ANONYMOUS_OWNER
+        ):
+            return data
+        resolved = await self._entitlements.resolve_for(ObjectId(data.owner_id))
+        if resolved.degraded:
+            log.warning("entitlements_degraded", path="redirect", short_code=short_code)
+            return data
+        if from_cache:
+            if data.owner_ent_version == resolved.version:
+                return data
+            doc = await self._url_repo.find_by_alias(short_code, scope)
+            if doc is None:
+                return data
+            data = UrlCacheData.from_v2_doc(doc)
+        shaped = apply_lapse_policies(data, resolved)
+        if from_cache:
+            await self._url_cache.set(short_code, shaped)
+        return shaped
 
     async def _raise_if_time_expired(
         self, data: UrlCacheData, schema: SchemaVersion, short_code: str, source: str

--- a/services/webhooks/service.py
+++ b/services/webhooks/service.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from bson import ObjectId
 
-from errors import NotFoundError, ValidationError
+from errors import LimitReachedError, NotFoundError, ValidationError
 from infrastructure.crypto import decrypt_secret, encrypt_secret
 from infrastructure.logging import get_logger
 from infrastructure.safe_fetch import FetchHardError, validate_public_https_url
@@ -27,6 +27,7 @@ from schemas.models.webhook import (
     WebhookScope,
 )
 from services.events.contract import DomainEvent
+from services.features.catalog import UNLIMITED
 from services.webhooks.executor import SECRET_ENC_DOMAIN, DeliveryExecutor
 from services.webhooks.matcher import OwnerSubscriptionCache
 from services.webhooks.registry import (
@@ -54,7 +55,6 @@ class WebhookService:
         owner_cache: OwnerSubscriptionCache,
         *,
         master_secret: str,
-        max_endpoints: int = 5,
     ) -> None:
         self._endpoints = endpoint_repo
         self._deliveries = delivery_repo
@@ -62,7 +62,6 @@ class WebhookService:
         self._executor = executor
         self._cache = owner_cache
         self._master_secret = master_secret
-        self._max_endpoints = max_endpoints
 
     # ── CRUD ─────────────────────────────────────────────────────────────
 
@@ -75,15 +74,21 @@ class WebhookService:
         description: str | None,
         scope_links: list[str] | None,
         flavor: WebhookFlavor,
+        max_endpoints: int,
     ) -> tuple[WebhookEndpointDoc, str]:
-        """Returns (doc, raw signing secret). The secret's only appearance."""
+        """Returns (doc, raw signing secret). The secret's only appearance.
+
+        ``max_endpoints`` is the owner's plan limit (``-1`` unlimited); every
+        endpoint counts, paused and disabled ones included.
+        """
         await self._validate_url(url)
         validate_patterns(events)
-        if await self._endpoints.count_by_user(user_id) >= self._max_endpoints:
-            raise ValidationError(
-                f"Endpoint limit reached ({self._max_endpoints}). "
-                "Delete an endpoint to add a new one."
-            )
+        if max_endpoints != UNLIMITED:
+            current = await self._endpoints.count_by_user(user_id)
+            if current >= max_endpoints:
+                raise LimitReachedError(
+                    "webhook_endpoints_max", max_=max_endpoints, current=current
+                )
 
         secret = generate_signing_secret()
         now = datetime.now(timezone.utc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ def build_test_app(
         )
         app.state.entitlement_service.usage_for = AsyncMock(return_value={})
         app.state.entitlement_service.plan_hint_for = AsyncMock(return_value="free")
+        app.state.entitlement_service.over_limit_for = AsyncMock(return_value={})
         app.state.tenant_resolver = AsyncMock()
         # A REAL permissive L0 gate (no providers): valid URLs pass,
         # invalid/self-links reject — matches the pre-gate route behavior.
@@ -126,6 +127,16 @@ def build_test_app(
     # Set outside the lifespan — some tests build TestClient without a `with`
     # block (no lifespan run) and the redirect route always resolves GeoIP.
     application.state.geoip = AsyncMock()
+    # Same reason for these three: the Entitled dependency and the auth
+    # dependency read them on every request, lifespan or not.
+    application.state.db = MagicMock()
+    application.state.settings = settings
+    application.state.entitlement_service = AsyncMock()
+    application.state.entitlement_service.resolve_for = AsyncMock(
+        return_value=for_plan(Plan.FREE)
+    )
+    application.state.entitlement_service.usage_for = AsyncMock(return_value={})
+    application.state.entitlement_service.over_limit_for = AsyncMock(return_value={})
     application.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     register_error_handlers(application)
 

--- a/tests/integration/api_v1/test_bulk.py
+++ b/tests/integration/api_v1/test_bulk.py
@@ -65,10 +65,25 @@ class TestBulkDeleteRoute:
         assert resp.status_code == 422
         mock_svc.bulk_delete.assert_not_awaited()
 
-    def test_over_cap_is_422(self):
+    def test_over_plan_batch_is_403_limit_reached(self):
+        # The free plan's bulk_batch_max is 100; the DTO cap is the pro max.
         user = _make_user()
         mock_svc = AsyncMock()
         ids = [f"{i:024x}" for i in range(101)]
+        with _client(mock_svc, user) as client:
+            resp = client.post("/api/v1/urls/bulk/delete", json={"ids": ids})
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["code"] == "limit_reached"
+        assert body["limit"] == "bulk_batch_max"
+        assert body["max"] == 100
+        assert body["current"] == 101
+        mock_svc.bulk_delete.assert_not_awaited()
+
+    def test_over_dto_cap_is_422(self):
+        user = _make_user()
+        mock_svc = AsyncMock()
+        ids = [f"{i:024x}" for i in range(1001)]
         with _client(mock_svc, user) as client:
             resp = client.post("/api/v1/urls/bulk/delete", json={"ids": ids})
         assert resp.status_code == 422

--- a/tests/integration/api_v1/test_me_entitlements.py
+++ b/tests/integration/api_v1/test_me_entitlements.py
@@ -26,6 +26,7 @@ from .test_me_features import _flag_svc
 def _app(user, resolved: Resolved, *, enabled: set[str] = frozenset(), used=None):
     ent_service = AsyncMock()
     ent_service.usage_for = AsyncMock(return_value=used or {})
+    ent_service.over_limit_for = AsyncMock(return_value={})
     return _build_test_app(
         {
             require_jwt: lambda: user,
@@ -105,6 +106,7 @@ def test_version_header_is_set_from_the_dependency():
     ent_service = AsyncMock()
     ent_service.resolve_for = AsyncMock(return_value=resolved)
     ent_service.usage_for = AsyncMock(return_value={})
+    ent_service.over_limit_for = AsyncMock(return_value={})
     app = _build_test_app(
         {
             require_jwt: lambda: user,
@@ -127,6 +129,7 @@ def test_dependency_passes_the_jwt_plan_hint():
     ent_service = AsyncMock()
     ent_service.resolve_for = AsyncMock(return_value=for_plan(Plan.FREE))
     ent_service.usage_for = AsyncMock(return_value={})
+    ent_service.over_limit_for = AsyncMock(return_value={})
     app = _build_test_app(
         {
             require_jwt: lambda: user,
@@ -153,3 +156,26 @@ def test_until_is_the_prepaid_end_for_an_active_prepaid():
     with TestClient(_app(user, resolved)) as client:
         body = client.get("/api/v1/me/entitlements").json()
     assert body["plan"]["until"] == end.isoformat()
+
+
+def test_over_limit_lists_paused_items_per_limit():
+    user = _make_user()
+    resolved = for_plan(Plan.FREE, version=4)
+    ent_service = AsyncMock()
+    ent_service.usage_for = AsyncMock(return_value={"webhook_endpoints_max": 3})
+    ent_service.over_limit_for = AsyncMock(
+        return_value={"webhook_endpoints_max": ["aaa", "bbb"]}
+    )
+    app = _build_test_app(
+        {
+            require_jwt: lambda: user,
+            get_current_user: lambda: user,
+            get_feature_flag_service: lambda: _flag_svc(set()),
+            get_entitlements: lambda: resolved,
+            get_entitlement_service: lambda: ent_service,
+        }
+    )
+    with TestClient(app) as client:
+        body = client.get("/api/v1/me/entitlements").json()
+    assert body["over_limit"] == {"webhook_endpoints_max": {"paused": ["aaa", "bbb"]}}
+    assert body["limits"]["webhook_endpoints_max"] == {"max": 1, "used": 3}

--- a/tests/integration/api_v1/test_plan_gates.py
+++ b/tests/integration/api_v1/test_plan_gates.py
@@ -1,0 +1,97 @@
+"""One route test per plan-gated field: a free account posting the field gets
+403 ``plan_required`` naming the feature, on create and on update."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from dependencies import (
+    get_current_user,
+    get_entitlements,
+    get_feature_flag_service,
+    get_url_service,
+    require_auth,
+)
+from services.entitlements import for_plan
+from services.feature_flag_service import FeatureFlagService
+from services.features.catalog import Plan
+
+from .conftest import _build_test_app, _make_user
+
+GATED_FIELDS = [
+    ("geo_rules", {"IN": "https://example.in/"}, "geo_targeting"),
+    ("ab_variants", [{"url": "https://example.com/b", "weight": 40}], "ab_variants"),
+    ("expired_redirect_url", "https://example.com/gone", "expired_fallback"),
+    ("meta_tags", {"title": "Launch"}, "custom_meta_tags"),
+    ("starts_at", "2030-01-01T00:00:00Z", "link_scheduling"),
+]
+
+
+def _flag_svc() -> FeatureFlagService:
+    """Real ``require`` with every flag rolled out, so only the plan gate decides."""
+    svc = FeatureFlagService.__new__(FeatureFlagService)
+
+    async def _is_enabled(name, user):
+        return True
+
+    svc.is_enabled = _is_enabled  # type: ignore[method-assign]
+    return svc
+
+
+def _client(plan: Plan) -> tuple[TestClient, AsyncMock]:
+    user = _make_user()
+    url_svc = AsyncMock()
+    app = _build_test_app(
+        {
+            get_current_user: lambda: user,
+            require_auth: lambda: user,
+            get_url_service: lambda: url_svc,
+            get_feature_flag_service: _flag_svc,
+            get_entitlements: lambda: for_plan(plan),
+        }
+    )
+    return TestClient(app, raise_server_exceptions=False), url_svc
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "feature"), GATED_FIELDS, ids=lambda v: str(v)[:24]
+)
+def test_free_account_cannot_shorten_with_the_field(field, value, feature):
+    client, url_svc = _client(Plan.FREE)
+    with client:
+        resp = client.post(
+            "/api/v1/shorten", json={"long_url": "https://example.com", field: value}
+        )
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "plan_required"
+    assert resp.json()["feature"] == feature
+    url_svc.create.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "feature"), GATED_FIELDS, ids=lambda v: str(v)[:24]
+)
+def test_free_account_cannot_update_with_the_field(field, value, feature):
+    client, url_svc = _client(Plan.FREE)
+    with client:
+        resp = client.patch(f"/api/v1/urls/{ObjectId()}", json={field: value})
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "plan_required"
+    assert resp.json()["feature"] == feature
+    url_svc.update.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "feature"), GATED_FIELDS, ids=lambda v: str(v)[:24]
+)
+def test_pro_account_passes_the_gate(field, value, feature):
+    client, _ = _client(Plan.PRO)
+    with client:
+        resp = client.post(
+            "/api/v1/shorten", json={"long_url": "https://example.com", field: value}
+        )
+    assert resp.status_code != 403, resp.json()

--- a/tests/integration/api_v1/test_public_preview.py
+++ b/tests/integration/api_v1/test_public_preview.py
@@ -16,6 +16,8 @@ from fastapi.testclient import TestClient
 
 from dependencies.services import get_public_preview_service
 from schemas.models.url import UrlV2Doc
+from services.entitlements import for_plan
+from services.features.catalog import Plan
 from services.public_link_resolver import PublicLinkResolver
 from services.public_preview_service import PublicPreviewService
 
@@ -49,6 +51,8 @@ def _make_service(
     v2_docs: tuple[UrlV2Doc, ...] = (),
     v1_docs: dict[str, dict] | None = None,
     emoji_docs: dict[str, dict] | None = None,
+    plan: Plan = Plan.FREE,
+    flag_on: bool = False,
 ) -> PublicPreviewService:
     """Real service over dict-backed repo mocks (exact-match lookups)."""
     v2_by_key = {(d.alias, d.domain): d for d in v2_docs}
@@ -69,13 +73,19 @@ def _make_service(
         side_effect=lambda pipeline: emoji_map.get(pipeline[0]["$match"]["_id"])
     )
 
+    entitlements = AsyncMock()
+    entitlements.resolve_for = AsyncMock(return_value=for_plan(plan))
+    flags = AsyncMock()
+    flags.is_enabled_for_owner = AsyncMock(return_value=flag_on)
     return PublicPreviewService(
         PublicLinkResolver(
             url_repo,
             legacy_repo,
             emoji_repo,
             system_default_domain="spoo.me",
-        )
+        ),
+        entitlements,
+        flags,
     )
 
 
@@ -106,6 +116,7 @@ def test_v2_active_plain_full_body():
         "generation": "v2",
         "alias": "testme",
         "short_url": "https://spoo.me/testme",
+        "whitelabel": False,
         "status": "active",
         "created_at": "2024-01-01T00:00:00+00:00",
         "starts_at": None,
@@ -313,6 +324,7 @@ def test_v1_active_full_body():
         "generation": "v1",
         "alias": "abc123",
         "short_url": "https://spoo.me/abc123",
+        "whitelabel": False,
         "status": "active",
         "created_at": "2024-03-10T12:00:00+00:00",
         "starts_at": None,
@@ -483,3 +495,21 @@ def test_v2_started_reads_active_without_start():
     assert body["status"] == "active"
     assert body["starts_at"] is None
     assert body["destination"] is not None
+
+
+def test_whitelabel_needs_the_flag_and_the_entitlement():
+    doc = _make_v2()
+    assert (
+        _get(_make_service((doc,), plan=Plan.PRO), "testme").json()["whitelabel"]
+        is False
+    )
+    assert (
+        _get(_make_service((doc,), plan=Plan.PRO, flag_on=True), "testme").json()[
+            "whitelabel"
+        ]
+        is True
+    )
+    assert (
+        _get(_make_service((doc,), flag_on=True), "testme").json()["whitelabel"]
+        is False
+    )

--- a/tests/integration/api_v1/test_public_stats.py
+++ b/tests/integration/api_v1/test_public_stats.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from unittest.mock import AsyncMock
 
 from bson import ObjectId
 from fastapi.testclient import TestClient
@@ -17,6 +18,8 @@ from dependencies import get_current_user
 from dependencies.services import get_public_stats_service
 from infrastructure.crypto import hash_password
 from schemas.models.url import UrlV2Doc
+from services.entitlements import for_plan
+from services.features.catalog import Plan
 from services.public_link_resolver import PublicLinkResolver
 from services.public_stats_service import PublicStatsService
 from services.stats_service import StatsService
@@ -122,16 +125,21 @@ def _build_service(
     v1_docs: dict[str, dict[str, Any]] | None = None,
     emoji_docs: dict[str, dict[str, Any]] | None = None,
     click_repo: _CapturingClickRepo | None = None,
+    flag_on: bool = False,
 ) -> tuple[PublicStatsService, _CapturingClickRepo]:
     click_repo = click_repo or _CapturingClickRepo()
-    stats_service = StatsService(click_repo, _DictUrlRepo(), max_date_range_days=90)
+    stats_service = StatsService(click_repo, _DictUrlRepo())
     resolver = PublicLinkResolver(
         _DictUrlRepo(v2_docs),
         _DictLegacyRepo(v1_docs),
         _DictLegacyRepo(emoji_docs),
         system_default_domain=_DOMAIN,
     )
-    service = PublicStatsService(resolver, stats_service, max_date_range_days=90)
+    entitlements = AsyncMock()
+    entitlements.resolve_for = AsyncMock(return_value=for_plan(Plan.FREE))
+    flags = AsyncMock()
+    flags.is_enabled_for_owner = AsyncMock(return_value=flag_on)
+    service = PublicStatsService(resolver, stats_service, entitlements, flags)
     return service, click_repo
 
 
@@ -837,3 +845,50 @@ def test_inverted_date_range_is_a_validation_error():
 
     assert resp.status_code == 400
     assert resp.json()["code"] == "validation_error"
+
+
+def _pro_service(doc: UrlV2Doc) -> tuple[PublicStatsService, _CapturingClickRepo]:
+    service, click_repo = _build_service(v2_docs=[doc])
+    service._entitlements.resolve_for = AsyncMock(return_value=for_plan(Plan.PRO))
+    return service, click_repo
+
+
+def _two_years_back() -> str:
+    start = datetime.now(timezone.utc) - timedelta(days=720)
+    return f"?start_date={start:%Y-%m-%dT%H:%M:%SZ}&timezone=UTC"
+
+
+def test_anonymous_visitor_is_clamped_to_the_free_window_on_a_pro_link():
+    doc = _make_v2_doc(alias="abc1234")
+    service, click_repo = _pro_service(doc)
+    with _client(service) as client:
+        resp = client.get(_url("abc1234", _two_years_back()))
+
+    assert resp.status_code == 200
+    since = click_repo.pipelines[0][0]["$match"]["clicked_at"]["$gte"]
+    assert datetime.now(timezone.utc) - since < timedelta(days=91)
+
+
+def test_owner_gets_the_plan_window_on_a_pro_link():
+    doc = _make_v2_doc(alias="abc1234")
+    service, click_repo = _pro_service(doc)
+    with _client(service, user=_make_user(user_id=doc.owner_id)) as client:
+        resp = client.get(_url("abc1234", _two_years_back()))
+
+    assert resp.status_code == 200
+    since = click_repo.pipelines[0][0]["$match"]["clicked_at"]["$gte"]
+    assert datetime.now(timezone.utc) - since > timedelta(days=700)
+
+
+def test_whitelabel_needs_the_flag_and_the_entitlement():
+    doc = _make_v2_doc(alias="abc1234")
+    service, _ = _pro_service(doc)
+    with _client(service) as client:
+        assert client.get(_url("abc1234")).json()["whitelabel"] is False
+    service, _ = _build_service(v2_docs=[doc], flag_on=True)
+    service._entitlements.resolve_for = AsyncMock(return_value=for_plan(Plan.PRO))
+    with _client(service) as client:
+        assert client.get(_url("abc1234")).json()["whitelabel"] is True
+    service, _ = _build_service(v2_docs=[doc], flag_on=True)
+    with _client(service) as client:
+        assert client.get(_url("abc1234")).json()["whitelabel"] is False

--- a/tests/integration/api_v1/test_webhooks.py
+++ b/tests/integration/api_v1/test_webhooks.py
@@ -20,7 +20,12 @@ import pytest
 from bson import ObjectId
 from fastapi.testclient import TestClient
 
-from dependencies import get_current_user, get_feature_flag_service, get_webhook_service
+from dependencies import (
+    get_current_user,
+    get_entitlements,
+    get_feature_flag_service,
+    get_webhook_service,
+)
 from errors import ForbiddenError
 from infrastructure.safe_fetch import PostResult
 from middleware.rate_limiter import limiter
@@ -31,6 +36,8 @@ from schemas.models.webhook import (
     WebhookEndpointDoc,
     WebhookEventDoc,
 )
+from services.entitlements import for_plan
+from services.features.catalog import Plan, plan_defaults
 from services.webhooks import DeliveryExecutor, OwnerSubscriptionCache, WebhookService
 from services.webhooks.renderers import default_renderers
 from services.webhooks.signing import verify
@@ -271,12 +278,12 @@ class _FakeEventRepo:
 
 
 class _AllowFlags:
-    async def require(self, name, user):
+    async def require(self, name, user, **kwargs):
         return None
 
 
 class _DenyFlags:
-    async def require(self, name, user):
+    async def require(self, name, user, **kwargs):
         raise ForbiddenError("This feature is not available on your account")
 
 
@@ -284,6 +291,14 @@ class _DenyFlags:
 
 
 def _build(max_endpoints: int = 5, flags: Any | None = None):
+    entitlements = for_plan(Plan.PRO).model_copy(
+        update={
+            "values": {
+                **plan_defaults(Plan.PRO),
+                "webhook_endpoints_max": max_endpoints,
+            }
+        }
+    )
     endpoint_repo = _FakeEndpointRepo()
     delivery_repo = _FakeDeliveryRepo()
     event_repo = _FakeEventRepo()
@@ -301,7 +316,6 @@ def _build(max_endpoints: int = 5, flags: Any | None = None):
         executor,
         OwnerSubscriptionCache(None, ttl_seconds=60),
         master_secret=_MASTER,
-        max_endpoints=max_endpoints,
     )
     user = _make_user()
     app = build_test_app(
@@ -310,6 +324,7 @@ def _build(max_endpoints: int = 5, flags: Any | None = None):
             get_webhook_service: lambda: service,
             get_current_user: lambda: user,
             get_feature_flag_service: lambda: flags or _AllowFlags(),
+            get_entitlements: lambda: entitlements,
         },
     )
     return app, user, endpoint_repo, delivery_repo
@@ -371,8 +386,12 @@ def test_create_over_quota_rejected():
     with _NO_SSRF, TestClient(app) as c:
         assert c.post(_URL, json=_create_body()).status_code == 201
         resp = c.post(_URL, json=_create_body())
-    assert resp.status_code == 400
-    assert "limit" in resp.json()["error"].lower()
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["code"] == "limit_reached"
+    assert body["limit"] == "webhook_endpoints_max"
+    assert body["max"] == 1
+    assert body["current"] == 1
 
 
 def test_create_rejects_non_https_url():

--- a/tests/integration/test_custom_domain_routes.py
+++ b/tests/integration/test_custom_domain_routes.py
@@ -22,6 +22,7 @@ from dependencies import (
     CurrentUser,
     get_current_user,
     get_custom_domain_service,
+    get_entitlements,
     get_feature_flag_service,
 )
 from errors import (
@@ -33,6 +34,9 @@ from errors import (
 from routes.api_v1 import router as api_v1_router
 from schemas.enums.domain_status import DomainStatus, VerificationMethod
 from schemas.models.custom_domain import CustomDomainDoc
+from services.entitlements import for_plan
+from services.feature_flag_service import FeatureFlagService
+from services.features.catalog import Plan
 from tests.conftest import build_test_app
 
 _USER_ID = ObjectId()
@@ -62,12 +66,18 @@ def _doc(**overrides) -> CustomDomainDoc:
 
 
 def _flag_svc(enabled: bool = True):
-    svc = AsyncMock()
-    svc.is_enabled = AsyncMock(return_value=enabled)
+    """Real service with only the flag lookup faked, so ``require`` keeps
+    its real semantics: flag off hides the endpoint with a 404."""
+    svc = FeatureFlagService.__new__(FeatureFlagService)
+
+    async def _is_enabled(name, user):
+        return enabled
+
+    svc.is_enabled = _is_enabled  # type: ignore[method-assign]
     return svc
 
 
-def _make_app(svc_mock, flag_enabled=True, current_user=None):
+def _make_app(svc_mock, flag_enabled=True, current_user=None, plan=Plan.PRO):
     """Wire test app, overriding get_current_user so the real auth dependency
     chain (require_auth → require_scopes → require_scopes_verified) executes
     against the stub user. Lets us exercise the scope and email-verified
@@ -79,11 +89,31 @@ def _make_app(svc_mock, flag_enabled=True, current_user=None):
             get_current_user: lambda: user,
             get_custom_domain_service: lambda: svc_mock,
             get_feature_flag_service: lambda: _flag_svc(flag_enabled),
+            get_entitlements: lambda: for_plan(plan),
         },
     )
 
 
 class TestCreateCustomDomain:
+    def test_free_plan_gets_403_plan_required_not_404(self):
+        svc = AsyncMock()
+        client = TestClient(
+            _make_app(svc, plan=Plan.FREE), raise_server_exceptions=False
+        )
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+        assert resp.status_code == 403
+        assert resp.json()["code"] == "plan_required"
+        assert resp.json()["feature"] == "custom_domains"
+        svc.create.assert_not_awaited()
+
+    def test_limit_is_passed_from_the_plan(self):
+        svc = AsyncMock()
+        svc.create = AsyncMock(return_value=_doc())
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.post("/api/v1/custom-domains", json={"fqdn": "links.acme.com"})
+        assert resp.status_code == 201
+        assert svc.create.await_args.kwargs["max_domains"] == 5
+
     def test_happy_path(self):
         svc = AsyncMock()
         svc.create = AsyncMock(return_value=_doc())
@@ -259,6 +289,44 @@ class TestListCustomDomains:
             _make_app(svc, flag_enabled=False), raise_server_exceptions=False
         )
         resp = client.get("/api/v1/custom-domains")
+        assert resp.status_code == 200
+
+
+class TestUpdateCustomDomain:
+    def test_free_plan_gets_403_plan_required(self):
+        svc = AsyncMock()
+        client = TestClient(
+            _make_app(svc, plan=Plan.FREE), raise_server_exceptions=False
+        )
+        resp = client.patch(
+            f"/api/v1/custom-domains/{_DOMAIN_ID}",
+            json={"root_redirect": "https://acme.com/"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["code"] == "plan_required"
+        assert resp.json()["feature"] == "domain_polish"
+        svc.update_routing.assert_not_awaited()
+
+    def test_clearing_is_never_gated(self):
+        svc = AsyncMock()
+        svc.update_routing = AsyncMock(return_value=_doc())
+        client = TestClient(
+            _make_app(svc, plan=Plan.FREE), raise_server_exceptions=False
+        )
+        resp = client.patch(
+            f"/api/v1/custom-domains/{_DOMAIN_ID}", json={"root_redirect": None}
+        )
+        assert resp.status_code == 200
+        svc.update_routing.assert_awaited_once()
+
+    def test_pro_plan_sets_routing(self):
+        svc = AsyncMock()
+        svc.update_routing = AsyncMock(return_value=_doc())
+        client = TestClient(_make_app(svc), raise_server_exceptions=False)
+        resp = client.patch(
+            f"/api/v1/custom-domains/{_DOMAIN_ID}",
+            json={"root_redirect": "https://acme.com/"},
+        )
         assert resp.status_code == 200
 
 

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -23,16 +23,22 @@ from slowapi.errors import RateLimitExceeded
 os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/")
 
 import pytest
+from bson import ObjectId
 
 from config import AppSettings
+from dependencies import Entitled, get_current_user
+from dependencies.auth import CurrentUser
 from middleware.error_handler import register_error_handlers
 from middleware.rate_limiter import (
     Limits,
     RateLimitHeadersMiddleware,
     limiter,
+    plan_scaled,
     rate_limit_key,
 )
 from routes.health_routes import router as health_router
+from services.entitlements import for_plan
+from services.features.catalog import Plan
 
 _STATIC_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "static"
@@ -426,3 +432,51 @@ def test_response_endpoints_get_single_header_set():
         reset_values = resp.headers.get_list("X-RateLimit-Reset")
         assert len(reset_values) == 1 and reset_values[0].isdigit()
         assert "Retry-After" not in resp.headers
+
+
+# ── Plan multiplier ──────────────────────────────────────────────────────────
+
+
+_scaled_router = APIRouter(prefix="/api/v1")
+
+
+# Registered once: slowapi keys route limits by function name, so a second
+# decoration of the same name would count every request twice.
+@_scaled_router.get("/test-scaled")
+@limiter.limit(plan_scaled("2/minute"))
+async def _scaled(request: Request, entitlements: Entitled):
+    return {"plan": entitlements.plan.value}
+
+
+def _plan_scaled_app(plan):
+    app = _build_test_app(extra_routers=[_scaled_router])
+    user = CurrentUser(user_id=ObjectId(), email_verified=True)
+    app.dependency_overrides[get_current_user] = lambda: user
+    ent = AsyncMock()
+    ent.resolve_for = AsyncMock(return_value=for_plan(Plan(plan)))
+    app.state.entitlement_service = ent
+    return app
+
+
+def _hit(client, n: int, token: str) -> list[int]:
+    return [
+        client.get(
+            "/api/v1/test-scaled", headers={"Authorization": f"Bearer {token}"}
+        ).status_code
+        for _ in range(n)
+    ]
+
+
+def test_pro_multiplier_scales_the_route_limit_through_the_real_dependency():
+    _reset_limiter()
+    token = str(ObjectId())
+    with TestClient(_plan_scaled_app("pro")) as client:
+        assert _hit(client, 10, token) == [200] * 10
+        assert _hit(client, 1, token) == [429]
+
+
+def test_free_plan_keeps_the_base_limit():
+    _reset_limiter()
+    token = str(ObjectId())
+    with TestClient(_plan_scaled_app("free")) as client:
+        assert _hit(client, 3, token) == [200, 200, 429]

--- a/tests/integration/test_redirect_lapse.py
+++ b/tests/integration/test_redirect_lapse.py
@@ -1,0 +1,279 @@
+"""Lapse policies on the redirect path, through the real route and a real
+UrlService: a lapsed owner's link behaves like a free link, the versioned
+cache entry is reshaped once, and a store failure never breaks a redirect."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from dependencies import get_click_sink, get_entitlement_service, get_url_service
+from infrastructure.cache.url_cache import UrlCache, UrlCacheData
+from routes.redirect_routes import router as redirect_router
+from schemas.models.url import UrlV2Doc
+from services.entitlements import Resolved, for_plan
+from services.features.catalog import Plan
+from services.safety.policy import UrlPolicyService
+from services.url_service import UrlService
+from tests.conftest import build_test_app
+
+OWNER = ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")
+GEO_RULES = {"IN": "https://example.in/", "US": "https://example.com/us"}
+BROWSER_UA = "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126.0 Safari/537.36"
+BOT_UA = "Twitterbot/1.0"
+
+
+class _FakeRedis:
+    """Just enough of redis.asyncio for UrlCache: get / setex / delete."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def setex(self, key, ttl, value):
+        self.store[key] = value
+
+    async def delete(self, *keys):
+        for k in keys:
+            self.store.pop(k, None)
+
+
+def _doc(**overrides) -> UrlV2Doc:
+    base = {
+        "_id": ObjectId("507f1f77bcf86cd799439011"),
+        "alias": "abc1234",
+        "owner_id": OWNER,
+        "created_at": datetime.now(timezone.utc),
+        "long_url": "https://example.com/default",
+        "status": "ACTIVE",
+        "total_clicks": 0,
+        "domain": "spoo.me",
+        "geo_rules": GEO_RULES,
+    }
+    base.update(overrides)
+    return UrlV2Doc.from_mongo(base)
+
+
+def _url_service(cache: UrlCache, doc: UrlV2Doc | None, entitlements) -> UrlService:
+    url_repo = AsyncMock()
+    url_repo.find_by_alias = AsyncMock(return_value=doc)
+    url_repo.find_by_id = AsyncMock(return_value=doc)
+    url_repo.expire_if_time_reached = AsyncMock(return_value=False)
+    legacy_repo = AsyncMock()
+    legacy_repo.find_by_id = AsyncMock(return_value=None)
+    emoji_repo = AsyncMock()
+    emoji_repo.find_by_id = AsyncMock(return_value=None)
+    blocked = AsyncMock()
+    blocked.get_patterns = AsyncMock(return_value=[])
+    svc = UrlService(
+        url_repo,
+        legacy_repo,
+        emoji_repo,
+        blocked,
+        cache,
+        [],
+        system_default_domain="spoo.me",
+        url_policy=UrlPolicyService([], blocked_self_domains=[]),
+        entitlements=entitlements,
+    )
+    return svc
+
+
+def _entitlements(resolved: Resolved):
+    svc = AsyncMock()
+    svc.resolve_for = AsyncMock(return_value=resolved)
+    return svc
+
+
+def _client(url_svc, ent_svc) -> TestClient:
+    sink = MagicMock()
+    sink.emit = AsyncMock(return_value=None)
+    app = build_test_app(
+        redirect_router,
+        overrides={
+            get_url_service: lambda: url_svc,
+            get_click_sink: lambda: sink,
+            get_entitlement_service: lambda: ent_svc,
+        },
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _get(client, path="/abc1234", ua=BROWSER_UA, country="IN"):
+    return client.get(
+        path,
+        headers={"User-Agent": ua, "CF-IPCountry": country},
+        follow_redirects=False,
+    )
+
+
+PRO = for_plan(Plan.PRO, version=1)
+LAPSED = Resolved(
+    plan=Plan.FREE,
+    status="lapsed",
+    values=for_plan(Plan.FREE).values,
+    version=2,
+)
+
+
+class TestGeoRules:
+    def test_pro_owner_gets_the_country_rule(self):
+        ent = _entitlements(PRO)
+        client = _client(_url_service(UrlCache(None), _doc(), ent), ent)
+        resp = _get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.in/"
+
+    def test_lapsed_owner_falls_back_to_long_url(self):
+        ent = _entitlements(LAPSED)
+        client = _client(_url_service(UrlCache(None), _doc(), ent), ent)
+        resp = _get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/default"
+
+
+AB_VARIANTS = [{"url": "https://example.com/b", "weight": 100}]
+
+
+class TestAbVariants:
+    def test_pro_owner_is_split_to_the_variant(self):
+        ent = _entitlements(PRO)
+        doc = _doc(geo_rules=None, ab_variants=AB_VARIANTS)
+        client = _client(_url_service(UrlCache(None), doc, ent), ent)
+        resp = _get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/b"
+
+    def test_lapsed_owner_always_gets_the_default(self):
+        ent = _entitlements(LAPSED)
+        doc = _doc(geo_rules=None, ab_variants=AB_VARIANTS)
+        client = _client(_url_service(UrlCache(None), doc, ent), ent)
+        resp = _get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/default"
+
+
+class TestExpiredFallback:
+    def _expired(self):
+        return _doc(
+            geo_rules=None,
+            status="EXPIRED",
+            expire_after=datetime.now(timezone.utc) - timedelta(days=1),
+            expired_redirect_url="https://example.com/after",
+        )
+
+    def test_pro_owner_is_sent_to_the_fallback(self):
+        ent = _entitlements(PRO)
+        client = _client(_url_service(UrlCache(None), self._expired(), ent), ent)
+        resp = _get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/after"
+
+    def test_lapsed_owner_sees_the_expired_page(self):
+        ent = _entitlements(LAPSED)
+        client = _client(_url_service(UrlCache(None), self._expired(), ent), ent)
+        resp = _get(client)
+        assert resp.status_code == 410
+
+
+class TestMetaCard:
+    def _with_meta(self):
+        return _doc(
+            geo_rules=None,
+            meta_tags={"title": "Owner card", "description": "d"},
+        )
+
+    def test_pro_owner_serves_the_card_to_bots(self):
+        ent = _entitlements(PRO)
+        client = _client(_url_service(UrlCache(None), self._with_meta(), ent), ent)
+        resp = _get(client, ua=BOT_UA)
+        assert resp.status_code == 200
+        assert "Owner card" in resp.text
+
+    def test_lapsed_owner_gives_bots_the_plain_redirect(self):
+        ent = _entitlements(LAPSED)
+        client = _client(_url_service(UrlCache(None), self._with_meta(), ent), ent)
+        resp = _get(client, ua=BOT_UA)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/default"
+
+
+class TestVersionedCache:
+    def test_stale_entry_is_reshaped_once_and_then_served_from_cache(self):
+        redis = _FakeRedis()
+        cache = UrlCache(redis)
+        ent = _entitlements(PRO)
+        svc = _url_service(cache, _doc(), ent)
+        client = _client(svc, ent)
+
+        # First hit: miss, shaped under version 1 with the geo rules kept.
+        assert _get(client).headers["location"] == "https://example.in/"
+        entry = UrlCacheData.model_validate_json(
+            redis.store["url_cache:spoo.me:abc1234"]
+        )
+        assert entry.owner_ent_version == 1
+        assert entry.geo_rules == GEO_RULES
+        assert svc._url_repo.find_by_alias.await_count == 1
+
+        # Owner lapses: version 2. The cached entry is stale, so the document
+        # is re-read once and the entry rewritten without the rules.
+        ent.resolve_for = AsyncMock(return_value=LAPSED)
+        assert _get(client).headers["location"] == "https://example.com/default"
+        entry = UrlCacheData.model_validate_json(
+            redis.store["url_cache:spoo.me:abc1234"]
+        )
+        assert entry.owner_ent_version == 2
+        assert entry.geo_rules is None
+        assert svc._url_repo.find_by_alias.await_count == 2
+
+        # Same version again: served straight from the cache.
+        assert _get(client).headers["location"] == "https://example.com/default"
+        assert svc._url_repo.find_by_alias.await_count == 2
+
+    def test_resubscribe_brings_the_rules_back(self):
+        redis = _FakeRedis()
+        cache = UrlCache(redis)
+        ent = _entitlements(LAPSED)
+        svc = _url_service(cache, _doc(), ent)
+        client = _client(svc, ent)
+        assert _get(client).headers["location"] == "https://example.com/default"
+        ent.resolve_for = AsyncMock(return_value=for_plan(Plan.PRO, version=3))
+        assert _get(client).headers["location"] == "https://example.in/"
+
+
+class TestDegradation:
+    def test_redirect_survives_redis_down(self):
+        # UrlCache(None) is exactly the no-Redis state: every get misses and
+        # every set is a no-op, so the redirect comes straight from Mongo.
+        ent = _entitlements(PRO)
+        client = _client(_url_service(UrlCache(None), _doc(), ent), ent)
+        resp = _get(client, country="US")
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.com/us"
+
+    def test_degraded_resolver_serves_the_cached_behaviour_as_is(self):
+        redis = _FakeRedis()
+        cache = UrlCache(redis)
+        ent = _entitlements(PRO)
+        svc = _url_service(cache, _doc(), ent)
+        client = _client(svc, ent)
+        assert _get(client).headers["location"] == "https://example.in/"
+
+        degraded = for_plan(Plan.FREE).model_copy(update={"degraded": True})
+        ent.resolve_for = AsyncMock(return_value=degraded)
+        resp = _get(client)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.in/"
+        assert svc._url_repo.find_by_alias.await_count == 1
+
+    def test_anonymous_link_never_consults_the_resolver(self):
+        ent = _entitlements(LAPSED)
+        svc = _url_service(UrlCache(None), _doc(owner_id=None), ent)
+        client = _client(svc, ent)
+        assert _get(client).headers["location"] == "https://example.in/"
+        ent.resolve_for.assert_not_awaited()

--- a/tests/unit/repositories/test_custom_domain_repository.py
+++ b/tests/unit/repositories/test_custom_domain_repository.py
@@ -73,7 +73,11 @@ class TestCustomDomainRepository:
 
         await repo.find_active_by_fqdn("links.example.com")
         col.find_one.assert_awaited_once_with(
-            {"fqdn": "links.example.com", "status": DomainStatus.ACTIVE}
+            {
+                "fqdn": "links.example.com",
+                "status": DomainStatus.ACTIVE,
+                "paused_by_limit": {"$ne": True},
+            }
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/services/entitlements/test_over_limit.py
+++ b/tests/unit/services/entitlements/test_over_limit.py
@@ -1,0 +1,240 @@
+"""Over-limit pausing: newest items pause, oldest keep working, and a grown
+limit lifts exactly the pauses this policy made."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from bson import ObjectId
+
+from schemas.enums.webhook import EndpointDisabledReason, WebhookStatus
+from schemas.models.api_key import ApiKeyDoc
+from schemas.models.custom_domain import CustomDomainDoc
+from schemas.models.webhook import WebhookEndpointDoc
+from services.entitlements import for_plan
+from services.entitlements.over_limit import OverLimitService, split_newest
+from services.features.catalog import Plan, plan_defaults
+
+UID = ObjectId()
+T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _at(days: int) -> datetime:
+    return T0 + timedelta(days=days)
+
+
+class TestSplitNewest:
+    def test_keeps_the_oldest_within_the_limit(self):
+        a, b, c = ObjectId(), ObjectId(), ObjectId()
+        keep, pause = split_newest([(c, _at(3)), (a, _at(1)), (b, _at(2))], 2)
+        assert keep == [a, b]
+        assert pause == [c]
+
+    def test_unlimited_pauses_nothing(self):
+        ids = [(ObjectId(), _at(i)) for i in range(5)]
+        keep, pause = split_newest(ids, -1)
+        assert len(keep) == 5 and pause == []
+
+    def test_zero_limit_pauses_everything(self):
+        ids = [(ObjectId(), _at(i)) for i in range(3)]
+        keep, pause = split_newest(ids, 0)
+        assert keep == [] and len(pause) == 3
+
+    def test_missing_created_at_sorts_last(self):
+        a, b = ObjectId(), ObjectId()
+        keep, pause = split_newest([(a, None), (b, _at(1))], 1)
+        assert keep == [b] and pause == [a]
+
+
+def _endpoint(created: datetime, status=WebhookStatus.ACTIVE, reason=None):
+    return WebhookEndpointDoc(
+        _id=ObjectId(),
+        user_id=UID,
+        url="https://hooks.example/x",
+        status=status,
+        disabled_reason=reason,
+        created_at=created,
+    )
+
+
+def _domain(created: datetime, paused=False):
+    return CustomDomainDoc(
+        _id=ObjectId(),
+        fqdn=f"d{created.day}.example.com",
+        owner_id=UID,
+        status="active",
+        verification_method="cf_http_dcv",
+        created_at=created,
+        paused_by_limit=paused,
+    )
+
+
+def _key(created: datetime, paused=False, revoked=False):
+    return ApiKeyDoc(
+        _id=ObjectId(),
+        user_id=UID,
+        token_prefix="abcd1234",
+        token_hash="x" * 64,
+        name="k",
+        created_at=created,
+        paused_by_limit=paused,
+        revoked=revoked,
+    )
+
+
+def _service(endpoints=(), domains=(), keys=()):
+    ep = AsyncMock()
+    ep.find_by_user = AsyncMock(return_value=list(endpoints))
+    dm = AsyncMock()
+    dm.list_live_by_owner = AsyncMock(return_value=list(domains))
+    ks = AsyncMock()
+    ks.list_by_user = AsyncMock(return_value=list(keys))
+    tenants = AsyncMock()
+    owner_cache = AsyncMock()
+    svc = OverLimitService(
+        endpoints=ep,
+        domains=dm,
+        keys=ks,
+        tenant_resolver=tenants,
+        webhook_owner_cache=owner_cache,
+    )
+    return svc, ep, dm, ks, tenants, owner_cache
+
+
+def _resolved(**limits):
+    values = {**plan_defaults(Plan.FREE), **limits}
+    return for_plan(Plan.FREE).model_copy(update={"values": values})
+
+
+class TestEndpoints:
+    @pytest.mark.asyncio
+    async def test_free_limit_pauses_the_newest_and_drops_the_matcher_cache(self):
+        old, mid, new = _endpoint(_at(1)), _endpoint(_at(2)), _endpoint(_at(3))
+        svc, ep, _, _, _, owner_cache = _service(endpoints=[new, old, mid])
+
+        paused = await svc.apply(UID, _resolved(webhook_endpoints_max=1))
+
+        assert paused["webhook_endpoints_max"] == [str(mid.id), str(new.id)]
+        disabled = {c.args[0] for c in ep.disable.await_args_list}
+        assert disabled == {mid.id, new.id}
+        assert all(
+            c.args[1] is EndpointDisabledReason.OVER_LIMIT
+            for c in ep.disable.await_args_list
+        )
+        owner_cache.invalidate.assert_awaited_once_with(str(UID))
+
+    @pytest.mark.asyncio
+    async def test_grown_limit_lifts_only_our_pauses(self):
+        kept = _endpoint(_at(1))
+        ours = _endpoint(
+            _at(2), WebhookStatus.DISABLED, EndpointDisabledReason.OVER_LIMIT
+        )
+        theirs = _endpoint(_at(3), WebhookStatus.DISABLED, EndpointDisabledReason.GONE)
+        svc, ep, _, _, _, _ = _service(endpoints=[kept, ours, theirs])
+
+        paused = await svc.apply(UID, _resolved(webhook_endpoints_max=10))
+
+        assert paused == {}
+        ep.reactivate_over_limit.assert_awaited_once_with(ours.id)
+        ep.disable.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_already_disabled_endpoints_are_not_re_disabled(self):
+        gone = _endpoint(_at(2), WebhookStatus.DISABLED, EndpointDisabledReason.GONE)
+        svc, ep, _, _, _, owner_cache = _service(endpoints=[_endpoint(_at(1)), gone])
+
+        paused = await svc.apply(UID, _resolved(webhook_endpoints_max=1))
+
+        ep.disable.assert_not_awaited()
+        owner_cache.invalidate.assert_not_awaited()
+        assert paused == {}
+
+    @pytest.mark.asyncio
+    async def test_within_limit_touches_nothing(self):
+        svc, ep, _, _, _, owner_cache = _service(endpoints=[_endpoint(_at(1))])
+        assert await svc.apply(UID, _resolved(webhook_endpoints_max=1)) == {}
+        ep.disable.assert_not_awaited()
+        owner_cache.invalidate.assert_not_awaited()
+
+
+class TestDomains:
+    @pytest.mark.asyncio
+    async def test_lapsed_owner_pauses_every_domain_and_drops_tenant_cache(self):
+        d1, d2 = _domain(_at(1)), _domain(_at(2))
+        svc, _, dm, _, tenants, _ = _service(domains=[d1, d2])
+
+        paused = await svc.apply(UID, _resolved(custom_domains_max=0))
+
+        assert paused["custom_domains_max"] == [str(d1.id), str(d2.id)]
+        dm.set_paused_by_limit.assert_awaited_once_with([d1.id, d2.id], True)
+        assert {c.args[0] for c in tenants.invalidate.await_args_list} == {
+            d1.fqdn,
+            d2.fqdn,
+        }
+
+    @pytest.mark.asyncio
+    async def test_owner_without_the_feature_pauses_every_domain(self):
+        d1, d2 = _domain(_at(1)), _domain(_at(2))
+        svc, _, domains, _, tenants, _ = _service(domains=[d1, d2])
+        resolved = _resolved(custom_domains=False, custom_domains_max=5)
+
+        paused = await svc.apply(UID, resolved)
+
+        assert set(paused["custom_domains_max"]) == {str(d1.id), str(d2.id)}
+        domains.set_paused_by_limit.assert_awaited_once_with([d1.id, d2.id], True)
+        assert tenants.invalidate.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_resubscribe_unpauses(self):
+        d1 = _domain(_at(1), paused=True)
+        svc, _, dm, _, tenants, _ = _service(domains=[d1])
+
+        paused = await svc.apply(
+            UID, _resolved(custom_domains=True, custom_domains_max=5)
+        )
+
+        assert paused == {}
+        dm.set_paused_by_limit.assert_awaited_once_with([d1.id], False)
+        tenants.invalidate.assert_awaited_once_with(d1.fqdn)
+
+
+class TestKeys:
+    @pytest.mark.asyncio
+    async def test_revoked_keys_do_not_count(self):
+        live = [_key(_at(i)) for i in range(3)]
+        revoked = _key(_at(0), revoked=True)
+        svc, _, _, ks, _, _ = _service(keys=[revoked, *live])
+
+        paused = await svc.apply(UID, _resolved(api_keys_max=2))
+
+        assert paused["api_keys_max"] == [str(live[2].id)]
+        ks.set_paused_by_limit.assert_awaited_once_with([live[2].id], True)
+
+
+class TestPaused:
+    @pytest.mark.asyncio
+    async def test_reports_only_this_policys_pauses(self):
+        ours = _endpoint(
+            _at(1), WebhookStatus.DISABLED, EndpointDisabledReason.OVER_LIMIT
+        )
+        theirs = _endpoint(_at(2), WebhookStatus.DISABLED, EndpointDisabledReason.GONE)
+        d = _domain(_at(1), paused=True)
+        k = _key(_at(1), paused=True)
+        svc, *_ = _service(
+            endpoints=[ours, theirs],
+            domains=[d, _domain(_at(2))],
+            keys=[k, _key(_at(2))],
+        )
+
+        assert await svc.paused(UID) == {
+            "webhook_endpoints_max": [str(ours.id)],
+            "custom_domains_max": [str(d.id)],
+            "api_keys_max": [str(k.id)],
+        }
+
+    @pytest.mark.asyncio
+    async def test_nothing_paused_is_an_empty_map(self):
+        svc, *_ = _service(endpoints=[_endpoint(_at(1))])
+        assert await svc.paused(UID) == {}

--- a/tests/unit/services/entitlements/test_service.py
+++ b/tests/unit/services/entitlements/test_service.py
@@ -247,3 +247,35 @@ class TestUsage:
         )
         assert await svc.usage_for(UID) == {"custom_domains_max": 2}
         counter.assert_awaited_once_with(UID)
+
+
+class TestOverLimitHook:
+    @pytest.mark.asyncio
+    async def test_plan_change_reconciles_over_limit(self):
+        svc, _, _, _, cache = _service(sub=_sub(SubscriptionStatus.ACTIVE))
+        over_limit = AsyncMock()
+        over_limit.apply = AsyncMock(return_value={"custom_domains_max": ["x"]})
+        svc._over_limit = over_limit
+        cache.get = AsyncMock(return_value=None)
+
+        await svc.transition(UID, SubscriptionEvent.ENDED, actor="ops", reason="refund")
+
+        over_limit.apply.assert_awaited_once()
+        assert over_limit.apply.await_args.args[0] == UID
+
+    @pytest.mark.asyncio
+    async def test_same_plan_transition_does_not_reconcile(self):
+        svc, *_ = _service(sub=_sub(SubscriptionStatus.ACTIVE))
+        over_limit = AsyncMock()
+        svc._over_limit = over_limit
+
+        await svc.transition(
+            UID, SubscriptionEvent.PAYMENT_FAILED, actor="paddle", reason="declined"
+        )
+
+        over_limit.apply.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_over_limit_for_is_empty_without_the_service(self):
+        svc, *_ = _service()
+        assert await svc.over_limit_for(UID) == {}

--- a/tests/unit/services/test_api_key_service.py
+++ b/tests/unit/services/test_api_key_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from bson import ObjectId
 
-from errors import EmailNotVerifiedError, ValidationError
+from errors import EmailNotVerifiedError, LimitReachedError
 from schemas.models.api_key import ApiKeyDoc
 
 USER_OID = ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")
@@ -57,6 +57,7 @@ class TestApiKeyServiceCreate:
             scopes=["urls:read"],
             user_id=USER_OID,
             email_verified=True,
+            max_keys=20,
         )
 
         assert isinstance(doc, ApiKeyDoc)
@@ -74,20 +75,22 @@ class TestApiKeyServiceCreate:
                 scopes=[],
                 user_id=USER_OID,
                 email_verified=False,
+                max_keys=20,
             )
 
     @pytest.mark.asyncio
     async def test_create_raises_when_at_max_limit(self):
         repo = make_repo()
-        repo.count_by_user = AsyncMock(return_value=20)  # default max_active_keys
+        repo.count_by_user = AsyncMock(return_value=20)
         svc = make_service(repo)
 
-        with pytest.raises(ValidationError, match="maximum"):
+        with pytest.raises(LimitReachedError):
             await svc.create(
                 name="Key",
                 scopes=[],
                 user_id=USER_OID,
                 email_verified=True,
+                max_keys=20,
             )
 
     @pytest.mark.asyncio
@@ -101,6 +104,7 @@ class TestApiKeyServiceCreate:
             scopes=["urls:manage"],
             user_id=USER_OID,
             email_verified=True,
+            max_keys=20,
             description="My description",
             expires_at=expires,
         )

--- a/tests/unit/services/test_custom_domain_service.py
+++ b/tests/unit/services/test_custom_domain_service.py
@@ -19,6 +19,7 @@ from errors import (
     FeatureDisabledError,
     ForbiddenError,
     InvalidDomainTransitionError,
+    LimitReachedError,
     NotFoundError,
 )
 from schemas.dto.requests.custom_domain import (
@@ -153,7 +154,7 @@ class TestEnabledGate:
         svc, _, _, _, _ = _build_service(enabled=False)
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
         with pytest.raises(FeatureDisabledError):
-            await svc.create(req, _user())
+            await svc.create(req, _user(), max_domains=5)
 
     @pytest.mark.asyncio
     async def test_verify_refused_when_disabled(self):
@@ -185,7 +186,7 @@ class TestCreate:
         svc, repo, _, _, _ = _build_service()
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
-        doc = await svc.create(req, _user())
+        doc = await svc.create(req, _user(), max_domains=5)
         assert doc.status == DomainStatus.PENDING
         repo.insert.assert_awaited_once()
         # Token always stamped — lets users switch backends later without re-registering.
@@ -196,7 +197,9 @@ class TestCreate:
     async def test_picker_chooses_cf_when_backend_wired(self):
         svc, repo, _, _, _ = _build_service()
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
-        await svc.create(CreateCustomDomainRequest(fqdn="links.acme.com"), _user())
+        await svc.create(
+            CreateCustomDomainRequest(fqdn="links.acme.com"), _user(), max_domains=5
+        )
         inserted = repo.insert.call_args.args[0]
         assert inserted["verification_method"] == VerificationMethod.CF_HTTP_DCV
 
@@ -207,7 +210,9 @@ class TestCreate:
         verifiers = {VerificationMethod.CNAME: cname}
         svc, repo, _, _, _ = _build_service(verifiers=verifiers)
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
-        await svc.create(CreateCustomDomainRequest(fqdn="links.acme.com"), _user())
+        await svc.create(
+            CreateCustomDomainRequest(fqdn="links.acme.com"), _user(), max_domains=5
+        )
         inserted = repo.insert.call_args.args[0]
         assert inserted["verification_method"] == VerificationMethod.CNAME
 
@@ -223,7 +228,9 @@ class TestCreate:
         }
         svc, repo, _, _, _ = _build_service(verifiers=verifiers)
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
-        await svc.create(CreateCustomDomainRequest(fqdn="acme.com"), _user())
+        await svc.create(
+            CreateCustomDomainRequest(fqdn="acme.com"), _user(), max_domains=5
+        )
         inserted = repo.insert.call_args.args[0]
         assert inserted["verification_method"] == VerificationMethod.A_RECORD
 
@@ -236,7 +243,7 @@ class TestCreate:
             DomainAlreadyRegisteredError,
             match="registered to another account",
         ):
-            await svc.create(req, _user())
+            await svc.create(req, _user(), max_domains=5)
 
     @pytest.mark.asyncio
     async def test_uniqueness_ignores_revoked_docs(self):
@@ -251,16 +258,27 @@ class TestCreate:
         repo.find_blocking_by_fqdn = AsyncMock(return_value=None)
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
-        await svc.create(req, _user())  # must not raise
+        await svc.create(req, _user(), max_domains=5)  # must not raise
         repo.insert.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_per_user_quota_enforced(self):
         svc, repo, _, _, _ = _build_service()
-        repo.count_by_owner = AsyncMock(return_value=2)  # at default cap
+        repo.count_by_owner = AsyncMock(return_value=2)
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
-        with pytest.raises(DomainQuotaExceededError):
-            await svc.create(req, _user())
+        with pytest.raises(LimitReachedError) as exc:
+            await svc.create(req, _user(), max_domains=2)
+        assert exc.value.to_dict()["limit"] == "custom_domains_max"
+        assert exc.value.to_dict()["current"] == 2
+
+    @pytest.mark.asyncio
+    async def test_unlimited_plan_never_counts(self):
+        svc, repo, _, _, _ = _build_service()
+        repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
+        repo.count_by_owner = AsyncMock(return_value=900)
+        req = CreateCustomDomainRequest(fqdn="links.acme.com")
+        await svc.create(req, _user(), max_domains=-1)
+        repo.count_by_owner.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_blocklist_enforced_via_repo(self):
@@ -269,7 +287,7 @@ class TestCreate:
         svc, _, _, _, _ = _build_service(blocked_domain_repo=blocked)
         req = CreateCustomDomainRequest(fqdn="evil.com")
         with pytest.raises(DomainBlocklistedError):
-            await svc.create(req, _user())
+            await svc.create(req, _user(), max_domains=5)
         blocked.is_blocked.assert_awaited_once_with("evil.com")
 
     @pytest.mark.asyncio
@@ -282,7 +300,7 @@ class TestCreate:
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
         req = CreateCustomDomainRequest(fqdn="anything.example.com")
         # Must not raise — just skip the check.
-        await svc.create(req, _user())
+        await svc.create(req, _user(), max_domains=5)
 
     @pytest.mark.asyncio
     async def test_duplicate_key_during_race_translates_to_friendly_error(self):
@@ -296,7 +314,7 @@ class TestCreate:
         )
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
         with pytest.raises(DomainAlreadyRegisteredError):
-            await svc.create(req, _user())
+            await svc.create(req, _user(), max_domains=5)
 
 
 class TestVerify:
@@ -746,7 +764,7 @@ class TestRegistrarIntegration:
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
 
-        await svc.create(req, _user())
+        await svc.create(req, _user(), max_domains=5)
 
         registrar.register.assert_awaited_once()
         repo.update_edge_metadata.assert_awaited_once()
@@ -763,7 +781,7 @@ class TestRegistrarIntegration:
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
 
         with pytest.raises(RuntimeError):
-            await svc.create(req, _user())
+            await svc.create(req, _user(), max_domains=5)
 
         # Doc inserted, then deleted because registration blew up.
         repo.insert.assert_awaited_once()
@@ -781,7 +799,7 @@ class TestRegistrarIntegration:
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
 
         with pytest.raises(RuntimeError, match="CF down"):
-            await svc.create(req, _user())
+            await svc.create(req, _user(), max_domains=5)
 
         # Both attempted exactly once.
         repo.insert.assert_awaited_once()
@@ -807,7 +825,7 @@ class TestRegistrarIntegration:
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
 
-        await svc.create(req, _user())
+        await svc.create(req, _user(), max_domains=5)
 
         kwargs = repo.update_edge_metadata.call_args.kwargs
         assert kwargs["dns_instructions"] == instructions
@@ -822,7 +840,7 @@ class TestRegistrarIntegration:
         repo.find_by_id = AsyncMock(return_value=_doc(status=DomainStatus.PENDING))
         req = CreateCustomDomainRequest(fqdn="links.acme.com")
 
-        await svc.create(req, _user())
+        await svc.create(req, _user(), max_domains=5)
 
         repo.update_edge_metadata.assert_not_called()
 

--- a/tests/unit/services/test_feature_flag_service.py
+++ b/tests/unit/services/test_feature_flag_service.py
@@ -186,6 +186,17 @@ class TestRolloutAllowlist:
         assert await service.is_enabled("test_flag", _user(USER_B)) is False
 
     @pytest.mark.asyncio
+    async def test_owner_by_id_matches_the_id_allowlist_only(self):
+        flag = _flag(
+            rollout_type=RolloutType.ALLOWLIST,
+            allowlist_user_ids=[USER_A],
+            allowlist_emails=["bob@example.com"],
+        )
+        service, _, _ = make_service(flag=flag)
+        assert await service.is_enabled_for_owner("test_flag", USER_A) is True
+        assert await service.is_enabled_for_owner("test_flag", USER_B) is False
+
+    @pytest.mark.asyncio
     async def test_email_match_case_insensitive(self):
         flag = _flag(
             rollout_type=RolloutType.ALLOWLIST,

--- a/tests/unit/services/test_stats_service.py
+++ b/tests/unit/services/test_stats_service.py
@@ -97,6 +97,7 @@ class TestDateHandling:
                 timezone="UTC",
             ),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         assert "time_range" in result
         assert result["time_range"]["start_date"] is not None
@@ -114,20 +115,25 @@ class TestDateHandling:
                     end_date=NOW_ISO,
                 ),
                 owner_id=OWNER_ID,
+                window_days=90,
             )
 
     @pytest.mark.asyncio
-    async def test_date_range_exceeding_90_days_raises(self):
+    async def test_date_range_past_the_window_is_clamped_not_rejected(self):
         svc, _, _ = make_service()
 
-        with pytest.raises(ValidationError, match="date range cannot exceed 90 days"):
-            await svc.query(
-                query=_q(
-                    start_date=(NOW - timedelta(days=95)).isoformat(),
-                    end_date=NOW_ISO,
-                ),
-                owner_id=OWNER_ID,
-            )
+        result = await svc.query(
+            query=_q(
+                start_date=(NOW - timedelta(days=95)).isoformat(),
+                end_date=NOW_ISO,
+            ),
+            owner_id=OWNER_ID,
+            window_days=90,
+        )
+        time_range = result["time_range"]
+        assert time_range["clamped"] is True
+        assert time_range["window_days"] == 90
+        assert time_range["end_date"] - time_range["start_date"] == timedelta(days=90)
 
 
 # ── Tests: authentication ─────────────────────────────────────────────────────
@@ -140,14 +146,14 @@ class TestAuthValidation:
         svc, _, _ = make_service()
 
         with pytest.raises(AuthenticationError):
-            await svc.query(query=_q(), owner_id=None)
+            await svc.query(query=_q(), owner_id=None, window_days=90)
 
     @pytest.mark.asyncio
     async def test_authenticated_succeeds(self):
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
-        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        result = await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
         assert result["scope"] == "all"
 
 
@@ -164,6 +170,7 @@ class TestAggregationPipeline:
         await svc.query(
             query=_q(group_by="time,browser"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         click_repo.aggregate.assert_awaited_once()
 
@@ -175,6 +182,7 @@ class TestAggregationPipeline:
         await svc.query(
             query=_q(),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         pipeline = click_repo.aggregate.call_args[0][0]
         assert pipeline[0].get("$match") is not None
@@ -187,6 +195,7 @@ class TestAggregationPipeline:
         await svc.query(
             query=_q(group_by="browser,country"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         pipeline = click_repo.aggregate.call_args[0][0]
         assert pipeline[1].get("$facet") is not None
@@ -199,6 +208,7 @@ class TestAggregationPipeline:
         await svc.query(
             query=_q(group_by="browser,os"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         facet = click_repo.aggregate.call_args[0][0][1]["$facet"]
         assert "_summary" in facet
@@ -215,6 +225,7 @@ class TestAggregationPipeline:
         await svc.query(
             query=_q(),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.owner_id"] == ObjectId(OWNER_ID)
@@ -230,6 +241,7 @@ class TestAggregationPipeline:
         await svc.query(
             query=_q(short_code="mycode"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.owner_id"] == ObjectId(OWNER_ID)
@@ -248,6 +260,7 @@ class TestResponseStructure:
         result = await svc.query(
             query=_q(),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         for key in (
             "scope",
@@ -268,7 +281,7 @@ class TestResponseStructure:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
-        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        result = await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
         assert result["scope"] == "all"
         assert "short_code" not in result
 
@@ -280,6 +293,7 @@ class TestResponseStructure:
         result = await svc.query(
             query=_q(),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         assert result["summary"]["total_clicks"] == 50
         assert result["summary"]["unique_clicks"] == 20
@@ -292,6 +306,7 @@ class TestResponseStructure:
         result = await svc.query(
             query=_q(),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         cm = result.get("computed_metrics", {})
         assert cm["unique_click_rate"] == 40.0
@@ -306,6 +321,7 @@ class TestResponseStructure:
         result = await svc.query(
             query=_q(group_by="browser"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         assert result["metrics"]["clicks_by_browser"] == []
         assert result["summary"]["avg_redirection_time"] is None
@@ -315,7 +331,7 @@ class TestResponseStructure:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response(avg_redirect=120.456)
 
-        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        result = await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
         assert result["summary"]["avg_redirection_time"] == 120.46
 
     @pytest.mark.asyncio
@@ -324,7 +340,7 @@ class TestResponseStructure:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = [{"_summary": [], "time": []}]
 
-        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        result = await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
         assert result["summary"]["total_clicks"] == 0
         assert result["summary"]["avg_redirection_time"] is None
 
@@ -334,7 +350,7 @@ class TestResponseStructure:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response(total=3, avg_redirect=None)
 
-        result = await svc.query(query=_q(), owner_id=OWNER_ID)
+        result = await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
         assert result["summary"]["total_clicks"] == 3
         assert result["summary"]["avg_redirection_time"] is None
 
@@ -351,6 +367,7 @@ class TestTimezone:
         result = await svc.query(
             query=_q(timezone_="Not/ATimezone"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         assert result["timezone"] == "UTC"
 
@@ -363,6 +380,7 @@ class TestTimezone:
         result = await svc.query(
             query=_q(timezone_="Asia/Calcutta"),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         assert result["timezone"] == "Asia/Kolkata"
 
@@ -554,7 +572,7 @@ class TestClaimedLinksArm:
         click_repo.aggregate.return_value = facet_response()
         url_repo.list_claimed_ids.return_value = []
 
-        await svc.query(query=_q(), owner_id=OWNER_ID)
+        await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
 
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.owner_id"] == ObjectId(OWNER_ID)
@@ -569,7 +587,7 @@ class TestClaimedLinksArm:
         claimed = [ObjectId("f" * 24)]
         url_repo.list_claimed_ids.return_value = claimed
 
-        await svc.query(query=_q(), owner_id=OWNER_ID)
+        await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
 
         url_repo.list_claimed_ids.assert_awaited_once_with(ObjectId(OWNER_ID))
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
@@ -638,6 +656,7 @@ class TestUrlIdFilter:
         await svc.query(
             query=_q(url_id=oid),
             owner_id=OWNER_ID,
+            window_days=90,
         )
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.url_id"] == {"$in": [ObjectId(oid)]}
@@ -692,7 +711,7 @@ class TestQueryLink:
         click_repo.aggregate.return_value = facet_response()
         url = make_url_doc()
 
-        await svc.query_link(_lq(), url)
+        await svc.query_link(_lq(), url, window_days=90)
 
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["meta.url_id"] == url.id
@@ -707,7 +726,7 @@ class TestQueryLink:
         click_repo.aggregate.return_value = facet_response()
         url = make_url_doc(alias="promo")
 
-        result = await svc.query_link(_lq(), url)
+        result = await svc.query_link(_lq(), url, window_days=90)
 
         assert result["url_id"] == str(url.id)
         assert result["alias"] == "promo"
@@ -719,7 +738,9 @@ class TestQueryLink:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
-        await svc.query_link(_lq(utm_source="(none)", browser="Chrome"), make_url_doc())
+        await svc.query_link(
+            _lq(utm_source="(none)", browser="Chrome"), make_url_doc(), window_days=90
+        )
 
         match = click_repo.aggregate.call_args[0][0][0]["$match"]
         assert match["browser"] == {"$in": ["Chrome"]}
@@ -734,7 +755,7 @@ class TestQueryLink:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
-        await svc.query_link(_lq(group_by="variant"), make_url_doc())
+        await svc.query_link(_lq(group_by="variant"), make_url_doc(), window_days=90)
 
         facet = click_repo.aggregate.call_args[0][0][1]["$facet"]
         group = next(s["$group"] for s in facet["variant"] if "$group" in s)
@@ -745,76 +766,64 @@ class TestQueryLink:
         svc, click_repo, _ = make_service()
         click_repo.aggregate.return_value = facet_response()
 
-        await svc.query_link(_lq(group_by="time,utm_source"), make_url_doc())
+        await svc.query_link(
+            _lq(group_by="time,utm_source"), make_url_doc(), window_days=90
+        )
 
         facet = click_repo.aggregate.call_args[0][0][1]["$facet"]
         assert "utm_source" in facet
 
     @pytest.mark.asyncio
-    async def test_window_validation_shared_with_account_query(self):
+    async def test_window_clamp_shared_with_account_query(self):
         svc, _, _ = make_service()
 
-        with pytest.raises(ValidationError, match="date range cannot exceed 90 days"):
-            await svc.query_link(
-                _lq(start_date=(NOW - timedelta(days=95)).isoformat()),
-                make_url_doc(),
-            )
+        result = await svc.query_link(
+            _lq(start_date=(NOW - timedelta(days=95)).isoformat()),
+            make_url_doc(),
+            window_days=90,
+        )
+        assert result["time_range"]["clamped"] is True
 
 
-# ── Window parity with the public stats service ──────────────────────────────
+# ── Window clamp ─────────────────────────────────────────────────────────────
 
 
-class TestResolveWindowParity:
-    """StatsService._resolve_window and PublicStatsService._resolve_window are
-    two implementations of one contract ("the three must not drift") — run
-    both over the same inputs and pin equal answers."""
-
-    @staticmethod
-    def _both():
-        from services.public_stats_service import PublicStatsService
-
+class TestResolveWindow:
+    def test_range_inside_window_is_untouched(self):
         stats, _, _ = make_service()
-        public = PublicStatsService(resolver=AsyncMock(), stats_service=stats)
-        return stats, public
+        start, end, clamped = stats.resolve_window(
+            "2025-01-01T00:00:00Z", "2025-02-01T00:00:00Z", 90
+        )
+        assert (start, end) == (
+            datetime(2025, 1, 1, tzinfo=timezone.utc),
+            datetime(2025, 2, 1, tzinfo=timezone.utc),
+        )
+        assert clamped is False
 
-    @pytest.mark.parametrize(
-        ("start_raw", "end_raw"),
-        [
-            # fully explicit — byte-equal output required
-            ("2025-01-01T00:00:00Z", "2025-02-01T00:00:00Z"),
-            # end-only: start defaults to end - 7d, still deterministic
-            (None, "2025-02-01T00:00:00Z"),
-        ],
-        ids=["explicit", "end-only"],
-    )
-    def test_deterministic_windows_equal(self, start_raw, end_raw):
-        stats, public = self._both()
-        s1 = stats._resolve_window(start_raw, end_raw)
-        s2 = public._resolve_window(start_raw, end_raw, "UTC")[:2]
-        assert s1 == s2
+    def test_range_past_window_is_clamped_to_end_minus_window(self):
+        stats, _, _ = make_service()
+        start, end, clamped = stats.resolve_window(
+            "2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", 90
+        )
+        assert end == datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert start == end - timedelta(days=90)
+        assert clamped is True
 
-    @pytest.mark.parametrize(
-        ("start_raw", "end_raw"),
-        [
-            (None, None),  # both default: end=now, start=now-7d
-            # end defaults to now — start must be genuinely recent (module NOW
-            # is a frozen constant) or the 90-day cap fires first.
-            (
-                (datetime.now(timezone.utc) - timedelta(days=3)).isoformat(),
-                None,
-            ),
-            ("2999-01-01T00:00:00Z", "2999-01-02T00:00:00Z"),  # future-capped
-        ],
-        ids=["both-default", "start-only", "future-capped"],
-    )
-    def test_now_dependent_windows_agree(self, start_raw, end_raw):
-        # Each implementation samples now() itself; equality holds up to that
-        # sampling skew, so pin the pair to within a second of each other.
-        stats, public = self._both()
-        s1 = stats._resolve_window(start_raw, end_raw)
-        s2 = public._resolve_window(start_raw, end_raw, "UTC")[:2]
-        for a, b in zip(s1, s2, strict=True):
-            assert abs(a - b) < timedelta(seconds=1)
+    def test_pro_window_keeps_a_year(self):
+        stats, _, _ = make_service()
+        start, _, clamped = stats.resolve_window(
+            "2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", 730
+        )
+        assert start == datetime(2024, 1, 1, tzinfo=timezone.utc)
+        assert clamped is False
+
+    def test_unlimited_window_never_clamps(self):
+        stats, _, _ = make_service()
+        start, _, clamped = stats.resolve_window(
+            "2000-01-01T00:00:00Z", "2025-01-01T00:00:00Z", -1
+        )
+        assert start == datetime(2000, 1, 1, tzinfo=timezone.utc)
+        assert clamped is False
 
     @pytest.mark.parametrize(
         ("start_raw", "end_raw", "match"),
@@ -822,13 +831,22 @@ class TestResolveWindowParity:
             ("not-a-date", None, "invalid start_date"),
             (None, "not-a-date", "invalid end_date"),
             ("2025-02-01T00:00:00Z", "2025-01-01T00:00:00Z", "before end_date"),
-            ("2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", "90 days"),
         ],
-        ids=["bad-start", "bad-end", "inverted", "too-wide"],
+        ids=["bad-start", "bad-end", "inverted"],
     )
-    def test_rejections_agree(self, start_raw, end_raw, match):
-        stats, public = self._both()
+    def test_rejections(self, start_raw, end_raw, match):
+        stats, _, _ = make_service()
         with pytest.raises(ValidationError, match=match):
-            stats._resolve_window(start_raw, end_raw)
-        with pytest.raises(ValidationError, match=match):
-            public._resolve_window(start_raw, end_raw, "UTC")
+            stats.resolve_window(start_raw, end_raw, 90)
+
+    def test_public_stats_reuses_the_same_window(self):
+        from services.public_stats_service import PublicStatsService
+
+        stats, _, _ = make_service()
+        public = PublicStatsService(AsyncMock(), stats, AsyncMock(), AsyncMock())
+        s1 = stats.resolve_window("2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", 90)
+        start, end, tz, clamped = public._resolve_window(
+            "2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", "UTC", 90
+        )
+        assert (start, end, clamped) == s1
+        assert tz == "UTC"

--- a/tests/unit/services/test_stats_service_tags.py
+++ b/tests/unit/services/test_stats_service_tags.py
@@ -47,7 +47,7 @@ class TestTagScope:
         svc, click_repo, url_repo, _ = _svc()
         url_repo.list_ids_by_owner_and_tag_ids.return_value = [A, B]
 
-        await svc.query(query=_q(tag_id=str(T1)), owner_id=OWNER_ID)
+        await svc.query(query=_q(tag_id=str(T1)), owner_id=OWNER_ID, window_days=90)
 
         url_repo.list_ids_by_owner_and_tag_ids.assert_awaited_once_with(
             ObjectId(OWNER_ID), [T1]
@@ -62,7 +62,9 @@ class TestTagScope:
         svc, _, url_repo, tag_service = _svc([_tag(T2, "launch")])
         url_repo.list_ids_by_owner_and_tag_ids.return_value = [A]
 
-        await svc.query(query=_q(tag="Launch", tag_id=str(T1)), owner_id=OWNER_ID)
+        await svc.query(
+            query=_q(tag="Launch", tag_id=str(T1)), owner_id=OWNER_ID, window_days=90
+        )
 
         tag_service.ids_for_names.assert_awaited_once_with(
             ObjectId(OWNER_ID), ["launch"]
@@ -75,7 +77,7 @@ class TestTagScope:
     async def test_unknown_name_matches_nothing(self):
         svc, click_repo, url_repo, _ = _svc([])
 
-        await svc.query(query=_q(tag="ghost"), owner_id=OWNER_ID)
+        await svc.query(query=_q(tag="ghost"), owner_id=OWNER_ID, window_days=90)
 
         url_repo.list_ids_by_owner_and_tag_ids.assert_not_called()
         assert _match(click_repo)["meta.url_id"] == {"$in": [NOTHING]}
@@ -85,7 +87,7 @@ class TestTagScope:
         svc, click_repo, url_repo, _ = _svc()
         url_repo.list_ids_by_owner_and_tag_ids.return_value = []
 
-        await svc.query(query=_q(tag_id=str(T1)), owner_id=OWNER_ID)
+        await svc.query(query=_q(tag_id=str(T1)), owner_id=OWNER_ID, window_days=90)
 
         assert _match(click_repo)["meta.url_id"] == {"$in": [NOTHING]}
 
@@ -94,7 +96,9 @@ class TestTagScope:
         svc, click_repo, url_repo, _ = _svc()
         url_repo.list_ids_by_owner_and_tag_ids.return_value = [A, B]
 
-        await svc.query(query=_q(tag_id=str(T1), url_id=str(B)), owner_id=OWNER_ID)
+        await svc.query(
+            query=_q(tag_id=str(T1), url_id=str(B)), owner_id=OWNER_ID, window_days=90
+        )
 
         assert _match(click_repo)["meta.url_id"] == {"$in": [B]}
 
@@ -103,7 +107,9 @@ class TestTagScope:
         svc, _, url_repo, _ = _svc()
         url_repo.list_ids_by_owner_and_tag_ids.return_value = [A]
 
-        resp = await svc.query(query=_q(tag_id=str(T1)), owner_id=OWNER_ID)
+        resp = await svc.query(
+            query=_q(tag_id=str(T1)), owner_id=OWNER_ID, window_days=90
+        )
 
         assert resp["filters"] == {"tag_id": [str(T1)]}
 
@@ -111,7 +117,7 @@ class TestTagScope:
     async def test_no_tag_filter_skips_resolution(self):
         svc, _, url_repo, tag_service = _svc()
 
-        await svc.query(query=_q(), owner_id=OWNER_ID)
+        await svc.query(query=_q(), owner_id=OWNER_ID, window_days=90)
 
         url_repo.list_ids_by_owner_and_tag_ids.assert_not_called()
         tag_service.ids_for_names.assert_not_called()

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -789,3 +789,17 @@ class TestApiKeyHygiene:
             key_id=str(KEY_OID),
             user_id=str(USER_OID),
         )
+
+
+class TestPausedApiKey:
+    @pytest.mark.asyncio
+    async def test_paused_key_is_denied(self):
+        key = make_key_doc().model_copy(update={"paused_by_limit": True})
+        req = make_request(auth_header="Bearer spoo_rawtoken")
+        db = MagicMock()
+        with (
+            patch("dependencies.auth.get_settings", return_value=make_settings()),
+            patch("dependencies.auth.ApiKeyRepository") as repo_cls,
+        ):
+            repo_cls.return_value.find_by_hash = AsyncMock(return_value=key)
+            assert await get_current_user(req, db=db) is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -277,10 +277,6 @@ class TestCustomDomainSettings:
         monkeypatch.setenv("CUSTOM_DOMAINS_ENABLED", "true")
         assert CustomDomainSettings().enabled is True
 
-    def test_prefixed_max_per_user_overrides_default(self, monkeypatch):
-        monkeypatch.setenv("CUSTOM_DOMAINS_MAX_PER_USER", "10")
-        assert CustomDomainSettings().max_per_user == 10
-
 
 class TestWebhookSettingsGuard:
     def test_enabled_webhooks_require_secret_key(self, monkeypatch):


### PR DESCRIPTION
## What

The enforcement sweep. Everything that gates or counts now reads the resolved entitlements from the `Entitled` dependency; nothing reads config for a plan number any more.

- Gated writes (geo rules, custom meta tags, expired fallback, link scheduling on shorten and update; custom domain creation) answer 403 `{"code": "plan_required", "feature": key}` when the flag is on and the plan does not include the feature. Flag off keeps its old answer (403 not enabled, or 404 for domains).
- Count limits (webhook endpoints, API keys, custom domains, bulk batch size) count live and answer 403 `{"code": "limit_reached", "limit", "max", "current"}`. The config knobs `WEBHOOKS_MAX_ENDPOINTS`, `MAX_ACTIVE_API_KEYS`, `CUSTOM_DOMAINS_MAX_PER_USER` and `MAX_DATE_RANGE_DAYS` are gone; the catalog owns those numbers.
- Redirect path: the URL cache entry carries `owner_ent_version`. On a match the entry is served as is; on a mismatch the document is re-read, the lapse policies applied (geo rules ignored, expired fallback ignored, meta card default; scheduling keeps) and the entry rewritten. A degraded resolver serves the entry as is and logs. A custom domain stops serving with a 404 once its owner's plan no longer includes domains.
- Rate limiter: the key carries the plan's `api_rate_multiplier` and the limit string scales with it, so a pro caller gets 300 per minute where free gets 60.
- Stats: the range is clamped to the plan's `analytics_window_days` instead of rejected; `time_range` says `clamped` and `window_days`. Public stats and preview pages read the owner's plan for the window and a `whitelabel` flag.
- Edge: the hotness detector takes `CLICK_EVENTS_HOT_THRESHOLDS` (default `[50, 500]`). Promotion resolves the owner's plan at the fresh lookup: free links promote at the first threshold, links whose owner holds `viral_full_tracking` wait for the last one and promote with `track: true` on the KV entry. The contract schema and fixtures gained the flag; the Worker tests pass with it.
- Over-limit pausing: when a plan change drops a limit below what an owner has, the newest endpoints, domains and API keys pause (`pause_newest`), stored on the document. Paused endpoints are disabled with reason `over_limit`, paused domains stop resolving as tenants, paused keys stop authenticating. `/me/entitlements` lists them under `over_limit`; a plan that grows again lifts exactly those pauses.

## Why

Phase 1 made the answer available; this makes every write, redirect and counter obey it, so the frontend's LOCKED state and the API agree, and a lapsed owner's links behave like free links without deleting anything.

## Deploy notes

- Remove the four deleted env vars from the deployment env if set (they are ignored).
- `CLICK_EVENTS_HOT_THRESHOLD` becomes `CLICK_EVENTS_HOT_THRESHOLDS` (a JSON list).

## How proven

- Full suite green: 4193 passed, 8 skipped. `ruff check` and `ruff format --check` pass. `openapi.json` regenerated. Edge Worker vitest: 77 passed with the new fixture.
- New tests: one route test per gated field posting as free (403 `plan_required`); limit tests for endpoints, keys, domains and bulk; redirect lapse tests through the real route with a lapsed owner (geo falls back to long_url, expired fallback becomes 410, bot gets the plain redirect, custom domain 404s), the versioned cache reshaping once then serving from cache, resubscribe bringing rules back, Redis down still serving, degraded resolver serving the cached behaviour; rate multiplier scaling; window clamp; detector tiers; promotion tiers and the track flag; over-limit pausing and unpausing.
- Live run against the app with real Mongo and Redis in Docker, one fresh free account: each gated field on shorten answers 403 `plan_required` with the right feature; custom domain create answers 403 `plan_required`; 101 bulk ids answer 403 `limit_reached` (100/101); the second webhook endpoint answers 403 `limit_reached` (1/1); `X-RateLimit-Limit` is 60 free and 300 after a manual pro grant; a 400-day stats range clamps to 90 days free and passes at 730 pro; a pro geo link redirects an IN visitor to the IN destination, the same link goes to `long_url` right after the subscription ends and back to the IN destination after a re-grant; ending the subscription paused the 2 newest of 3 endpoints and `/me/entitlements` listed them, the re-grant cleared them; with the Redis container stopped the redirect still served 302.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plans now control API rate limits, bulk-operation sizes, statistics windows, feature access, and resource quotas.
  * Added structured errors for unavailable plan features and reached limits.
  * Added over-limit pausing and automatic reactivation for webhooks, domains, and API keys.
  * Public previews and statistics now report white-label availability and statistics window details.
  * Bulk URL requests support up to 1,000 IDs, subject to plan limits.

* **Bug Fixes**
  * API keys paused by plan limits no longer authenticate.
  * Redirect behavior now adapts correctly when entitlements change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->