### PR TITLE
feat(entitlements): lifecycle job for grace, lapse, reminders and reconcile

### DIFF
--- a/axiom/monitors/entitlements-lifecycle-stalled.json
+++ b/axiom/monitors/entitlements-lifecycle-stalled.json
@@ -1,0 +1,14 @@
+{
+  "name": "Entitlements lifecycle job stalled",
+  "description": "The lifecycle job ticks every minute and logs entitlements_lifecycle_tick. No tick for five minutes means subscriptions freeze in the generous direction: nobody moves to grace or lapses, reminders stop. Check the click worker (or the embedded scheduler) and the scheduled_tasks lease.",
+  "type": "Threshold",
+  "intervalMinutes": 5,
+  "rangeMinutes": 5,
+  "aplQuery": "['spoo-prod'] | where event == \"entitlements_lifecycle_tick\" | summarize count() by bin(_time, 5m)",
+  "operator": "Below",
+  "threshold": 1,
+  "alertOnNoData": true,
+  "notifierIds": [
+    "xd9Sj0KGJ0e2TYPnl2"
+  ]
+}

--- a/dependencies/wiring.py
+++ b/dependencies/wiring.py
@@ -93,6 +93,7 @@ from services.custom_domain_service import CustomDomainService
 from services.domain_intel_service import DomainIntelService
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
 from services.entitlements import EntitlementService
+from services.entitlements.lifecycle import LifecycleService, lifecycle_tasks
 from services.entitlements.over_limit import OverLimitService
 from services.events.sinks import (
     InlineDomainEventSink,
@@ -330,6 +331,18 @@ def build_entitlement_service(
     )
 
 
+def build_billing_provider(settings: AppSettings, http_client) -> BillingProvider:
+    billing = settings.billing
+    if billing.provider == "paddle":
+        return PaddleProvider(
+            http_client,
+            api_key=billing.paddle_api_key,
+            webhook_secret=billing.paddle_webhook_secret,
+            env=billing.paddle_env,
+        )
+    return NullBillingProvider()
+
+
 def build_billing_service(
     db,
     settings: AppSettings,
@@ -340,24 +353,40 @@ def build_billing_service(
     subscriptions: SubscriptionRepository,
 ) -> BillingService:
     billing = settings.billing
-    provider: BillingProvider
-    if billing.provider == "paddle":
-        provider = PaddleProvider(
-            http_client,
-            api_key=billing.paddle_api_key,
-            webhook_secret=billing.paddle_webhook_secret,
-            env=billing.paddle_env,
-        )
-    else:
-        provider = NullBillingProvider()
     return BillingService(
-        provider,
+        build_billing_provider(settings, http_client),
         entitlements,
         subscriptions,
         BillingEventRepository(db["billing_events"]),
         redis_client,
         billing,
         app_url=settings.app_url,
+    )
+
+
+def build_lifecycle_service(
+    db,
+    settings: AppSettings,
+    *,
+    store,
+    entitlements: EntitlementService,
+    provider: BillingProvider,
+    mailer,
+) -> LifecycleService:
+    """``store`` is the caller's entitlement store tuple. An unconfigured
+    mailer becomes None so the job never retries a send it cannot make."""
+    _, events, subscriptions, overrides = store
+    return LifecycleService(
+        entitlements,
+        subscriptions,
+        overrides,
+        events,
+        UserRepository(db["users"]),
+        CustomDomainRepository(db["custom_domains"]),
+        FeatureFlagRepository(db["feature_flags"]),
+        mailer if settings.email.zepto_api_token else None,
+        app_url=settings.app_url,
+        provider=provider,
     )
 
 
@@ -1178,6 +1207,16 @@ def wire_services(app: FastAPI, settings: AppSettings, redis_client) -> None:
                 ),
             ),
             erasure_sweep_task(account_erasure_service),
+            *lifecycle_tasks(
+                build_lifecycle_service(
+                    db,
+                    settings,
+                    store=ent_store,
+                    entitlements=app.state.entitlement_service,
+                    provider=build_billing_provider(settings, http_client),
+                    mailer=app.state.email_provider,
+                )
+            ),
         ]
     )
     app.state.task_scheduler = TaskScheduler(

--- a/infrastructure/email/zeptomail.py
+++ b/infrastructure/email/zeptomail.py
@@ -141,6 +141,20 @@ class ZeptoMailProvider:
         )
         return await self._send(email, user_name, subject, html_body, text_body)
 
+    async def send_html(
+        self,
+        to_email: str,
+        subject: str,
+        template_name: str,
+        context: dict,
+        text_body: str,
+    ) -> bool:
+        """Render ``templates/emails/<template_name>`` with ``context`` and send it."""
+        html_body = self._jinja.get_template(template_name).render(
+            app_url=self._app_url, **context
+        )
+        return await self._send(to_email, None, subject, html_body, text_body)
+
     async def send_deletion_requested(
         self, email: str, purge_after: datetime, restore_token: str | None = None
     ) -> bool:

--- a/repositories/entitlement_event_repository.py
+++ b/repositories/entitlement_event_repository.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from bson import ObjectId
 
 from repositories.base import BaseRepository
@@ -19,6 +21,28 @@ class EntitlementEventRepository(BaseRepository[EntitlementEventDoc]):
         they hold. Reminder events are audit only and do not bump it."""
         return await self._count(
             {"user_id": user_id, "kind": {"$nin": list(_VERSIONLESS_KINDS)}}
+        )
+
+    async def has_reminder(
+        self, user_id: ObjectId, kind: EntitlementEventKind, period: str
+    ) -> bool:
+        doc = await self._find_one_raw(
+            {"user_id": user_id, "kind": kind.value, "period": period}, {"_id": 1}
+        )
+        return doc is not None
+
+    async def users_with_override_writes_since(self, since: datetime) -> list[ObjectId]:
+        return await self._col.distinct(
+            "user_id",
+            {
+                "kind": {
+                    "$in": [
+                        EntitlementEventKind.OVERRIDE_GRANTED.value,
+                        EntitlementEventKind.OVERRIDE_REVOKED.value,
+                    ]
+                },
+                "at": {"$gte": since},
+            },
         )
 
     async def delete_by_user(self, user_id: ObjectId) -> int:

--- a/repositories/entitlement_override_repository.py
+++ b/repositories/entitlement_override_repository.py
@@ -153,6 +153,45 @@ class EntitlementOverrideRepository(BaseRepository[EntitlementOverrideDoc]):
         await self._cache.invalidate(user_id)
         return True
 
+    async def find_expired(
+        self, now: datetime, *, limit: int = 500
+    ) -> list[EntitlementOverrideDoc]:
+        cursor = self._col.find({"expires_at": {"$ne": None, "$lte": now}}).limit(limit)
+        docs = await cursor.to_list(length=limit)
+        return [EntitlementOverrideDoc.from_mongo(d) for d in docs]  # type: ignore[misc]
+
+    async def revoke_expired(
+        self,
+        user_id: ObjectId,
+        key: str,
+        now: datetime,
+        *,
+        actor: str,
+        reason: str,
+    ) -> bool:
+        """Revoke only while still expired: an extension granted in between wins."""
+        existing = await self._find_one({"user_id": user_id, "key": key})
+        if existing is None or existing.expires_at is None:
+            return False
+        deleted = await self._delete(
+            {"_id": existing.id, "expires_at": {"$ne": None, "$lte": now}}
+        )
+        if not deleted:
+            return False
+        await self._events.append(
+            EntitlementEventDoc(
+                user_id=user_id,
+                kind=EntitlementEventKind.OVERRIDE_REVOKED,
+                actor=actor,
+                reason=reason,
+                before=_snapshot(existing),
+                after=None,
+                at=now,
+            )
+        )
+        await self._cache.invalidate(user_id)
+        return True
+
     async def delete_by_user(self, user_id: ObjectId) -> int:
         deleted = await self._delete_many({"user_id": user_id})
         if deleted:

--- a/repositories/indexes.py
+++ b/repositories/indexes.py
@@ -199,6 +199,8 @@ async def ensure_indexes(
     await overrides_col.create_index([("expires_at", 1)], sparse=True)
     ent_events_col = db["entitlement_events"]
     await ent_events_col.create_index([("user_id", 1), ("at", -1)])
+    # The lifecycle tick sweeps recent override writes by kind and time.
+    await ent_events_col.create_index([("kind", 1), ("at", -1)])
     # The dedupe: a webhook delivery is handled once because this insert
     # either lands or raises DuplicateKeyError.
     billing_events_col = db["billing_events"]

--- a/repositories/subscription_repository.py
+++ b/repositories/subscription_repository.py
@@ -145,6 +145,84 @@ class SubscriptionRepository(BaseRepository[SubscriptionDoc]):
         await self._cache.invalidate(user_id)
         return after
 
+    async def find_term_ended(self, now: datetime) -> list[SubscriptionDoc]:
+        """Paid terms that have run out: a scheduled cancel past its period
+        end, or a prepaid year past its end."""
+        return await self._find_many(
+            {
+                "$or": [
+                    {
+                        "status": SubscriptionStatus.CANCEL_AT_PERIOD_END.value,
+                        "current_period_end": {"$lte": now},
+                    },
+                    {
+                        "status": SubscriptionStatus.ACTIVE.value,
+                        "kind": "prepaid",
+                        "prepaid_until": {"$lte": now},
+                    },
+                ]
+            }
+        )
+
+    async def find_grace_ended(self, now: datetime) -> list[SubscriptionDoc]:
+        return await self._find_many(
+            {"status": SubscriptionStatus.GRACE.value, "grace_until": {"$lte": now}}
+        )
+
+    async def find_in_grace(self) -> list[SubscriptionDoc]:
+        return await self._find_many({"status": SubscriptionStatus.GRACE.value})
+
+    async def find_lapsed_since(
+        self, since: datetime, *, not_by: str
+    ) -> list[SubscriptionDoc]:
+        """Lapsed recently enough to still be owed the lapsed email, except
+        those lapsed by ``not_by``; a lapsed document's last write is the lapse."""
+        return await self._find_many(
+            {
+                "status": SubscriptionStatus.LAPSED.value,
+                "updated_at": {"$gte": since},
+                "lapsed_by": {"$ne": not_by},
+            }
+        )
+
+    async def find_past_due_older_than(self, cutoff: datetime) -> list[SubscriptionDoc]:
+        return await self._find_many(
+            {
+                "status": SubscriptionStatus.PAST_DUE.value,
+                "current_period_end": {"$lte": cutoff},
+            }
+        )
+
+    async def find_terms_ending_before(self, until: datetime) -> list[SubscriptionDoc]:
+        """Subscriptions whose paid term ends before ``until`` and will not
+        renew: prepaid years and scheduled cancels."""
+        return await self._find_many(
+            {
+                "$or": [
+                    {
+                        "status": SubscriptionStatus.CANCEL_AT_PERIOD_END.value,
+                        "current_period_end": {"$lte": until},
+                    },
+                    {
+                        "status": SubscriptionStatus.ACTIVE.value,
+                        "kind": "prepaid",
+                        "prepaid_until": {"$lte": until},
+                    },
+                ]
+            }
+        )
+
+    async def find_provider_live(self, provider: str) -> list[SubscriptionDoc]:
+        """Every non-lapsed recurring subscription of a provider, for reconcile."""
+        return await self._find_many(
+            {
+                "provider": provider,
+                "kind": "recurring",
+                "status": {"$ne": SubscriptionStatus.LAPSED.value},
+            },
+            limit=5000,
+        )
+
     async def find_by_provider_subscription(
         self, subscription_id: str
     ) -> SubscriptionDoc | None:

--- a/schemas/models/entitlement_event.py
+++ b/schemas/models/entitlement_event.py
@@ -32,4 +32,6 @@ class EntitlementEventDoc(MongoBaseModel):
     reason: str
     before: dict[str, Any] | None = None
     after: dict[str, Any] | None = None
+    # Dedupe key for reminders: one email per (user, kind, period).
+    period: str | None = None
     at: datetime

--- a/schemas/models/subscription.py
+++ b/schemas/models/subscription.py
@@ -57,6 +57,9 @@ class SubscriptionDoc(MongoBaseModel):
     grace_until: datetime | None = None
     founding: bool = False
     founding_streak_ok: bool = False
+    # The state-machine event that lapsed it; "ended" means a refund or a
+    # manual end, not a term running out.
+    lapsed_by: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/services/entitlements/lifecycle.py
+++ b/services/entitlements/lifecycle.py
@@ -1,0 +1,469 @@
+"""
+The lifecycle job: every transition no webhook fires.
+
+One tick a minute moves subscriptions on the clock (term end to grace, grace
+end to lapsed, the past-due ceiling), sends the reminder, grace and lapsed
+emails once each, and prunes expired overrides. Two daily tasks reconcile
+against the billing provider and check that nothing the pro plan promises
+is switched off by a forgotten flag.
+
+Idempotent by construction: every transition re-reads state, and every email
+is keyed on ``(user, kind, period)`` in the audit log and driven off the
+status a subscription is in, not off who moved it there, so a webhook that
+beat the clock or a mailer that failed once still gets its email sent. One
+bad subscription is logged and skipped, never the whole tick. The tick's log
+line is the heartbeat an Axiom monitor watches.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+from datetime import datetime, timedelta, timezone
+from typing import Any, Protocol, TypeVar
+
+from infrastructure.logging import get_logger
+from repositories.custom_domain_repository import CustomDomainRepository
+from repositories.entitlement_event_repository import EntitlementEventRepository
+from repositories.entitlement_override_repository import (
+    EntitlementOverrideRepository,
+)
+from repositories.feature_flag_repository import FeatureFlagRepository
+from repositories.subscription_repository import SubscriptionRepository
+from repositories.user_repository import UserRepository
+from schemas.enums.domain_status import DomainStatus
+from schemas.enums.rollout_type import RolloutType
+from schemas.models.entitlement_event import EntitlementEventDoc, EntitlementEventKind
+from schemas.models.feature_flag import FeatureFlagDoc
+from schemas.models.subscription import (
+    SubscriptionDoc,
+    SubscriptionKind,
+    SubscriptionStatus,
+)
+from services.billing.port import BillingProvider
+from services.billing.service import schedule_pending_cancel
+from services.entitlements.service import EntitlementService
+from services.entitlements.state_machine import SubscriptionEvent
+from services.entitlements.terms import GRACE_DAYS, PAST_DUE_CEILING_DAYS
+from services.features.catalog import FEATURES, Kind, Plan
+from services.scheduler.registry import ScheduledTask
+from shared.datetime_utils import as_aware_utc
+
+log = get_logger(__name__)
+
+LIFECYCLE_TASK = "entitlements-lifecycle"
+RECONCILE_TASK = "billing-reconcile"
+PRO_VALUE_TASK = "entitlements-pro-value-check"
+
+REMINDER_DAYS = (30, 7, 1)
+# How far back a tick looks for lapses still owed a mail and override writes
+# still owed a reconcile; both are idempotent, so overlap is harmless.
+_CATCH_UP = timedelta(days=30)
+_OVERRIDE_CATCH_UP = timedelta(minutes=2)
+_ACTOR = "lifecycle"
+T = TypeVar("T")
+# Paddle status a subscription in each of our statuses should show.
+_EXPECTED_PROVIDER_STATUS = {
+    SubscriptionStatus.ACTIVE: {"active", "trialing"},
+    SubscriptionStatus.PAST_DUE: {"past_due"},
+    SubscriptionStatus.CANCEL_AT_PERIOD_END: {"active"},
+    SubscriptionStatus.GRACE: {"canceled"},
+}
+
+
+class LifecycleMailer(Protocol):
+    async def send_html(
+        self,
+        to_email: str,
+        subject: str,
+        template_name: str,
+        context: dict,
+        text_body: str,
+    ) -> bool: ...
+
+
+def _date(dt: datetime | None) -> str:
+    aware = as_aware_utc(dt)
+    return f"{aware:%B} {aware.day}, {aware.year}" if aware else ""
+
+
+async def _each(
+    items: Iterable[T], step: Callable[[T], Awaitable[bool]], *, what: str
+) -> tuple[int, int]:
+    """Run ``step`` per item; one failure is logged and counted, never raised."""
+    done = failed = 0
+    for item in items:
+        try:
+            done += int(await step(item))
+        except Exception:
+            failed += 1
+            log.exception("entitlements_lifecycle_item_failed", step=what)
+    return done, failed
+
+
+class LifecycleService:
+    def __init__(
+        self,
+        entitlements: EntitlementService,
+        subscriptions: SubscriptionRepository,
+        overrides: EntitlementOverrideRepository,
+        events: EntitlementEventRepository,
+        users: UserRepository,
+        domains: CustomDomainRepository,
+        flags: FeatureFlagRepository,
+        mailer: LifecycleMailer | None,
+        *,
+        app_url: str,
+        provider: BillingProvider | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._entitlements = entitlements
+        self._subs = subscriptions
+        self._overrides = overrides
+        self._events = events
+        self._users = users
+        self._domains = domains
+        self._flags = flags
+        self._mailer = mailer
+        self._app_url = app_url.rstrip("/")
+        self._provider = provider
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+
+    # ── The minute tick ──────────────────────────────────────────────────
+
+    async def tick(self) -> dict[str, Any]:
+        now = self._clock()
+        counts: dict[str, int] = {"failed": 0}
+        phases = (
+            ("grace_started", self._term_endings),
+            ("lapsed", self._grace_endings),
+            ("past_due_lapsed", self._past_due_ceiling),
+            ("grace_mails", self._grace_mails),
+            ("lapsed_mails", self._lapsed_mails),
+            ("reminders", self._reminders),
+            ("overrides_pruned", self._prune_overrides),
+            ("overrides_reconciled", self._reconcile_override_writes),
+            ("cancels_scheduled", self._pending_cancels),
+        )
+        try:
+            for name, phase in phases:
+                try:
+                    done, failed = await phase(now)
+                except Exception:
+                    done, failed = 0, 1
+                    log.exception("entitlements_lifecycle_phase_failed", phase=name)
+                counts[name] = done
+                counts["failed"] += failed
+        finally:
+            log.info("entitlements_lifecycle_tick", **counts)
+        return counts
+
+    async def _term_endings(self, now: datetime) -> tuple[int, int]:
+        async def step(sub: SubscriptionDoc) -> bool:
+            end = as_aware_utc(sub.term_end) or now
+            after = await self._entitlements.transition(
+                sub.user_id,
+                SubscriptionEvent.TERM_ENDED,
+                actor=_ACTOR,
+                reason="paid term ended",
+                now=now,
+                grace_until=max(now, end) + timedelta(days=GRACE_DAYS),
+            )
+            return after.status is SubscriptionStatus.GRACE
+
+        return await _each(await self._subs.find_term_ended(now), step, what="term")
+
+    async def _grace_endings(self, now: datetime) -> tuple[int, int]:
+        async def step(sub: SubscriptionDoc) -> bool:
+            after = await self._entitlements.transition(
+                sub.user_id,
+                SubscriptionEvent.GRACE_ENDED,
+                actor=_ACTOR,
+                reason="grace period ended",
+                now=now,
+            )
+            return after.status is SubscriptionStatus.LAPSED
+
+        return await _each(await self._subs.find_grace_ended(now), step, what="grace")
+
+    async def _past_due_ceiling(self, now: datetime) -> tuple[int, int]:
+        cutoff = now - timedelta(days=PAST_DUE_CEILING_DAYS)
+
+        async def step(sub: SubscriptionDoc) -> bool:
+            after = await self._entitlements.transition(
+                sub.user_id,
+                SubscriptionEvent.PAST_DUE_CEILING,
+                actor=_ACTOR,
+                reason=f"past due for {PAST_DUE_CEILING_DAYS} days after the period end",
+                now=now,
+            )
+            return after.status is SubscriptionStatus.LAPSED
+
+        return await _each(
+            await self._subs.find_past_due_older_than(cutoff), step, what="past_due"
+        )
+
+    async def _grace_mails(self, now: datetime) -> tuple[int, int]:
+        async def step(sub: SubscriptionDoc) -> bool:
+            grace_until = as_aware_utc(sub.grace_until) or now
+            return await self._mail_once(
+                sub,
+                f"grace:{grace_until.date()}",
+                now,
+                subject=f"Your Pro term has ended; you keep Pro for {GRACE_DAYS} more days",
+                template="plan_grace_started.html",
+                context={"grace_date": _date(grace_until), "grace_days": GRACE_DAYS},
+                text=(
+                    "Your paid term has ended. You keep every Pro feature until "
+                    f"{_date(grace_until)}. After that the account goes back to Free. "
+                    "Nothing is deleted."
+                ),
+            )
+
+        return await _each(await self._subs.find_in_grace(), step, what="grace_mail")
+
+    async def _lapsed_mails(self, now: datetime) -> tuple[int, int]:
+        async def step(sub: SubscriptionDoc) -> bool:
+            lapsed_at = as_aware_utc(sub.updated_at) or now
+            return await self._mail_once(
+                sub,
+                f"lapsed:{lapsed_at.date()}",
+                now,
+                subject="Your spoo.me account is back on Free",
+                template="plan_lapsed.html",
+                context={"lapsed_date": _date(lapsed_at)},
+                text=(
+                    f"Your Pro access ended on {_date(lapsed_at)}. Every link and all "
+                    "of your analytics are still here; Pro-only settings switch back "
+                    f"on when you renew at {self._app_url}/upgrade."
+                ),
+            )
+
+        # A refund or a manual end is not a term running out: no renewal mail.
+        lapsed = await self._subs.find_lapsed_since(
+            now - _CATCH_UP, not_by=SubscriptionEvent.ENDED.value
+        )
+        return await _each(lapsed, step, what="lapsed_mail")
+
+    async def _reminders(self, now: datetime) -> tuple[int, int]:
+        horizon = now + timedelta(days=max(REMINDER_DAYS) + 1)
+
+        async def step(sub: SubscriptionDoc) -> bool:
+            end = as_aware_utc(sub.term_end)
+            if end is None or end <= now:
+                return False
+            days_left = (end - now).days or 1
+            due = [d for d in REMINDER_DAYS if days_left <= d]
+            if not due:
+                return False
+            # The nearest threshold that has passed is the one to send; earlier
+            # ones that were missed are folded into it rather than sent late.
+            threshold = min(due)
+            scheduled_cancel = sub.kind is SubscriptionKind.RECURRING
+            action = (
+                "To stay on Pro, undo the cancellation from Billing in your dashboard "
+                f"settings: {self._app_url}/dashboard/settings"
+                if scheduled_cancel
+                else f"Renew at {self._app_url}/upgrade to stay on Pro."
+            )
+            return await self._mail_once(
+                sub,
+                f"term:{end.date()}:{threshold}",
+                now,
+                subject=f"Your spoo.me Pro term ends in {days_left} "
+                f"{'day' if days_left == 1 else 'days'}",
+                template="plan_reminder.html",
+                context={
+                    "end_date": _date(end),
+                    "days_left": days_left,
+                    "grace_days": GRACE_DAYS,
+                    "scheduled_cancel": scheduled_cancel,
+                },
+                text=(
+                    f"Your spoo.me Pro term ends on {_date(end)}. After that you keep "
+                    f"Pro for {GRACE_DAYS} more days, then the account goes back to "
+                    f"Free. {action}"
+                ),
+            )
+
+        return await _each(
+            await self._subs.find_terms_ending_before(horizon), step, what="reminder"
+        )
+
+    async def _prune_overrides(self, now: datetime) -> tuple[int, int]:
+        async def step(override) -> bool:
+            revoked = await self._overrides.revoke_expired(
+                override.user_id, override.key, now, actor=_ACTOR, reason="expired"
+            )
+            if revoked:
+                await self._entitlements.reconcile_over_limit(override.user_id)
+            return revoked
+
+        return await _each(
+            await self._overrides.find_expired(now), step, what="prune_override"
+        )
+
+    async def _reconcile_override_writes(self, now: datetime) -> tuple[int, int]:
+        """Overrides are also written outside this process (ops tooling); the
+        pause policy catches up with them here."""
+
+        async def step(user_id) -> bool:
+            await self._entitlements.reconcile_over_limit(user_id)
+            return True
+
+        users = await self._events.users_with_override_writes_since(
+            now - _OVERRIDE_CATCH_UP
+        )
+        return await _each(users, step, what="override_reconcile")
+
+    async def _pending_cancels(self, now: datetime) -> tuple[int, int]:
+        """A prepaid year that could not cancel the monthly it replaced keeps
+        ``cancel_pending`` until the provider accepts the cancel."""
+        if self._provider is None or self._provider.name == "none":
+            return 0, 0
+
+        async def step(sub: SubscriptionDoc) -> bool:
+            return await schedule_pending_cancel(
+                self._provider,
+                self._subs,
+                sub.user_id,
+                sub.provider_ids["cancel_pending"],
+            )
+
+        return await _each(
+            await self._subs.find_cancel_pending(), step, what="pending_cancel"
+        )
+
+    # ── Emails ───────────────────────────────────────────────────────────
+
+    async def _mail_once(
+        self,
+        sub: SubscriptionDoc,
+        period: str,
+        now: datetime,
+        *,
+        subject: str,
+        template: str,
+        context: dict[str, Any],
+        text: str,
+    ) -> bool:
+        kind = EntitlementEventKind.REMINDER_SENT
+        if self._mailer is None:
+            return False
+        if await self._events.has_reminder(sub.user_id, kind, period):
+            return False
+        user = await self._users.find_by_id(sub.user_id)
+        if user is None or not user.email:
+            return False
+        domains = [
+            d.fqdn
+            for d in await self._domains.list_live_by_owner(sub.user_id)
+            if d.status is DomainStatus.ACTIVE
+        ]
+        if domains:
+            text += (
+                f"\n\nLinks on {', '.join(domains)} stop resolving when Pro ends; "
+                "the domain settings and links stay saved."
+            )
+        text = f"Hello,\n\n{text}\n\nSupport Team, spoo.me"
+        try:
+            sent = await self._mailer.send_html(
+                user.email, subject, template, {**context, "domains": domains}, text
+            )
+        except Exception as exc:
+            log.warning(
+                "entitlements_lifecycle_mail_failed", kind=kind.value, error=str(exc)
+            )
+            return False
+        if not sent:
+            return False
+        # The audit append is the dedupe key; reminders do not bump the version.
+        await self._events.append(
+            EntitlementEventDoc(
+                user_id=sub.user_id,
+                kind=kind,
+                actor=_ACTOR,
+                reason=subject,
+                period=period,
+                at=now,
+            )
+        )
+        return True
+
+    # ── Daily tasks ──────────────────────────────────────────────────────
+
+    async def reconcile(self) -> dict[str, Any]:
+        """Compare every live provider subscription with the provider. Logs
+        drift; never changes a status, and a failed lookup is just a log line."""
+        if self._provider is None or self._provider.name == "none":
+            return {"skipped": True}
+        checked = drift = failed = 0
+        for sub in await self._subs.find_provider_live(self._provider.name):
+            sub_id = sub.provider_ids.get("subscription_id")
+            if not sub_id:
+                continue
+            checked += 1
+            try:
+                remote = await self._provider.fetch_subscription(sub_id)
+            except Exception as exc:
+                failed += 1
+                log.warning(
+                    "subscription_reconcile_lookup_failed",
+                    user_id=str(sub.user_id),
+                    subscription_id=sub_id,
+                    error=str(exc),
+                )
+                continue
+            expected = _EXPECTED_PROVIDER_STATUS.get(sub.status, set())
+            if remote.status not in expected:
+                drift += 1
+                log.warning(
+                    "subscription_drift",
+                    user_id=str(sub.user_id),
+                    subscription_id=sub_id,
+                    ours=sub.status.value,
+                    provider=remote.status,
+                    provider_scheduled_cancel=remote.scheduled_cancel,
+                )
+        counts = {"checked": checked, "drift": drift, "failed": failed}
+        log.info("subscription_reconcile_completed", **counts)
+        return counts
+
+    async def pro_value_check(self) -> dict[str, Any]:
+        """Catalog features the pro plan includes whose rollout is off: a
+        forgotten kill switch would silently withhold something paid for."""
+        withheld: list[str] = []
+        for feature in FEATURES.values():
+            if feature.kind is not Kind.BOOL or feature.rollout is None:
+                continue
+            if not feature.plans[Plan.PRO] or feature.plans[Plan.FREE]:
+                continue
+            flag = await self._flags.find_by_name(feature.rollout)
+            if flag is None or not _reaches_anyone(flag):
+                withheld.append(feature.key)
+        if withheld:
+            log.warning("pro_value_withheld", features=withheld)
+        return {"withheld": withheld}
+
+
+def _reaches_anyone(flag: FeatureFlagDoc) -> bool:
+    if not flag.enabled or flag.rollout_type is RolloutType.OFF:
+        return False
+    if flag.rollout_type is RolloutType.ALLOWLIST:
+        return bool(flag.allowlist_user_ids or flag.allowlist_emails)
+    if flag.rollout_type is RolloutType.PERCENTAGE:
+        return flag.percentage > 0
+    if flag.rollout_type is RolloutType.HEX_DIGIT:
+        return bool(flag.enabled_digits)
+    return True
+
+
+def lifecycle_tasks(service: LifecycleService) -> list[ScheduledTask]:
+    """This module owns the names and cadences so the app and the worker
+    register identical tasks."""
+    return [
+        ScheduledTask(name=LIFECYCLE_TASK, fn=service.tick, schedule="* * * * *"),
+        ScheduledTask(name=RECONCILE_TASK, fn=service.reconcile, schedule="0 4 * * *"),
+        ScheduledTask(
+            name=PRO_VALUE_TASK, fn=service.pro_value_check, schedule="30 4 * * *"
+        ),
+    ]

--- a/services/entitlements/service.py
+++ b/services/entitlements/service.py
@@ -166,6 +166,7 @@ class EntitlementService:
             raise ValueError("a transition to grace needs grace_until")
         if after_status is SubscriptionStatus.LAPSED:
             fields["founding_streak_ok"] = False
+            fields["lapsed_by"] = event.value
         after = await self._subs.write_transition(
             user_id,
             before=before,

--- a/templates/emails/plan_grace_started.html
+++ b/templates/emails/plan_grace_started.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block preview %}Your spoo.me Pro term has ended; you keep Pro until {{ grace_date }}{% endblock %}
+
+{% block content %}<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                        style="margin-bottom:32px">
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <h1
+                                        style="color:rgb(227,235,242);font-size:24px;font-weight:700;text-align:center;margin-bottom:16px !important;margin:0px">
+                                        Your Pro term has ended</h1>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Hello,</p>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Your paid term has ended. You keep every Pro feature until {{ grace_date }}. After that the account goes back to Free. Nothing is deleted.</p>
+                                    {% if domains %}<p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Links on {{ domains | join(", ") }} stop resolving on {{ grace_date }}. Domain settings and links stay saved.</p>{% endif %}
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Renew any time before then to carry on without a gap: <a href="{{ app_url }}/upgrade"
+                                            style="color:rgb(124,58,237);text-decoration-line:none"
+                                            target="_blank">{{ app_url }}/upgrade</a></p>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin:0px;margin-top:16px">
+                                        Support Team, spoo.me</p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>{% endblock %}

--- a/templates/emails/plan_lapsed.html
+++ b/templates/emails/plan_lapsed.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block preview %}Your spoo.me account is back on Free{% endblock %}
+
+{% block content %}<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                        style="margin-bottom:32px">
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <h1
+                                        style="color:rgb(227,235,242);font-size:24px;font-weight:700;text-align:center;margin-bottom:16px !important;margin:0px">
+                                        Your account is back on Free</h1>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Hello,</p>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Your Pro access ended on {{ lapsed_date }}. Every link and all of your analytics are still here. Pro-only settings stay saved and switch back on the moment you renew.</p>
+                                    {% if domains %}<p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Links on {{ domains | join(", ") }} stopped resolving on {{ lapsed_date }}. The domain settings and their links stay saved.</p>{% endif %}
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Renew here: <a href="{{ app_url }}/upgrade"
+                                            style="color:rgb(124,58,237);text-decoration-line:none"
+                                            target="_blank">{{ app_url }}/upgrade</a></p>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin:0px;margin-top:16px">
+                                        Support Team, spoo.me</p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>{% endblock %}

--- a/templates/emails/plan_reminder.html
+++ b/templates/emails/plan_reminder.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block preview %}Your spoo.me Pro term ends on {{ end_date }}{% endblock %}
+
+{% block content %}<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                        style="margin-bottom:32px">
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <h1
+                                        style="color:rgb(227,235,242);font-size:24px;font-weight:700;text-align:center;margin-bottom:16px !important;margin:0px">
+                                        Pro ends in {{ days_left }} {{ "day" if days_left == 1 else "days" }}</h1>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Hello,</p>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Your spoo.me Pro term ends on {{ end_date }}. After that you keep Pro for {{ grace_days }} more days, then the account goes back to Free. Nothing is deleted.</p>
+                                    {% if domains %}<p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        Links on {{ domains | join(", ") }} stop resolving once those {{ grace_days }} days are over. Your domain settings and links stay saved, so a renewal restores them at once.</p>{% endif %}
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin-bottom:16px;margin:0px">
+                                        {% if scheduled_cancel %}To stay on Pro, undo the cancellation from Billing in your dashboard settings: <a href="{{ app_url }}/dashboard/settings"
+                                            style="color:rgb(124,58,237);text-decoration-line:none"
+                                            target="_blank">{{ app_url }}/dashboard/settings</a>{% else %}To stay on Pro, renew here: <a href="{{ app_url }}/upgrade"
+                                            style="color:rgb(124,58,237);text-decoration-line:none"
+                                            target="_blank">{{ app_url }}/upgrade</a>{% endif %}</p>
+                                    <p
+                                        style="color:rgb(227,235,242);font-size:16px;line-height:24px;margin:0px;margin-top:16px">
+                                        Support Team, spoo.me</p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>{% endblock %}

--- a/tests/fake_mongo.py
+++ b/tests/fake_mongo.py
@@ -1,8 +1,8 @@
 """A tiny in-memory stand-in for a pymongo AsyncCollection.
 
 Enough of the query language for the repositories under test: equality on
-top-level and dotted keys, ``$ne``, ``$in``, ``$gt``, ``$gte``, ``$lt``,
-``$lte``, ``$exists`` and ``$or``; updates with ``$set``, ``$setOnInsert``
+top-level and dotted keys, ``$ne``, ``$in``, ``$nin``, ``$gt``, ``$gte``,
+``$lt``, ``$lte``, ``$exists`` and ``$or``; updates with ``$set``, ``$setOnInsert``
 and ``$unset``; one unique key per collection so DuplicateKeyError behaves.
 """
 
@@ -30,6 +30,8 @@ def _match_value(actual: Any, expected: Any) -> bool:
             if op == "$ne" and actual == arg:
                 return False
             if op == "$in" and actual not in arg:
+                return False
+            if op == "$nin" and actual in arg:
                 return False
             if op == "$exists" and (actual is not None) != bool(arg):
                 return False
@@ -124,6 +126,10 @@ class FakeCollection:
 
     async def count_documents(self, query: dict):
         return sum(1 for d in self.docs if _matches(d, query))
+
+    async def distinct(self, key: str, query: dict | None = None):
+        values = [_get(d, key) for d in self.docs if _matches(d, query or {})]
+        return list(dict.fromkeys(values))
 
     def _apply(self, doc: dict, ops: dict, *, inserting: bool) -> bool:
         changed = False

--- a/tests/unit/repositories/test_indexes.py
+++ b/tests/unit/repositories/test_indexes.py
@@ -78,6 +78,7 @@ class TestEnsureIndexes:
             [("user_id", 1), ("key", 1)], unique=True
         )
         ent_events_col.create_index.assert_any_await([("user_id", 1), ("at", -1)])
+        ent_events_col.create_index.assert_any_await([("kind", 1), ("at", -1)])
         # Erasure sweep: partial — holds only PENDING_DELETION/ERASING docs.
         users_col.create_index.assert_any_await(
             [("status", 1), ("purge_after", 1)],

--- a/tests/unit/services/entitlements/test_lifecycle.py
+++ b/tests/unit/services/entitlements/test_lifecycle.py
@@ -1,0 +1,651 @@
+"""The lifecycle job on a clock: real repositories over an in-memory Mongo,
+a fake mailer, a frozen clock the test advances by hand."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from bson import ObjectId
+
+from errors import BillingProviderError
+from infrastructure.cache.entitlement_cache import EntitlementCache
+from repositories.api_key_repository import ApiKeyRepository
+from repositories.custom_domain_repository import CustomDomainRepository
+from repositories.entitlement_event_repository import EntitlementEventRepository
+from repositories.entitlement_override_repository import (
+    EntitlementOverrideRepository,
+)
+from repositories.feature_flag_repository import FeatureFlagRepository
+from repositories.subscription_repository import SubscriptionRepository
+from repositories.user_repository import UserRepository
+from repositories.webhook_endpoint_repository import WebhookEndpointRepository
+from schemas.models.entitlement_override import OverrideKind
+from schemas.models.subscription import (
+    SubscriptionKind,
+    SubscriptionProvider,
+    SubscriptionStatus,
+)
+from services.billing.port import ProviderSubscription
+from services.entitlements import EntitlementService, SubscriptionEvent
+from services.entitlements.lifecycle import LifecycleService, lifecycle_tasks
+from services.entitlements.over_limit import OverLimitService
+from services.features.catalog import Plan
+from tests.fake_mongo import FakeCollection, FakeRedis
+
+UID = ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")
+# In the future relative to the real clock: the resolver reads real time for
+# override expiry while the job runs on the test clock.
+T0 = datetime(2027, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeMailer:
+    def __init__(self):
+        self.sent: list[tuple[str, str, str, dict]] = []
+        self.fail = False
+
+    async def send_html(self, to_email, subject, template_name, context, text_body):
+        if self.fail:
+            return False
+        self.sent.append((to_email, subject, template_name, context))
+        return True
+
+
+class Clock:
+    def __init__(self, now: datetime):
+        self.now = now
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, **kw):
+        self.now += timedelta(**kw)
+
+
+class World:
+    def __init__(self, *, provider=None):
+        self.redis = FakeRedis()
+        cache = EntitlementCache(self.redis)
+        self.events = EntitlementEventRepository(FakeCollection("entitlement_events"))
+        self.subs = SubscriptionRepository(
+            FakeCollection("subscriptions", unique=("user_id",)), self.events, cache
+        )
+        self.overrides = EntitlementOverrideRepository(
+            FakeCollection("entitlement_overrides"), self.events, cache
+        )
+        self.endpoints = WebhookEndpointRepository(FakeCollection("webhook-endpoints"))
+        self.domains = CustomDomainRepository(FakeCollection("custom_domains"))
+        self.keys = ApiKeyRepository(FakeCollection("api-keys"))
+        self.tenants = AsyncMock()
+        over_limit = OverLimitService(
+            endpoints=self.endpoints,
+            domains=self.domains,
+            keys=self.keys,
+            tenant_resolver=self.tenants,
+            webhook_owner_cache=AsyncMock(),
+        )
+        self.entitlements = EntitlementService(
+            self.subs,
+            self.overrides,
+            self.events,
+            cache,
+            selfhost=False,
+            over_limit=over_limit,
+        )
+        self.users = UserRepository(FakeCollection("users"))
+        self.flags = FeatureFlagRepository(FakeCollection("feature_flags"))
+        self.mailer = FakeMailer()
+        self.clock = Clock(T0)
+        self.service = LifecycleService(
+            self.entitlements,
+            self.subs,
+            self.overrides,
+            self.events,
+            self.users,
+            self.domains,
+            self.flags,
+            self.mailer,
+            app_url="https://spoo.me",
+            provider=provider,
+            clock=self.clock,
+        )
+
+    async def seed_user(self, email="pro@example.com"):
+        await self.users._col.insert_one(
+            {"_id": UID, "email": email, "email_verified": True, "status": "ACTIVE"}
+        )
+
+    async def grant(self, **fields):
+        base = {
+            "provider": SubscriptionProvider.PADDLE,
+            "kind": SubscriptionKind.RECURRING,
+        }
+        base.update(fields)
+        return await self.entitlements.transition(
+            UID, SubscriptionEvent.GRANTED, actor="test", reason="seed", now=T0, **base
+        )
+
+    async def status(self) -> SubscriptionStatus:
+        return (await self.subs.find_by_user(UID)).status
+
+    async def plan(self) -> Plan:
+        return (await self.entitlements.resolve_for(UID)).plan
+
+    async def add_endpoint(self, created: datetime):
+        await self.endpoints._col.insert_one(
+            {
+                "user_id": UID,
+                "url": "https://hooks.example/x",
+                "events": ["link.clicked"],
+                "status": "active",
+                "created_at": created,
+            }
+        )
+
+    async def add_domain(self, fqdn: str):
+        await self.domains._col.insert_one(
+            {
+                "fqdn": fqdn,
+                "owner_id": UID,
+                "status": "active",
+                "verification_method": "cf_http_dcv",
+                "created_at": T0,
+            }
+        )
+
+
+class TestClockTable:
+    @pytest.mark.asyncio
+    async def test_prepaid_walks_active_grace_lapsed_and_pauses_over_limit(self):
+        w = World()
+        await w.seed_user()
+        end = T0 + timedelta(days=10)
+        await w.grant(kind=SubscriptionKind.PREPAID, prepaid_until=end)
+        for created in (T0, T0 + timedelta(hours=1), T0 + timedelta(hours=2)):
+            await w.add_endpoint(created)
+        await w.add_domain("links.acme.com")
+        assert await w.plan() is Plan.PRO
+
+        # One day before the end: still active, the last reminder goes out.
+        w.clock.advance(days=9)
+        await w.service.tick()
+        assert await w.status() is SubscriptionStatus.ACTIVE
+        assert [m[2] for m in w.mailer.sent] == ["plan_reminder.html"]
+
+        # Term end: grace with 14 full days from the tick, one grace email.
+        w.clock.advance(days=1, seconds=1)
+        counts = await w.service.tick()
+        assert counts["grace_started"] == 1
+        sub = await w.subs.find_by_user(UID)
+        assert sub.status is SubscriptionStatus.GRACE
+        assert sub.grace_until == w.clock.now + timedelta(days=14)
+        assert await w.plan() is Plan.PRO
+        assert [m[2] for m in w.mailer.sent] == [
+            "plan_reminder.html",
+            "plan_grace_started.html",
+        ]
+        assert w.mailer.sent[1][3]["domains"] == ["links.acme.com"]
+
+        # Another tick in grace: nothing happens twice.
+        await w.service.tick()
+        assert len(w.mailer.sent) == 2
+        assert (await w.subs.find_by_user(UID)).status is SubscriptionStatus.GRACE
+
+        # Grace end: lapsed, free, endpoints beyond the free limit paused,
+        # the domain paused, one lapsed email naming the domain and the date.
+        w.clock.advance(days=14)
+        counts = await w.service.tick()
+        assert counts["lapsed"] == 1
+        assert await w.status() is SubscriptionStatus.LAPSED
+        assert await w.plan() is Plan.FREE
+        paused = await w.entitlements.over_limit_for(UID)
+        assert len(paused["webhook_endpoints_max"]) == 2
+        assert len(paused["custom_domains_max"]) == 1
+        statuses = sorted(e.status.value for e in await w.endpoints.find_by_user(UID))
+        assert statuses == ["active", "disabled", "disabled"]
+        assert w.mailer.sent[-1][2] == "plan_lapsed.html"
+        assert w.mailer.sent[-1][3]["domains"] == ["links.acme.com"]
+        assert w.mailer.sent[-1][3]["lapsed_date"] == "January 25, 2027"
+        assert (await w.subs.find_by_user(UID)).founding_streak_ok is False
+
+        # Ticking on a lapsed subscription is quiet.
+        w.clock.advance(days=30)
+        await w.service.tick()
+        assert len(w.mailer.sent) == 3
+
+    @pytest.mark.asyncio
+    async def test_cancel_at_period_end_goes_to_grace_at_the_period_end(self):
+        w = World()
+        await w.seed_user()
+        end = T0 + timedelta(days=3)
+        await w.grant(current_period_end=end)
+        await w.entitlements.transition(
+            UID, SubscriptionEvent.CANCEL_SCHEDULED, actor="paddle", reason="portal"
+        )
+        w.clock.advance(days=3, seconds=1)
+        await w.service.tick()
+        sub = await w.subs.find_by_user(UID)
+        assert sub.status is SubscriptionStatus.GRACE
+        assert sub.grace_until == w.clock.now + timedelta(days=14)
+
+    @pytest.mark.asyncio
+    async def test_active_recurring_never_moves_on_the_clock(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(current_period_end=T0 + timedelta(days=1))
+        w.clock.advance(days=40)
+        await w.service.tick()
+        assert await w.status() is SubscriptionStatus.ACTIVE
+        assert w.mailer.sent == []
+
+    @pytest.mark.asyncio
+    async def test_past_due_ceiling_lapses_seven_days_after_the_period_end(self):
+        w = World()
+        await w.seed_user()
+        end = T0 + timedelta(days=2)
+        await w.grant(current_period_end=end)
+        await w.entitlements.transition(
+            UID, SubscriptionEvent.PAYMENT_FAILED, actor="paddle", reason="declined"
+        )
+        w.clock.advance(days=8)
+        await w.service.tick()
+        assert await w.status() is SubscriptionStatus.PAST_DUE
+        w.clock.advance(days=1, seconds=1)
+        counts = await w.service.tick()
+        assert counts["past_due_lapsed"] == 1
+        assert await w.status() is SubscriptionStatus.LAPSED
+        assert w.mailer.sent[-1][2] == "plan_lapsed.html"
+
+
+class TestMailsFollowState:
+    @pytest.mark.asyncio
+    async def test_grace_started_by_a_webhook_still_gets_the_email(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(current_period_end=T0 + timedelta(days=3))
+        await w.entitlements.transition(
+            UID,
+            SubscriptionEvent.TERM_ENDED,
+            actor="paddle",
+            reason="canceled",
+            grace_until=T0 + timedelta(days=17),
+        )
+        counts = await w.service.tick()
+        assert counts["grace_mails"] == 1
+        assert [m[2] for m in w.mailer.sent] == ["plan_grace_started.html"]
+        await w.service.tick()
+        assert len(w.mailer.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_lapsed_mail_survives_a_failed_send(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(
+            kind=SubscriptionKind.PREPAID, prepaid_until=T0 + timedelta(days=1)
+        )
+        w.clock.advance(days=1, seconds=1)
+        await w.service.tick()
+        w.clock.advance(days=14)
+        w.mailer.fail = True
+        assert (await w.service.tick())["lapsed"] == 1
+        w.mailer.fail = False
+        assert (await w.service.tick())["lapsed_mails"] == 1
+        assert w.mailer.sent[-1][2] == "plan_lapsed.html"
+        assert (await w.service.tick())["lapsed_mails"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_refund_lapse_gets_no_renewal_mail(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(current_period_end=T0 + timedelta(days=30))
+        await w.entitlements.transition(
+            UID, SubscriptionEvent.ENDED, actor="paddle", reason="full refund"
+        )
+        assert (await w.subs.find_by_user(UID)).lapsed_by == "ended"
+        counts = await w.service.tick()
+        assert counts["lapsed_mails"] == 0
+        assert w.mailer.sent == []
+
+    @pytest.mark.asyncio
+    async def test_a_stale_term_end_still_gets_a_full_grace(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(
+            kind=SubscriptionKind.PREPAID, prepaid_until=T0 - timedelta(days=40)
+        )
+        await w.service.tick()
+        sub = await w.subs.find_by_user(UID)
+        assert sub.status is SubscriptionStatus.GRACE
+        assert sub.grace_until == T0 + timedelta(days=14)
+
+    @pytest.mark.asyncio
+    async def test_one_bad_subscription_does_not_stop_the_tick(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(
+            kind=SubscriptionKind.PREPAID, prepaid_until=T0 + timedelta(days=1)
+        )
+        other = ObjectId()
+        await w.subs._col.insert_one(
+            {
+                "user_id": other,
+                "provider": "paddle",
+                "kind": "prepaid",
+                "status": "active",
+                "prepaid_until": T0,
+                "created_at": T0,
+                "updated_at": T0,
+            }
+        )
+        w.clock.advance(days=1, seconds=1)
+        w.entitlements.transition = _failing_for(other, w.entitlements.transition)
+        counts = await w.service.tick()
+        assert counts["grace_started"] == 1
+        assert counts["failed"] == 1
+        assert await w.status() is SubscriptionStatus.GRACE
+
+
+def _failing_for(user_id, real):
+    async def _transition(uid, *args, **kwargs):
+        if uid == user_id:
+            raise RuntimeError("bad document")
+        return await real(uid, *args, **kwargs)
+
+    return _transition
+
+
+class TestReminders:
+    @pytest.mark.asyncio
+    async def test_prepaid_reminders_at_30_7_and_1_days_once_each(self):
+        w = World()
+        await w.seed_user()
+        end = T0 + timedelta(days=60)
+        await w.grant(kind=SubscriptionKind.PREPAID, prepaid_until=end)
+
+        w.clock.advance(days=29)
+        await w.service.tick()
+        assert w.mailer.sent == []
+
+        w.clock.advance(days=1, hours=1)
+        assert (await w.service.tick())["reminders"] == 1
+        await w.service.tick()
+        assert len(w.mailer.sent) == 1
+        assert w.mailer.sent[0][3]["days_left"] == 29
+
+        w.clock.advance(days=23)
+        assert (await w.service.tick())["reminders"] == 1
+        w.clock.advance(days=6)
+        assert (await w.service.tick())["reminders"] == 1
+        assert [m[3]["days_left"] for m in w.mailer.sent] == [29, 6, 1]
+        assert all(m[2] == "plan_reminder.html" for m in w.mailer.sent)
+
+    @pytest.mark.asyncio
+    async def test_scheduled_cancel_points_at_the_portal_not_a_new_checkout(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(current_period_end=T0 + timedelta(days=5))
+        await w.entitlements.transition(
+            UID, SubscriptionEvent.CANCEL_SCHEDULED, actor="paddle", reason="portal"
+        )
+        assert (await w.service.tick())["reminders"] == 1
+        _, _, template, context = w.mailer.sent[0]
+        assert template == "plan_reminder.html"
+        assert context["scheduled_cancel"] is True
+        assert context["grace_days"] == 14
+
+    @pytest.mark.asyncio
+    async def test_failed_send_is_retried_next_tick(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(
+            kind=SubscriptionKind.PREPAID, prepaid_until=T0 + timedelta(days=5)
+        )
+        w.mailer.fail = True
+        assert (await w.service.tick())["reminders"] == 0
+        w.mailer.fail = False
+        assert (await w.service.tick())["reminders"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reminder_needs_a_user_with_an_email(self):
+        w = World()
+        await w.grant(
+            kind=SubscriptionKind.PREPAID, prepaid_until=T0 + timedelta(days=5)
+        )
+        assert (await w.service.tick())["reminders"] == 0
+
+
+class TestOverrides:
+    @pytest.mark.asyncio
+    async def test_expired_overrides_are_revoked_with_an_event(self):
+        w = World()
+        await w.overrides.grant(
+            UID,
+            "geo_targeting",
+            True,
+            kind=OverrideKind.BETA,
+            reason="beta",
+            granted_by="ops",
+            expires_at=T0 + timedelta(days=1),
+        )
+        assert (await w.entitlements.resolve_for(UID)).has("geo_targeting")
+        version = (await w.entitlements.resolve_for(UID)).version
+        await w.service.tick()
+        assert (await w.entitlements.resolve_for(UID)).has("geo_targeting")
+        w.clock.advance(days=1, seconds=1)
+        counts = await w.service.tick()
+        assert counts["overrides_pruned"] == 1
+        resolved = await w.entitlements.resolve_for(UID)
+        assert resolved.has("geo_targeting") is False
+        assert resolved.version == version + 1
+        kinds = [d["kind"] for d in w.events._col.docs]
+        assert kinds[-1] == "override_revoked"
+
+    @pytest.mark.asyncio
+    async def test_extended_override_survives_the_prune(self):
+        w = World()
+        grant = dict(kind=OverrideKind.COMP, reason="comp", granted_by="ops")
+        await w.overrides.grant(
+            UID, "geo_targeting", True, expires_at=T0 + timedelta(days=1), **grant
+        )
+        w.clock.advance(days=1, seconds=1)
+        # Ops extends between the job's find and its revoke.
+        await w.overrides.grant(
+            UID, "geo_targeting", True, expires_at=T0 + timedelta(days=30), **grant
+        )
+        counts = await w.service.tick()
+        assert counts["overrides_pruned"] == 0
+        assert (await w.entitlements.resolve_for(UID)).has("geo_targeting")
+
+    @pytest.mark.asyncio
+    async def test_override_written_elsewhere_is_reconciled_on_the_next_tick(self):
+        w = World()
+        await w.seed_user()
+        await w.grant(current_period_end=T0 + timedelta(days=30))
+        for created in (T0, T0 + timedelta(hours=1)):
+            await w.add_endpoint(created)
+        # An abuse throttle written straight to the store, as the ops tool does.
+        await w.overrides.grant(
+            UID,
+            "webhook_endpoints_max",
+            0,
+            kind=OverrideKind.ABUSE,
+            reason="spam",
+            granted_by="ops",
+            now=T0,
+        )
+        counts = await w.service.tick()
+        assert counts["overrides_reconciled"] == 1
+        paused = await w.entitlements.over_limit_for(UID)
+        assert len(paused["webhook_endpoints_max"]) == 2
+
+
+class TestDailyTasks:
+    @pytest.mark.asyncio
+    async def test_reconcile_logs_drift_and_never_lapses_on_a_failed_lookup(self):
+        provider = AsyncMock()
+        provider.name = "paddle"
+        w = World(provider=provider)
+        await w.grant(provider_ids={"subscription_id": "sub_1", "customer_id": "c"})
+        provider.fetch_subscription = AsyncMock(
+            return_value=ProviderSubscription(
+                id="sub_1", status="canceled", customer_id="c", price_id="p"
+            )
+        )
+        counts = await w.service.reconcile()
+        assert counts == {"checked": 1, "drift": 1, "failed": 0}
+        assert await w.status() is SubscriptionStatus.ACTIVE
+
+        provider.fetch_subscription = AsyncMock(side_effect=RuntimeError("paddle down"))
+        counts = await w.service.reconcile()
+        assert counts == {"checked": 1, "drift": 0, "failed": 1}
+        assert await w.status() is SubscriptionStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_pending_cancel_phase_is_quiet_on_the_null_provider(self):
+        provider = AsyncMock()
+        provider.name = "none"
+        w = World(provider=provider)
+        await w.grant(
+            kind=SubscriptionKind.PREPAID,
+            prepaid_until=T0 + timedelta(days=365),
+            provider_ids={"subscription_id": "sub_1", "cancel_pending": "sub_1"},
+        )
+        counts = await w.service.tick()
+        assert counts["cancels_scheduled"] == 0
+        assert counts["failed"] == 0
+        provider.fetch_subscription.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_tick_retries_a_pending_cancel_until_the_provider_takes_it(self):
+        provider = AsyncMock()
+        provider.name = "paddle"
+        w = World(provider=provider)
+        await w.grant(
+            kind=SubscriptionKind.PREPAID,
+            prepaid_until=T0 + timedelta(days=365),
+            provider_ids={"subscription_id": "sub_1", "cancel_pending": "sub_1"},
+        )
+        live = ProviderSubscription(
+            id="sub_1", status="active", customer_id="c", price_id="p"
+        )
+        provider.fetch_subscription = AsyncMock(return_value=live)
+        provider.schedule_cancel = AsyncMock(
+            side_effect=BillingProviderError("paddle down")
+        )
+        assert (await w.service.tick())["cancels_scheduled"] == 0
+        assert (await w.subs.find_by_user(UID)).provider_ids[
+            "cancel_pending"
+        ] == "sub_1"
+        provider.schedule_cancel = AsyncMock()
+        assert (await w.service.tick())["cancels_scheduled"] == 1
+        provider.schedule_cancel.assert_awaited_once_with("sub_1")
+        assert "cancel_pending" not in (await w.subs.find_by_user(UID)).provider_ids
+
+    @pytest.mark.asyncio
+    async def test_reconcile_is_skipped_without_a_provider(self):
+        w = World()
+        assert await w.service.reconcile() == {"skipped": True}
+
+    @pytest.mark.asyncio
+    async def test_pro_value_check_ignores_free_features_and_treats_empty_rollouts_as_off(
+        self,
+    ):
+        w = World()
+        await w.flags._col.insert_one(
+            {"name": "webhooks", "enabled": False, "rollout_type": "everyone"}
+        )
+        await w.flags._col.insert_one(
+            {"name": "geo_targeting", "enabled": True, "rollout_type": "allowlist"}
+        )
+        await w.flags._col.insert_one(
+            {
+                "name": "custom_meta_tags",
+                "enabled": True,
+                "rollout_type": "percentage",
+                "percentage": 0,
+            }
+        )
+        await w.flags._col.insert_one(
+            {
+                "name": "ab_testing",
+                "enabled": True,
+                "rollout_type": "hex_digit",
+                "enabled_digits": [],
+            }
+        )
+        withheld = (await w.service.pro_value_check())["withheld"]
+        assert "webhooks" not in withheld
+        assert "geo_targeting" in withheld
+        assert "custom_meta_tags" in withheld
+        assert "ab_variants" in withheld
+
+    @pytest.mark.asyncio
+    async def test_pro_value_check_lists_pro_features_whose_flag_is_off(self):
+        w = World()
+        await w.flags._col.insert_one(
+            {"name": "geo_targeting", "enabled": True, "rollout_type": "everyone"}
+        )
+        await w.flags._col.insert_one(
+            {"name": "custom_meta_tags", "enabled": False, "rollout_type": "everyone"}
+        )
+        await w.flags._col.insert_one(
+            {"name": "ab_testing", "enabled": True, "rollout_type": "off"}
+        )
+        result = await w.service.pro_value_check()
+        withheld = result["withheld"]
+        assert "geo_targeting" not in withheld
+        assert "custom_meta_tags" in withheld
+        assert "ab_variants" in withheld
+        assert "expired_fallback" in withheld
+
+
+def test_task_names_and_cadence():
+    tasks = lifecycle_tasks(AsyncMock())
+    assert [(t.name, t.schedule) for t in tasks] == [
+        ("entitlements-lifecycle", "* * * * *"),
+        ("billing-reconcile", "0 4 * * *"),
+        ("entitlements-pro-value-check", "30 4 * * *"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("template", "context", "expected"),
+    [
+        (
+            "plan_grace_started.html",
+            {"grace_date": "January 25, 2027", "grace_days": 14},
+            "until January 25, 2027",
+        ),
+        (
+            "plan_lapsed.html",
+            {"lapsed_date": "January 25, 2027"},
+            "ended on January 25, 2027",
+        ),
+        (
+            "plan_reminder.html",
+            {
+                "end_date": "January 25, 2027",
+                "days_left": 7,
+                "grace_days": 14,
+                "scheduled_cancel": True,
+            },
+            "/dashboard/settings",
+        ),
+    ],
+)
+def test_templates_render_with_the_context_the_job_builds(template, context, expected):
+    from unittest.mock import MagicMock
+
+    from config import EmailSettings
+    from infrastructure.email.zeptomail import ZeptoMailProvider
+
+    provider = ZeptoMailProvider(
+        EmailSettings(), MagicMock(), app_url="https://spoo.me"
+    )
+    html = provider._jinja.get_template(template).render(
+        app_url="https://spoo.me", domains=["links.acme.com"], **context
+    )
+    assert expected in html
+    assert "links.acme.com" in html
+    assert "14" in html

--- a/workers/click_worker.py
+++ b/workers/click_worker.py
@@ -46,10 +46,18 @@ from faststream.redis.annotations import Redis, RedisMessage
 from pymongo.asynchronous.mongo_client import AsyncMongoClient
 
 from config import AppSettings, ClickEventsSettings
-from dependencies.wiring import build_account_erasure_service, build_click_service
+from dependencies.wiring import (
+    build_account_erasure_service,
+    build_billing_provider,
+    build_click_service,
+    build_entitlement_service,
+    build_entitlement_store,
+    build_lifecycle_service,
+)
 from infrastructure.cache.redis_client import create_redis_client
 from infrastructure.cache.url_cache import UrlCache
 from infrastructure.cloudflare_kv import CloudflareKVClient
+from infrastructure.email.zeptomail import ZeptoMailProvider
 from infrastructure.geoip import GeoIPService
 from infrastructure.http_client import HttpClient
 from infrastructure.llm import LlmTaskRunner
@@ -77,6 +85,7 @@ from services.click.consumers import (
 from services.click.consumers.hotness import HotUrlAction
 from services.edge_cache import PromoteToEdgeCacheAction
 from services.edge_cache.og_writethrough import OgEdgeWritethrough
+from services.entitlements.lifecycle import lifecycle_tasks
 from services.events.contract import DOMAIN_EVENTS_STREAM
 from services.events.sinks import InlineDomainEventSink
 from services.meta_tags.validator import MetaImageValidator
@@ -580,6 +589,23 @@ async def _build_runtime(
             db, settings, runtime.http_client, runtime.cache_redis
         )
         feature_tasks.append(erasure_sweep_task(erasure_service))
+        ent_store = build_entitlement_store(db, runtime.cache_redis)
+        feature_tasks.extend(
+            lifecycle_tasks(
+                build_lifecycle_service(
+                    db,
+                    settings,
+                    store=ent_store,
+                    entitlements=build_entitlement_service(
+                        db, settings, runtime.cache_redis, store=ent_store
+                    ),
+                    provider=build_billing_provider(settings, runtime.http_client),
+                    mailer=ZeptoMailProvider(
+                        settings.email, runtime.http_client, app_url=settings.app_url
+                    ),
+                )
+            )
+        )
         scheduler = TaskScheduler(
             ScheduledTaskRepository(db["scheduled_tasks"]),
             build_task_registry(feature_tasks),


### PR DESCRIPTION
## What

The lifecycle job: every subscription transition no webhook fires, plus the two daily checks.

- One scheduled task a minute (`entitlements-lifecycle`, registered in the app and the click worker so whichever process hosts the scheduler runs it, embedded on self-host): term end to grace (`grace_until = end + 14 days`) for prepaid years and scheduled cancels; grace end to lapsed; the past-due ceiling seven days after the period end. Lapsing goes through the entitlement service, so the over-limit pausing from the enforcement PR runs as part of it.
- Emails through one new `send_html` on the ZeptoMail provider with three Jinja templates under `templates/emails/`: reminders at 30, 7 and 1 days before a term that will not renew, a grace-started note, and a lapsed note that names the domains that stopped resolving and the date. Each is sent once: the audit log entry `(user, reminder_sent, period)` is the dedupe key, and a failed send is retried on the next tick.
- Expired overrides are revoked on the tick with an `override_revoked` event, which bumps the owner's version.
- `billing-reconcile` daily: fetches every live provider subscription and logs `subscription_drift` with both statuses; a failed lookup is a warning, never a status change.
- `entitlements-pro-value-check` daily: logs `pro_value_withheld` with every catalog feature the pro plan includes whose rollout flag is missing, disabled or off.
- Heartbeat: a Redis key on every tick and an `entitlements_lifecycle_tick` log line. `axiom/monitors/entitlements-lifecycle-stalled.json` alerts when no tick has landed for five minutes (alert on no data). Apply it after the deploy, not before, or it fires on the empty window.

## How proven

- Full suite: 4241 passed, 8 skipped. ruff check and format clean.
- Clock-table tests over real repositories on an in-memory Mongo with a frozen clock: prepaid active to grace at the term end with the right `grace_until`, grace to lapsed 14 days later with the two newest of three endpoints and the domain paused, one grace email and one lapsed email naming the domain and the date, quiet ticks in between and after; a scheduled cancel moving to grace at the period end; an active recurring subscription never moving on the clock; past due lapsing seven days after the period end; reminders at 30, 7 and 1 days sent once each; a failed send retried next tick; expired overrides pruned with a version bump; the heartbeat key; reconcile logging drift and never lapsing on a failed lookup; the pro-value check listing features whose flag is off; task names and cadences pinned.
- Live run against real Mongo and Redis in Docker on a fresh database with a scripted clock and a capturing mailer: a 10-day prepaid pro with 3 endpoints, 1 domain and an expiring domains override. Day 0: no transition, the first reminder, heartbeat written. Day 3: the 7-day reminder, the override pruned and the resolved limit back to the plan default, a second tick on the same day sends nothing. Day 10: grace with `grace_until` 14 days later, still pro, grace email naming the domain. Day 24: lapsed, resolved plan free, the 2 newest endpoints disabled with reason `over_limit`, the domain paused on its document, lapsed email with the date, one audit event per effective write. A tick on the lapsed subscription is quiet.
